### PR TITLE
Add delete_wallet tool and unify Lightning swap status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ AI Assistant ←→ MCP Server (Python) ←→ LWK (Liquid) ──→ Electrum/E
 
 No local server required. Liquid uses Electrum/Esplora; Bitcoin uses Esplora only. All via Blockstream's public infrastructure.
 
-## Tools (19 total)
+## Tools (20 total)
 
 Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`.
 
@@ -29,6 +29,7 @@ Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified 
 | `lw_export_descriptor` | Export CT descriptor (watch-only) | `wallet_name`: optional |
 | `lw_import_descriptor` | Import watch-only wallet from CT descriptor | `descriptor`: string, `wallet_name`: string, `network`: optional |
 | `lw_list_wallets` | List all wallets | (none) |
+| `delete_wallet` | Delete a wallet and all its cached data | `wallet_name`: string |
 
 ### Wallet Operations (Liquid)
 
@@ -79,7 +80,7 @@ MCP resources provide static documentation to AI assistants.
 | `aqua://docs/networks` | Network Reference | Bitcoin and Liquid network details, address formats, explorers, common assets |
 | `aqua://docs/security` | Security Best Practices | Passphrase usage, encryption, backup, watch-only wallets, recovery |
 
-## Prompts (13 total)
+## Prompts (14 total)
 
 MCP prompts provide pre-built conversation starters for common workflows.
 
@@ -97,6 +98,7 @@ MCP prompts provide pre-built conversation starters for common workflows.
 | `transaction_status` | Check transaction status | `network`: optional (bitcoin/liquid) |
 | `list_wallets` | Show all wallets | (none) |
 | `export_descriptor` | Export descriptor for watch-only wallet | `wallet_name`: optional |
+| `delete_wallet` | Safely delete a wallet with balance check and seed backup reminder | `wallet_name`: required |
 | `pay_lightning` | Pay a Lightning invoice using Liquid Bitcoin | `wallet_name`: optional |
 
 ## Data Storage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ No local server required. Liquid uses Electrum/Esplora; Bitcoin uses Esplora onl
 
 Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`.
 
-### Wallet Management (Liquid)
+### Wallet Management
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
@@ -29,7 +29,7 @@ Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified 
 | `lw_export_descriptor` | Export CT descriptor (watch-only) | `wallet_name`: optional |
 | `lw_import_descriptor` | Import watch-only wallet from CT descriptor | `descriptor`: string, `wallet_name`: string, `network`: optional |
 | `lw_list_wallets` | List all wallets | (none) |
-| `delete_wallet` | Delete a wallet and all its cached data | `wallet_name`: string |
+| `delete_wallet` | Delete a wallet and all its cached data. Agent MUST check balances and confirm with user before calling. Use the `delete_wallet` prompt for the safe workflow. | `wallet_name`: string |
 
 ### Wallet Operations (Liquid)
 
@@ -68,7 +68,7 @@ Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified 
 |------|-------------|------------|
 | `lightning_receive` | Generate a Lightning invoice to receive L-BTC into Liquid wallet (~1-2 min after payment). Limits: 100 – 25,000,000 sats | `amount`: int (sats), `wallet_name`: optional (default: "default"), `passphrase`: optional |
 | `lightning_send` | Pay a Lightning invoice using L-BTC via Boltz submarine swap. Fees: ~0.1% + miner fees. Limits: 100 – 25,000,000 sats | `invoice`: BOLT11 string (lnbc... or lntb...), `wallet_name`: optional, `passphrase`: optional |
-| `lightning_transaction_status` | Check status of a Lightning receive swap. Auto-claims L-BTC when settled. | `swap_id`: string |
+| `lightning_transaction_status` | Check status of a Lightning swap (send or receive). For receive: auto-claims L-BTC when settled. For send: retrieves preimage when claimed. | `swap_id`: string |
 
 ## Resources (3 total)
 
@@ -441,4 +441,4 @@ Use standard Grep/Glob only for: exact string matches, simple file lookups, conf
 
 ---
 
-*Last updated: 2026-03-12*
+*Last updated: 2026-03-17*

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
-# 💧 AQUA MCP
+# AQUA MCP
 
-MCP server for managing **Liquid Network** and **Bitcoin** wallets through AI assistants like Claude. One mnemonic can back both networks (unified wallet).
+MCP server for managing **Liquid Network** and **Bitcoin** wallets through AI assistants like Claude. One mnemonic backs both networks (unified wallet).
 
 ## Features
 
-- 🔑 **Generate & Import** - Create new wallets or import existing mnemonics
-- 🔗 **Unified Wallet** - One mnemonic for Liquid and Bitcoin; `unified_balance` shows both
-- ₿ **Bitcoin (onchain)** - BIP84 wallets, balance and send via `btc_*` tools (BDK)
-- 👀 **Watch-Only** - Import CT descriptors for balance monitoring
-- 💸 **Send & Receive** - Full transaction support (L-BTC, BTC, and Liquid assets)
-- 🪙 **Assets** - Native support for L-BTC, USDT, and all Liquid assets
-- 🔒 **Secure** - Encrypted storage, no remote servers for keys
+- **Generate & Import** - Create new wallets or import existing mnemonics
+- **Unified Wallet** - One mnemonic for Liquid and Bitcoin; `unified_balance` shows both
+- **Bitcoin (onchain)** - BIP84 wallets, balance and send via `btc_*` tools (BDK)
+- **Watch-Only** - Import CT descriptors for balance monitoring
+- **Send & Receive** - Full transaction support (L-BTC, BTC, and Liquid assets)
+- **Lightning** - Send and receive via Lightning using L-BTC (via Boltz & Ankara)
+- **Assets** - Native support for L-BTC, USDT, and all Liquid assets
+- **Secure** - Encrypted storage, no remote servers for keys
 
 ## Installation
 
-### For End Users (Easiest!)
+### Recommended (uvx)
 
 If you don't have `uvx` installed:
 
@@ -26,7 +27,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
-Then configure Claude Desktop (`~/.claude/claude_desktop_config.json`):
+Configure Claude Desktop (`~/.claude/claude_desktop_config.json`):
 
 ```json
 {
@@ -39,14 +40,14 @@ Then configure Claude Desktop (`~/.claude/claude_desktop_config.json`):
 }
 ```
 
-**Important:** You can use the full path to `uvx` because Claude Desktop (macOS GUI app) doesn't inherit your shell's PATH. Find it with:
+Find the full path to `uvx` with:
 
 ```bash
 which uvx
-# Example output: /Users/yourname/.local/bin/uvx
+# Example: /Users/yourname/.local/bin/uvx
 ```
 
-Restart Claude Desktop and you're ready to use Liquid wallets.
+Restart Claude Desktop and you're ready to use Bitcoin and Liquid wallets.
 
 ### For Developers
 
@@ -58,7 +59,7 @@ cd aqua-mcp
 uv sync
 ```
 
-Configure Claude Desktop. Use the **full path** to `uv` (e.g. `which uv`) so the app finds it:
+Configure Claude Desktop using the full path to `uv` (find with `which uv`):
 
 ```json
 {
@@ -73,74 +74,39 @@ Configure Claude Desktop. Use the **full path** to `uv` (e.g. `which uv`) so the
 
 ## Quick Start
 
-### Use with Claude
-
 Once connected, you can ask Claude to:
 
-- "Create a new Liquid wallet" (also creates Bitcoin wallet from same mnemonic)
-- "Show me my L-BTC balance" / "What's my Bitcoin balance?"
-- "Show my unified balance (Bitcoin and Liquid)"
-- "Generate a new receive address" (Liquid or Bitcoin)
-- "Send 0.001 L-BTC to lq1..." / "Send 10,000 sats to bc1..."
-
-## Usage Examples
-
-### Create a New Wallet
-
-```
-User: Create a new Liquid wallet for me
-
-Claude: I'll generate a new wallet for you.
-[Uses lw_generate_mnemonic → lw_import_mnemonic]
-
-Your new wallet has been created!
-Mnemonic (SAVE THIS SECURELY):
-  abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
-
-⚠️ Write this down and store it safely. Anyone with these words can access your funds.
-```
-
-### Check Balance
-
-```
-User: What's my Liquid balance?
-
-Claude: [Uses lw_balance]
-
-Your balances:
-- L-BTC: 0.00100000 (100,000 sats)
-- USDT: 50.00
-```
-
-### Send Transaction
-
-```
-User: Send 50,000 sats to lq1qqw8...
-
-Claude: [Uses lw_send]
-
-Transaction sent!
-TXID: 7f3a8b2c...
-Fee: 250 sats
-```
+- "Create a new wallet" (creates both Bitcoin and Liquid wallets from one mnemonic)
+- "Show my balance" / "What's my Bitcoin balance?"
+- "Generate a receive address" (Liquid or Bitcoin)
+- "Send 10,000 sats to bc1..." / "Send 0.001 L-BTC to lq1..."
+- "Pay this Lightning invoice: lnbc..."
+- "Receive 50,000 sats via Lightning"
+- "Delete my wallet"
 
 ## Available Tools
 
-**Liquid (lw_*)**
+**Wallet Management**
 
 | Tool | Description |
 |------|-------------|
 | `lw_generate_mnemonic` | Generate new BIP39 mnemonic |
 | `lw_import_mnemonic` | Import wallet from mnemonic (also creates Bitcoin wallet) |
-| `lw_import_descriptor` | Import watch-only wallet |
-| `lw_export_descriptor` | Export CT descriptor |
+| `lw_import_descriptor` | Import watch-only wallet from CT descriptor |
+| `lw_export_descriptor` | Export CT descriptor for watch-only use |
+| `lw_list_wallets` | List all wallets |
+| `delete_wallet` | Delete a wallet and all its cached data |
+
+**Liquid (lw_*)**
+
+| Tool | Description |
+|------|-------------|
 | `lw_balance` | Get wallet balances (all assets) |
-| `lw_address` | Generate Liquid receive address |
+| `lw_address` | Generate Liquid receive address (lq1...) |
 | `lw_send` | Send L-BTC |
-| `lw_send_asset` | Send any Liquid asset |
+| `lw_send_asset` | Send any Liquid asset (USDT, etc.) |
 | `lw_transactions` | Transaction history |
 | `lw_tx_status` | Get transaction status (txid or explorer URL) |
-| `lw_list_wallets` | List all wallets |
 
 **Bitcoin (btc_*)**
 
@@ -157,6 +123,14 @@ Fee: 250 sats
 |------|-------------|
 | `unified_balance` | Get balance for both Bitcoin and Liquid |
 
+**Lightning**
+
+| Tool | Description |
+|------|-------------|
+| `lightning_receive` | Generate a Lightning invoice to receive L-BTC (100–25,000,000 sats) |
+| `lightning_send` | Pay a Lightning invoice using L-BTC via Boltz (~0.1% fee) |
+| `lightning_transaction_status` | Check status of a Lightning swap (send or receive) |
+
 ## Configuration
 
 Default config location: `~/.aqua-mcp/config.json`
@@ -170,26 +144,14 @@ Default config location: `~/.aqua-mcp/config.json`
 }
 ```
 
-### Networks
-
-- **Liquid**: `mainnet` (real funds), `testnet` (test funds) — Electrum/Esplora (Blockstream)
-- **Bitcoin**: `mainnet`, `testnet` — Esplora (Blockstream)
-
 ## Security
 
-### Mnemonic Storage
+Mnemonics are encrypted at rest using a passphrase (PBKDF2 + Fernet). Without a passphrase, the mnemonic is stored base64-encoded only — use a passphrase for real funds.
 
-Mnemonics are encrypted at rest using a passphrase. On first use, you'll be prompted to set a passphrase.
-
-### Watch-Only Mode
-
-For maximum security, you can:
+For maximum security you can:
 1. Generate wallet on an air-gapped device
 2. Export the CT descriptor
 3. Import as watch-only on your daily machine
-4. Sign transactions on the air-gapped device
-
-### No Remote Keys
 
 All private key operations happen locally. Only blockchain sync uses Blockstream's public servers.
 
@@ -210,12 +172,11 @@ uv run ruff check src/
 ## Architecture
 
 ```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│  AI Assistant   │────▶│   MCP Server    │────▶│   LWK (Liquid)  │───▶ Electrum/Esplora
-│  (Claude, etc)  │     │   (Python)      │     └─────────────────┘
-└─────────────────┘     └────────┬────────┘     ┌─────────────────┐
-                                 │              │   BDK (Bitcoin) │───▶ Esplora
-                                 └──────────────└─────────────────┘     (Blockstream)
+AI Assistant ←→ MCP Server (Python) ←→ LWK (Liquid) ──→ Electrum/Esplora
+                       │
+                       ├──→ BDK (Bitcoin) ──→ Esplora (Blockstream)
+                       │
+                       └──→ Boltz / Ankara ──→ Lightning
 ```
 
 ## Credits
@@ -224,4 +185,4 @@ Built with:
 - [LWK](https://github.com/Blockstream/lwk) - Liquid Wallet Kit by Blockstream
 - [BDK](https://github.com/bitcoindevkit/bdk-python) - Bitcoin Development Kit
 - [MCP](https://modelcontextprotocol.io/) - Model Context Protocol
-
+- [Boltz](https://boltz.exchange/) - Submarine swaps for Lightning

--- a/prompt_test_read_only.md
+++ b/prompt_test_read_only.md
@@ -111,7 +111,7 @@ Export the CT descriptor for my latest imported wallet.
 
 ---
 
-### 8. Check Lightning Swap Status
+### 8. Check Lightning Swap Status (that I paid)
 
 ```
 Check the status of my Lightning swap wneeB76Iu5k2 at boltz
@@ -126,7 +126,7 @@ Check the status of my Lightning swap wneeB76Iu5k2 at boltz
 
 ---
 
-### 9. Generate Lightning Invoice (Receive)
+### 9. Generate Lightning Invoice (to receive)
 
 ```
 Generate a Lightning invoice to receive 500 sats into my Liquid wallet.
@@ -140,10 +140,10 @@ Generate a Lightning invoice to receive 500 sats into my Liquid wallet.
 
 ---
 
-### 10. Check Lightning Swap Status
+### 10. Check Lightning Swap Status (Receiving)
 
 ```
-Check the status of my Lightning swap 3882e4fd-c73a-4e72-abbe-18ac1ea3b2aa
+Check the status of my Lightning swap id 3882e4fd-c73a-4e72-abbe-18ac1ea3b2aa
 ```
 
 **Expected behavior:**

--- a/prompt_test_read_only.md
+++ b/prompt_test_read_only.md
@@ -96,24 +96,9 @@ List all my wallets.
 **Expected behavior:**
 - Returns a list of all wallets
 - Each wallet shows: name, network, type (watch-only or signing), and creation date
-
 ---
 
-### 7. Check Lightning Swap Status
-
-```
-Check the status of my Lightning swap wneeB76Iu5k2
-```
-
-**Expected behavior:**
-- Returns swap status from Boltz API (e.g. `transaction.claim.pending`, `transaction.claimed`)
-- Shows `swap_id`, `status`, `lockup_txid`, `timeout_block_height`, and `network`
-- If claimed, includes `preimage` and `claim_txid`
-- If failed, includes `refund_info` with timeout block height
-
----
-
-### 8. Export Descriptor (Watch-Only)
+### 7. Export Descriptor (Watch-Only)
 
 ```
 Export the CT descriptor for my latest imported wallet.
@@ -123,6 +108,21 @@ Export the CT descriptor for my latest imported wallet.
 - Returns a CT descriptor string starting with `ct(slip77(...),elwpkh(...))`
 - Descriptor can be imported on another device for watch-only access
 - No private keys are exposed
+
+---
+
+### 8. Check Lightning Swap Status
+
+```
+Check the status of my Lightning swap wneeB76Iu5k2 at boltz
+```
+
+**Expected behavior:**
+- Returns swap status from Boltz API (e.g. `transaction.claim.pending`, `transaction.claimed`)
+- Shows `swap_id`, `status`, `lockup_txid`, `timeout_block_height`, and `network`
+- If claimed, includes `preimage` and `claim_txid`
+- If failed, includes `refund_info` with timeout block height
+
 
 ---
 
@@ -151,5 +151,33 @@ Check the status of my Lightning swap 3882e4fd-c73a-4e72-abbe-18ac1ea3b2aa
 - Shows `swap_id`, `status`, `invoice`, `amount`, and `receive_address`
 - If settled, includes `preimage` and auto-claims L-BTC to the Liquid wallet
 - If failed, reports the error state
+
+---
+
+### 11. Delete Wallet
+
+```
+Import a wallet named delete_test_<DATETIME> using the mnemonic "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about" on mainnet. Then delete the wallet and verify it no longer appears in the wallet list.
+```
+
+**Expected behavior:**
+- Wallet is imported successfully with name `delete_test_<DATETIME>`
+- `delete_wallet` removes the wallet
+- `lw_list_wallets` no longer shows the deleted wallet
+
+---
+
+### 12. Seed Backup & Restore with Passphrase
+
+```
+Create a new wallet named test_seed_restore_<DATETIME> with passphrase "test". Generate the first Bitcoin receiving address and remember it. Then delete the wallet. Re-import the wallet using the same seed and passphrase "test", generate the first Bitcoin receiving address again, and verify it matches the original.
+```
+
+**Expected behavior:**
+- New mnemonic is generated and wallet is imported with passphrase "test"
+- First BTC address is derived and stored in memory
+- Wallet is successfully deleted
+- Wallet is re-imported from the same mnemonic + passphrase "test"
+- New BTC address matches the original (deterministic derivation)
 
 ---

--- a/prompt_test_read_only.md
+++ b/prompt_test_read_only.md
@@ -114,7 +114,7 @@ Export the CT descriptor for my latest imported wallet.
 ### 8. Check Lightning Swap Status (that I paid)
 
 ```
-Check the status of my Lightning swap wneeB76Iu5k2 at boltz
+Check the status of my Lightning swap JHDBY9rzD2Qn at boltz
 ```
 
 **Expected behavior:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aqua-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "MCP server for Liquid Network wallet operations"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aqua-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server for Liquid Network wallet operations"
 readme = "README.md"
 license = "MIT"

--- a/src/aqua_mcp/__init__.py
+++ b/src/aqua_mcp/__init__.py
@@ -1,3 +1,3 @@
 """AQUA MCP - Manage Liquid Network wallets through AI assistants."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/aqua_mcp/__init__.py
+++ b/src/aqua_mcp/__init__.py
@@ -1,3 +1,3 @@
 """AQUA MCP - Manage Liquid Network wallets through AI assistants."""
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"

--- a/src/aqua_mcp/lightning.py
+++ b/src/aqua_mcp/lightning.py
@@ -7,6 +7,18 @@ from typing import Optional
 from .ankara import AnkaraClient
 from .boltz import BoltzClient, MIN_SWAP_AMOUNT_SATS as BOLTZ_MIN_SATS, MAX_SWAP_AMOUNT_SATS as BOLTZ_MAX_SATS, decode_bolt11_amount_sats, generate_keypair
 
+# Boltz API status string -> local lifecycle status (pending | processing | completed | failed)
+_BOLTZ_STATUS_MAP = {
+    "swap.created": "pending",
+    "transaction.mempool": "processing",
+    "transaction.confirmed": "processing",
+    "transaction.claim.pending": "completed",
+    "transaction.claimed": "completed",
+    "swap.expired": "failed",
+    "transaction.failed": "failed",
+    "transaction.refunded": "failed",
+}
+
 # Ankara swap amount limits (satoshis)
 ANKARA_MIN_SATS = 100
 ANKARA_MAX_SATS = 25_000_000
@@ -265,3 +277,92 @@ class LightningManager:
             result["claim_warning"] = claim_warning
 
         return result
+
+    def get_send_status(self, swap_id: str) -> dict:
+        """
+        Check the status of a Lightning send swap (Boltz) and enrich with claim details when claimed.
+
+        Args:
+            swap_id: Swap ID from pay_invoice (Boltz swap id).
+
+        Returns:
+            Dict with swap_id, swap_type, status, boltz_status, amount, wallet_name, invoice,
+            lockup_txid, network, and optional preimage, claim_txid, refund_info, warning.
+        """
+        swap = self.storage.load_lightning_swap(swap_id)
+        if not swap:
+            raise ValueError(f"Lightning swap not found: {swap_id}")
+        if swap.swap_type != "send":
+            raise ValueError(f"Swap {swap_id} is a receive swap, not a send swap")
+
+        warning = None
+        boltz_status = None
+        try:
+            client = BoltzClient(network=swap.network)
+            status_resp = client.get_swap_status(swap_id)
+            boltz_status = status_resp.get("status") or status_resp.get("state")
+            if boltz_status is None:
+                boltz_status = str(status_resp)
+
+            mapped = _BOLTZ_STATUS_MAP.get(boltz_status)
+            if mapped is not None:
+                swap.status = mapped
+                self.storage.save_lightning_swap(swap)
+
+            if boltz_status in ("transaction.claim.pending", "transaction.claimed"):
+                try:
+                    details = client.get_claim_details(swap_id)
+                    preimage = details.get("preimage")
+                    claim_txid = details.get("claimTxid") or details.get("transactionId") or details.get("transaction_id")
+                    if preimage:
+                        swap.preimage = preimage
+                    if claim_txid:
+                        swap.claim_txid = claim_txid
+                    if preimage or claim_txid:
+                        self.storage.save_lightning_swap(swap)
+                except Exception as e:
+                    warning = f"Claim details unavailable: {e}"
+        except Exception as e:
+            warning = f"Could not fetch Boltz status: {e}"
+
+        result = {
+            "swap_id": swap.swap_id,
+            "swap_type": swap.swap_type,
+            "status": swap.status,
+            "amount": swap.amount,
+            "wallet_name": swap.wallet_name,
+            "invoice": swap.invoice,
+            "lockup_txid": swap.lockup_txid,
+            "network": swap.network,
+        }
+        if boltz_status is not None:
+            result["boltz_status"] = boltz_status
+        if swap.preimage:
+            result["preimage"] = swap.preimage
+        if swap.claim_txid:
+            result["claim_txid"] = swap.claim_txid
+        if swap.status == "failed" and swap.timeout_block_height is not None:
+            result["refund_info"] = {"timeout_block_height": swap.timeout_block_height}
+        if warning:
+            result["warning"] = warning
+
+        return result
+
+    def get_swap_status(self, swap_id: str) -> dict:
+        """
+        Check the status of any Lightning swap (receive or send). Routes by swap_type.
+
+        Args:
+            swap_id: Swap ID from lightning_receive or lightning_send.
+
+        Returns:
+            Status dict from get_receive_status or get_send_status.
+        """
+        swap = self.storage.load_lightning_swap(swap_id)
+        if not swap:
+            raise ValueError(f"Lightning swap not found: {swap_id}")
+        if swap.swap_type == "receive":
+            return self.get_receive_status(swap_id)
+        if swap.swap_type == "send":
+            return self.get_send_status(swap_id)
+        raise ValueError(f"Unknown swap_type for swap {swap_id}: {swap.swap_type!r}")

--- a/src/aqua_mcp/server.py
+++ b/src/aqua_mcp/server.py
@@ -223,6 +223,19 @@ TOOL_SCHEMAS = {
             "properties": {},
         },
     },
+    "delete_wallet": {
+        "description": "Delete a wallet and all its cached data. IMPORTANT: The agent MUST check balances and ask for user confirmation before calling this tool. Use the 'delete_wallet' prompt for the safe workflow.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "wallet_name": {
+                    "type": "string",
+                    "description": "Name of the wallet to delete",
+                },
+            },
+            "required": ["wallet_name"],
+        },
+    },
     "btc_balance": {
         "description": "Get Bitcoin wallet balance in satoshis",
         "inputSchema": {
@@ -431,7 +444,12 @@ LIGHTNING:
 - Use lightning_send to pay a BOLT11 invoice using L-BTC (submarine swap via Boltz)
   Fees: ~0.1% + miner fees, Limits: 100 - 25,000,000 sats
 - Use lightning_transaction_status to check status of receive swaps (auto-claims when settled)
-- For send swaps: check on-chain transaction status using lw_tx_status after getting lockup_txid""",
+- For send swaps: check on-chain transaction status using lw_tx_status after getting lockup_txid
+
+WALLET DELETION:
+- ALWAYS use the delete_wallet prompt workflow (check balances, remind about seed backup, confirm)
+- NEVER call delete_wallet directly without first checking balances and getting user confirmation
+- Remind user to backup their mnemonic and passphrase before deletion""",
     )
 
     @server.list_prompts()
@@ -530,6 +548,13 @@ LIGHTNING:
                 description="Export descriptor for watch-only wallet",
                 arguments=[
                     PromptArgument(name="wallet_name", description="Wallet name", required=False),
+                ],
+            ),
+            Prompt(
+                name="delete_wallet",
+                description="Safely delete a wallet with balance check and seed backup reminder",
+                arguments=[
+                    PromptArgument(name="wallet_name", description="Wallet name", required=True),
                 ],
             ),
 
@@ -763,6 +788,26 @@ Use lw_export_descriptor and explain:
 - What the descriptor is for
 - How to import it in another wallet as watch-only
 - That it does NOT provide access to sign transactions""",
+                ),
+            )])
+
+        elif name == "delete_wallet":
+            return GetPromptResult(messages=[PromptMessage(
+                role="user",
+                content=TextContent(
+                    type="text",
+                    text=f"""I want to delete wallet '{wallet_name}'.
+
+Please follow this safety workflow:
+1. Check if the wallet exists with lw_list_wallets
+2. Check balances on BOTH networks using unified_balance for '{wallet_name}'
+3. If there are any funds (BTC or L-BTC > 0):
+   - WARN me clearly about the remaining funds
+   - Show me exactly how much is in each network
+4. REMIND me: "Make sure you have backed up your seed phrase (mnemonic) and passphrase before proceeding. Without these, you will permanently lose access to any funds associated with this wallet."
+5. Ask me for EXPLICIT confirmation: "Are you sure you want to delete wallet '{wallet_name}'? This cannot be undone."
+6. Only after I explicitly confirm, call delete_wallet with wallet_name='{wallet_name}'
+7. Confirm deletion was successful""",
                 ),
             )])
 

--- a/src/aqua_mcp/server.py
+++ b/src/aqua_mcp/server.py
@@ -371,13 +371,13 @@ TOOL_SCHEMAS = {
         },
     },
     "lightning_transaction_status": {
-        "description": "Check the status of a Lightning receive swap. Auto-claims L-BTC when settled.",
+        "description": "Check the status of a Lightning swap (send or receive). For receive: auto-claims L-BTC when settled. For send: checks Boltz status and retrieves preimage when claimed.",
         "inputSchema": {
             "type": "object",
             "properties": {
                 "swap_id": {
                     "type": "string",
-                    "description": "Swap ID returned from lightning_receive",
+                    "description": "Swap ID returned from lightning_receive or lightning_send",
                 },
             },
             "required": ["swap_id"],
@@ -443,8 +443,7 @@ LIGHTNING:
   Fees: ~0.1%, Limits: 100 - 25,000,000 sats, Time: ~1-2 min after payment
 - Use lightning_send to pay a BOLT11 invoice using L-BTC (submarine swap via Boltz)
   Fees: ~0.1% + miner fees, Limits: 100 - 25,000,000 sats
-- Use lightning_transaction_status to check status of receive swaps (auto-claims when settled)
-- For send swaps: check on-chain transaction status using lw_tx_status after getting lockup_txid
+- Use lightning_transaction_status to check status of any Lightning swap (send or receive)
 
 WALLET DELETION:
 - ALWAYS use the delete_wallet prompt workflow (check balances, remind about seed backup, confirm)

--- a/src/aqua_mcp/tools.py
+++ b/src/aqua_mcp/tools.py
@@ -551,6 +551,35 @@ def lw_list_wallets() -> dict[str, Any]:
     }
 
 
+def delete_wallet(wallet_name: str) -> dict[str, Any]:
+    """Delete a wallet and all its cached data.
+
+    Args:
+        wallet_name: Name of the wallet to delete.
+
+    Returns:
+        deleted: True if wallet was deleted.
+        wallet_name: Name of the deleted wallet.
+    """
+    manager = get_manager()
+    wallet_data = manager.storage.load_wallet(wallet_name)
+    if wallet_data is None:
+        raise ValueError(f"Wallet '{wallet_name}' not found")
+
+    # Clear Liquid (LWK) manager caches
+    manager._signers.pop(wallet_name, None)
+    manager._wollets.pop(wallet_name, None)
+
+    # Clear Bitcoin (BDK) manager caches
+    btc = get_btc_manager()
+    btc._wallets.pop(wallet_name, None)
+    btc._persisters.pop(wallet_name, None)
+    btc._networks.pop(wallet_name, None)
+
+    manager.storage.delete_wallet(wallet_name)
+    return {"deleted": True, "wallet_name": wallet_name}
+
+
 # ---------------------------------------------------------------------------
 # Lightning tools (unified interface)
 # ---------------------------------------------------------------------------
@@ -647,6 +676,7 @@ TOOLS = {
     "lw_send_asset": lw_send_asset,
     "lw_tx_status": lw_tx_status,
     "lw_list_wallets": lw_list_wallets,
+    "delete_wallet": delete_wallet,
     "btc_balance": btc_balance,
     "btc_address": btc_address,
     "btc_transactions": btc_transactions,

--- a/src/aqua_mcp/tools.py
+++ b/src/aqua_mcp/tools.py
@@ -651,16 +651,21 @@ def lightning_send(
 
 
 def lightning_transaction_status(swap_id: str) -> dict[str, Any]:
-    """Check the status of a Lightning receive swap and auto-claim when settled.
+    """Check the status of a Lightning swap (send or receive).
+
+    For receive swaps: auto-claims L-BTC when settled. For send swaps: checks
+    Boltz status and retrieves preimage when claimed.
 
     Args:
-        swap_id: Swap ID from lightning_receive
+        swap_id: Swap ID returned from lightning_receive or lightning_send
 
     Returns:
-        swap_id, status, amount, wallet_name, invoice, and optional preimage, warning, claim_warning
+        swap_id, status, amount, wallet_name, invoice; for receive: optional preimage,
+        warning, claim_warning; for send: optional boltz_status, lockup_txid, preimage,
+        claim_txid, refund_info, warning
     """
     manager = get_lightning_manager()
-    return manager.get_receive_status(swap_id)
+    return manager.get_swap_status(swap_id)
 
 
 # Tool registry for MCP

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -563,6 +563,236 @@ class TestLightningManagerReceiveStatus:
             assert "Connection error" in result["warning"]
 
 
+class TestLightningManagerSendStatus:
+    """Tests for LightningManager.get_send_status()."""
+
+    def test_send_status_processing(self, test_wallet, isolated_managers):
+        """Boltz returns transaction.mempool -> status processing."""
+        manager = get_lightning_manager()
+        swap = LightningSwap(
+            swap_id="wneeB76Iu5k2",
+            swap_type="send",
+            provider="boltz",
+            invoice=VALID_INVOICE_MAINNET,
+            amount=50069,
+            wallet_name="default",
+            status="processing",
+            network="mainnet",
+            created_at=datetime.now(UTC).isoformat(),
+            lockup_txid="abc123",
+            timeout_block_height=2500000,
+        )
+        isolated_managers.storage.save_lightning_swap(swap)
+
+        with patch("aqua_mcp.lightning.BoltzClient") as mock_boltz:
+            mock_client = MagicMock()
+            mock_boltz.return_value = mock_client
+            mock_client.get_swap_status.return_value = {"status": "transaction.mempool"}
+
+            result = manager.get_send_status("wneeB76Iu5k2")
+
+            assert result["status"] == "processing"
+            assert result["boltz_status"] == "transaction.mempool"
+            assert result["lockup_txid"] == "abc123"
+            assert result["swap_type"] == "send"
+
+    def test_send_status_claimed_with_preimage(self, test_wallet, isolated_managers):
+        """Boltz returns transaction.claimed, claim details has preimage."""
+        manager = get_lightning_manager()
+        swap = LightningSwap(
+            swap_id="boltz_claimed_123",
+            swap_type="send",
+            provider="boltz",
+            invoice=VALID_INVOICE_MAINNET,
+            amount=50069,
+            wallet_name="default",
+            status="processing",
+            network="mainnet",
+            created_at=datetime.now(UTC).isoformat(),
+            lockup_txid="lockup_abc",
+            timeout_block_height=2500000,
+        )
+        isolated_managers.storage.save_lightning_swap(swap)
+
+        with patch("aqua_mcp.lightning.BoltzClient") as mock_boltz:
+            mock_client = MagicMock()
+            mock_boltz.return_value = mock_client
+            mock_client.get_swap_status.return_value = {"status": "transaction.claimed"}
+            mock_client.get_claim_details.return_value = {
+                "preimage": "bb" * 32,
+                "claimTxid": "claim_txid_hex",
+            }
+
+            result = manager.get_send_status("boltz_claimed_123")
+
+            assert result["status"] == "completed"
+            assert result["boltz_status"] == "transaction.claimed"
+            assert result["preimage"] == "bb" * 32
+            assert result["claim_txid"] == "claim_txid_hex"
+            loaded = isolated_managers.storage.load_lightning_swap("boltz_claimed_123")
+            assert loaded.preimage == "bb" * 32
+            assert loaded.claim_txid == "claim_txid_hex"
+
+    def test_send_status_claim_details_fails_gracefully(self, test_wallet, isolated_managers):
+        """Claimed but get_claim_details raises -> warning, no crash."""
+        manager = get_lightning_manager()
+        swap = LightningSwap(
+            swap_id="boltz_claim_fail",
+            swap_type="send",
+            provider="boltz",
+            invoice=VALID_INVOICE_MAINNET,
+            amount=50069,
+            wallet_name="default",
+            status="processing",
+            network="mainnet",
+            created_at=datetime.now(UTC).isoformat(),
+            lockup_txid="lockup_abc",
+            timeout_block_height=2500000,
+        )
+        isolated_managers.storage.save_lightning_swap(swap)
+
+        with patch("aqua_mcp.lightning.BoltzClient") as mock_boltz:
+            mock_client = MagicMock()
+            mock_boltz.return_value = mock_client
+            mock_client.get_swap_status.return_value = {"status": "transaction.claimed"}
+            mock_client.get_claim_details.side_effect = RuntimeError("Claim details API error")
+
+            result = manager.get_send_status("boltz_claim_fail")
+
+            assert result["status"] == "completed"
+            assert "warning" in result
+            assert "Claim details API error" in result["warning"]
+
+    def test_send_status_expired(self, test_wallet, isolated_managers):
+        """swap.expired -> failed + refund_info."""
+        manager = get_lightning_manager()
+        swap = LightningSwap(
+            swap_id="boltz_expired_123",
+            swap_type="send",
+            provider="boltz",
+            invoice=VALID_INVOICE_MAINNET,
+            amount=50069,
+            wallet_name="default",
+            status="processing",
+            network="mainnet",
+            created_at=datetime.now(UTC).isoformat(),
+            lockup_txid="lockup_abc",
+            timeout_block_height=2500000,
+        )
+        isolated_managers.storage.save_lightning_swap(swap)
+
+        with patch("aqua_mcp.lightning.BoltzClient") as mock_boltz:
+            mock_client = MagicMock()
+            mock_boltz.return_value = mock_client
+            mock_client.get_swap_status.return_value = {"status": "swap.expired"}
+
+            result = manager.get_send_status("boltz_expired_123")
+
+            assert result["status"] == "failed"
+            assert result["boltz_status"] == "swap.expired"
+            assert "refund_info" in result
+            assert result["refund_info"]["timeout_block_height"] == 2500000
+
+    def test_send_status_api_down(self, test_wallet, isolated_managers):
+        """API fails -> returns local data + warning."""
+        manager = get_lightning_manager()
+        swap = LightningSwap(
+            swap_id="boltz_api_down",
+            swap_type="send",
+            provider="boltz",
+            invoice=VALID_INVOICE_MAINNET,
+            amount=50069,
+            wallet_name="default",
+            status="processing",
+            network="mainnet",
+            created_at=datetime.now(UTC).isoformat(),
+            lockup_txid="lockup_abc",
+            timeout_block_height=2500000,
+        )
+        isolated_managers.storage.save_lightning_swap(swap)
+
+        with patch("aqua_mcp.lightning.BoltzClient") as mock_boltz:
+            mock_client = MagicMock()
+            mock_boltz.return_value = mock_client
+            mock_client.get_swap_status.side_effect = RuntimeError("Boltz API unreachable")
+
+            result = manager.get_send_status("boltz_api_down")
+
+            assert result["status"] == "processing"
+            assert result["lockup_txid"] == "lockup_abc"
+            assert "warning" in result
+            assert "Boltz API unreachable" in result["warning"]
+
+    def test_send_status_receive_swap_raises(self, test_wallet, isolated_managers):
+        """get_send_status called on receive swap raises ValueError."""
+        manager = get_lightning_manager()
+        with patch("aqua_mcp.lightning.AnkaraClient") as mock_ankara:
+            mock_client = MagicMock()
+            mock_ankara.return_value = mock_client
+            mock_client.create_swap.return_value = MOCK_ANKARA_CREATE_RESPONSE
+            swap = manager.create_receive_invoice(100000, "default")
+
+        with pytest.raises(ValueError, match="receive swap"):
+            manager.get_send_status(swap.swap_id)
+
+
+class TestLightningManagerGetSwapStatus:
+    """Tests for LightningManager.get_swap_status() router."""
+
+    def test_routes_receive_to_get_receive_status(self, test_wallet, isolated_managers):
+        """Router dispatches receive swap to get_receive_status."""
+        manager = get_lightning_manager()
+        with patch("aqua_mcp.lightning.AnkaraClient") as mock_ankara:
+            mock_client = MagicMock()
+            mock_ankara.return_value = mock_client
+            mock_client.create_swap.return_value = MOCK_ANKARA_CREATE_RESPONSE
+            swap = manager.create_receive_invoice(100000, "default")
+            swap_id = swap.swap_id
+            mock_client.verify_swap.return_value = MOCK_ANKARA_VERIFY_PENDING
+
+            result = manager.get_swap_status(swap_id)
+
+            assert result["status"] == "pending"
+            assert result["amount"] == 100000
+            assert "swap_type" not in result  # receive path doesn't add swap_type
+
+    def test_routes_send_to_get_send_status(self, test_wallet, isolated_managers):
+        """Router dispatches send swap to get_send_status."""
+        manager = get_lightning_manager()
+        swap = LightningSwap(
+            swap_id="router_send_123",
+            swap_type="send",
+            provider="boltz",
+            invoice=VALID_INVOICE_MAINNET,
+            amount=50069,
+            wallet_name="default",
+            status="processing",
+            network="mainnet",
+            created_at=datetime.now(UTC).isoformat(),
+            lockup_txid="abc",
+            timeout_block_height=2500000,
+        )
+        isolated_managers.storage.save_lightning_swap(swap)
+
+        with patch("aqua_mcp.lightning.BoltzClient") as mock_boltz:
+            mock_client = MagicMock()
+            mock_boltz.return_value = mock_client
+            mock_client.get_swap_status.return_value = {"status": "transaction.confirmed"}
+
+            result = manager.get_swap_status("router_send_123")
+
+            assert result["swap_type"] == "send"
+            assert result["status"] == "processing"
+            assert result["boltz_status"] == "transaction.confirmed"
+
+    def test_not_found_raises(self):
+        """Non-existent swap_id raises ValueError."""
+        manager = get_lightning_manager()
+
+        with pytest.raises(ValueError, match="not found"):
+            manager.get_swap_status("nonexistent_swap_id")
+
+
 class TestLightningTools:
     """Tests for lightning_receive, lightning_send, lightning_transaction_status tools."""
 
@@ -615,11 +845,11 @@ class TestLightningTools:
             assert result["status"] == "processing"
 
     def test_lightning_transaction_status_tool(self):
-        """lightning_transaction_status tool delegates to manager."""
+        """lightning_transaction_status tool delegates to manager.get_swap_status."""
         with patch("aqua_mcp.tools.get_lightning_manager") as mock_get:
             mock_manager = MagicMock()
             mock_get.return_value = mock_manager
-            mock_manager.get_receive_status.return_value = {
+            mock_manager.get_swap_status.return_value = {
                 "swap_id": "test_123",
                 "status": "completed",
                 "amount": 100000,
@@ -630,3 +860,4 @@ class TestLightningTools:
             result = lightning_transaction_status("test_123")
 
             assert result["status"] == "completed"
+            mock_manager.get_swap_status.assert_called_once_with("test_123")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -48,6 +48,8 @@ ALL_PROMPTS = [
     ("transaction_status", None),
     ("list_wallets", None),
     ("export_descriptor", {"wallet_name": "test"}),
+    ("delete_wallet", {"wallet_name": "test"}),
+    ("pay_lightning", {"wallet_name": "test"}),
 ]
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,6 +10,7 @@ import pytest
 from aqua_mcp.storage import Storage, WalletData
 from aqua_mcp.tools import (
     _manager,
+    delete_wallet,
     get_manager,
     lw_address,
     lw_balance,
@@ -712,6 +713,7 @@ class TestToolRegistry:
             "lightning_receive",
             "lightning_send",
             "lightning_transaction_status",
+            "delete_wallet",
         }
         assert set(TOOLS.keys()) == expected
 
@@ -721,3 +723,62 @@ class TestToolRegistry:
 
         for name, fn in TOOLS.items():
             assert callable(fn), f"Tool {name} is not callable"
+
+
+# ---------------------------------------------------------------------------
+# delete_wallet
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteWallet:
+    """Tests for the delete_wallet tool."""
+
+    def test_delete_nonexistent_raises(self):
+        """ValueError when wallet doesn't exist."""
+        with pytest.raises(ValueError, match="not found"):
+            delete_wallet(wallet_name="nonexistent")
+
+    def test_delete_removes_wallet(self, isolated_manager):
+        """Wallet file is gone from storage after deletion."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="todelete", network="testnet")
+        assert "todelete" in lw_list_wallets()["wallets"]
+
+        result = delete_wallet(wallet_name="todelete")
+        assert result == {"deleted": True, "wallet_name": "todelete"}
+        assert "todelete" not in lw_list_wallets()["wallets"]
+
+    def test_delete_clears_lw_manager_caches(self, isolated_manager):
+        """Liquid manager caches (_signers/_wollets) are cleared."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="cached", network="testnet")
+        manager = get_manager()
+        # Force cache population by getting a wollet
+        manager._signers["cached"] = "fake_signer"
+        manager._wollets["cached"] = "fake_wollet"
+
+        delete_wallet(wallet_name="cached")
+        assert "cached" not in manager._signers
+        assert "cached" not in manager._wollets
+
+    def test_delete_clears_btc_manager_caches(self, isolated_manager):
+        """Bitcoin manager caches (_wallets/_persisters/_networks) are cleared."""
+        import aqua_mcp.tools as tools_module
+        from aqua_mcp.tools import get_btc_manager
+
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="btccached", network="testnet")
+        btc = get_btc_manager()
+        # Populate caches with fakes
+        btc._wallets["btccached"] = "fake_wallet"
+        btc._persisters["btccached"] = "fake_persister"
+        btc._networks["btccached"] = "testnet"
+
+        delete_wallet(wallet_name="btccached")
+        assert "btccached" not in btc._wallets
+        assert "btccached" not in btc._persisters
+        assert "btccached" not in btc._networks
+
+    def test_delete_returns_success(self, isolated_manager):
+        """Returns the expected success dict."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="success", network="testnet")
+        result = delete_wallet(wallet_name="success")
+        assert result["deleted"] is True
+        assert result["wallet_name"] == "success"

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "aqua-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "bdkpython" },


### PR DESCRIPTION
### Purpose

Add a `delete_wallet` tool to remove a wallet and all its cached data (Liquid + Bitcoin), and unify Lightning swap status so `lightning_transaction_status` works for both receive (Ankara) and send (Boltz) swaps.

#### Main Changes

- ✨ Added `delete_wallet` tool and prompt: removes wallet file and clears Liquid/BDK manager caches
- ♻️ Refactored Lightning status: `get_swap_status()` routes by swap type; new `get_send_status()` for Boltz with status mapping and claim/refund details
- 🐛 Fixed `lightning_transaction_status` to support send swaps (Boltz) as well as receive (Ankara)
- ✅ Added tests for `delete_wallet` (nonexistent, removal, cache clearing) and for `get_send_status` 
- 🔧 Bumped version to 0.2.1

### Checklist

- [ ] No hardcoded values (they should go in constants.py, .env, or our database)
- [x] Added/updated tests (if necessary)
- [x] Added/updated relevant documentation (if necessary)
