### PR TITLE
#21 Import and return Liquid-BTC descriptor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ AI Assistant ←→ MCP Server (Python) ←→ LWK (Liquid) ──→ Electrum/E
 
 No local server required. Liquid uses Electrum/Esplora; Bitcoin uses Esplora only. All via Blockstream's public infrastructure.
 
-## Tools (20 total)
+## Tools (22 total)
 
 Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`.
 
@@ -30,6 +30,10 @@ Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified 
 | `lw_import_descriptor` | Import watch-only wallet from CT descriptor | `descriptor`: string, `wallet_name`: string, `network`: optional |
 | `lw_list_wallets` | List all wallets | (none) |
 | `delete_wallet` | Delete a wallet and all its cached data. Agent MUST check balances and confirm with user before calling. Use the `delete_wallet` prompt for the safe workflow. | `wallet_name`: string |
+| `btc_import_descriptor` | Import watch-only Bitcoin wallet from BIP84 descriptor. ONLY Bitcoin — for Liquid use `lw_import_descriptor`. | `descriptor`: string, `wallet_name`: string, `network`: optional, `change_descriptor`: optional |
+| `btc_export_descriptor` | Export Bitcoin BIP84 descriptors + xpub. ONLY Bitcoin — for Liquid use `lw_export_descriptor`. | `wallet_name`: optional |
+
+> ⚠️ The Bitcoin descriptor and the Liquid CT descriptor cannot be derived from each other. Bitcoin uses derivation path `m/84'/0'/0'`; Liquid uses `m/84'/1776'/0'` and additionally requires a SLIP-77 master blinding key derived from the seed. To monitor both networks watch-only, both descriptors must be imported.
 
 ### Wallet Operations (Liquid)
 

--- a/README.md
+++ b/README.md
@@ -98,10 +98,14 @@ Once connected, you can ask Claude to:
 |------|-------------|
 | `lw_generate_mnemonic` | Generate new BIP39 mnemonic |
 | `lw_import_mnemonic` | Import wallet from mnemonic (also creates Bitcoin wallet) |
-| `lw_import_descriptor` | Import watch-only wallet from CT descriptor |
-| `lw_export_descriptor` | Export CT descriptor for watch-only use |
+| `lw_import_descriptor` | Import watch-only Liquid wallet from CT descriptor |
+| `lw_export_descriptor` | Export Liquid CT descriptor for watch-only use |
+| `btc_import_descriptor` | Import watch-only Bitcoin wallet from BIP84 descriptor |
+| `btc_export_descriptor` | Export Bitcoin BIP84 descriptors + xpub |
 | `lw_list_wallets` | List all wallets |
 | `delete_wallet` | Delete a wallet and all its cached data |
+
+> ⚠️ Bitcoin and Liquid descriptors cannot be derived from each other (different BIP84 paths + Liquid's SLIP-77 blinding key). To watch a unified wallet, import both descriptors separately.
 
 **Liquid (lw_*)**
 
@@ -153,8 +157,13 @@ aqua lightning --help
 aqua wallet generate-mnemonic
 aqua wallet import-mnemonic --wallet-name default --network mainnet
 aqua wallet list
-aqua wallet export-descriptor --wallet-name default
 aqua wallet delete --wallet-name old
+
+# Watch-only descriptors (Bitcoin and Liquid are separate)
+aqua btc export-descriptor    --wallet-name default
+aqua btc import-descriptor    --wallet-name cold --descriptor "wpkh([fp/84h/0h/0h]xpub.../0/*)#cs"
+aqua liquid export-descriptor --wallet-name default
+aqua liquid import-descriptor --wallet-name cold --descriptor "ct(slip77(...),elwpkh(...))"
 
 # Balances
 aqua balance                              # unified (BTC + Liquid)
@@ -187,6 +196,8 @@ aqua-mcp         # direct MCP entrypoint
 ```
 
 Output defaults to a human-readable table on the terminal and JSON when piped. Force a format with `--format json` or `--format pretty`.
+
+> **CLI breaking change:** `aqua wallet import-descriptor` and `aqua wallet export-descriptor` have moved to `aqua liquid import-descriptor` / `aqua liquid export-descriptor`. Use the new `aqua btc import-descriptor` / `aqua btc export-descriptor` for Bitcoin watch-only.
 
 ### Loading mnemonics safely (env vars from a text file)
 

--- a/scripts/cli_smoke_send_lbtc.py
+++ b/scripts/cli_smoke_send_lbtc.py
@@ -129,8 +129,14 @@ def run_suite(label: str, password: str | None):
 
     def t_tx_status():
         assert state["txid"] is not None, "No txid from send test"
-        result = run_cli("liquid", "tx-status", "--tx", state["txid"])
-        assert result is not None, "Status check failed"
+        result = None
+        for attempt in range(5):
+            result = run_cli("liquid", "tx-status", "--tx", state["txid"])
+            if result is not None:
+                break
+            print(f"  Indexer not ready yet (attempt {attempt + 1}/10), retrying in 3s...")
+            time.sleep(3)
+        assert result is not None, "Status check failed after retries"
         print(f"  Status: {result.get('status')}")
         print(f"  Explorer: {result.get('explorer_url')}")
         assert result["txid"] == state["txid"]

--- a/scripts/cli_smoke_send_lbtc.py
+++ b/scripts/cli_smoke_send_lbtc.py
@@ -134,7 +134,7 @@ def run_suite(label: str, password: str | None):
             result = run_cli("liquid", "tx-status", "--tx", state["txid"])
             if result is not None:
                 break
-            print(f"  Indexer not ready yet (attempt {attempt + 1}/10), retrying in 3s...")
+            print(f"  Indexer not ready yet (attempt {attempt + 1}/5), retrying in 3s...")
             time.sleep(3)
         assert result is not None, "Status check failed after retries"
         print(f"  Status: {result.get('status')}")

--- a/src/aqua/bitcoin.py
+++ b/src/aqua/bitcoin.py
@@ -17,11 +17,7 @@ _XPUB_RE = re.compile(
 
 
 def _extract_xpub_metadata(descriptor: str) -> dict:
-    """Pull xpub, fingerprint, derivation path from a descriptor string.
-
-    Supports both '[fp/84'/0'/0']xpub.../0/*' and bare 'xpub.../0/*' forms.
-    Returns dict with keys xpub, fingerprint, derivation_path; missing keys are None.
-    """
+    """Return xpub, fingerprint, derivation_path from a descriptor; missing keys are None."""
     m = _XPUB_RE.search(descriptor)
     if not m:
         return {"xpub": None, "fingerprint": None, "derivation_path": None}
@@ -35,16 +31,13 @@ def _extract_xpub_metadata(descriptor: str) -> dict:
 
 
 def _derive_change_from_external(external: str) -> str:
-    """Replace the last '/0/*' with '/1/*'.
-
-    Drops any trailing '#checksum' from the result, because the substitution
-    invalidates the original checksum. Raise ValueError if '/0/*' not found.
-    """
+    """Replace last '/0/*' with '/1/*', dropping the now-stale checksum. Raises if '/0/*' absent."""
     if "/0/*" not in external:
         raise ValueError("External descriptor missing '/0/*'; cannot auto-derive change")
     head, _sep, tail = external.rpartition("/0/*")
     derived = head + "/1/*" + tail
     return re.sub(r"#[a-zA-Z0-9]+$", "", derived)
+
 
 ESPLORA_URLS = {
     "mainnet": [
@@ -223,17 +216,7 @@ class BitcoinWalletManager:
         network: str = "mainnet",
         change_descriptor: Optional[str] = None,
     ) -> WalletData:
-        """Import a watch-only Bitcoin wallet from a BIP84 external descriptor.
-
-        If change_descriptor is omitted, derives it from external by replacing
-        the last '/0/*' with '/1/*'. Both descriptors are validated by parsing
-        them through bdk.Descriptor().
-
-        If wallet_name does not exist, creates a new wallet (watch_only=True,
-        descriptor=""). If it exists and has no btc_descriptor, adds Bitcoin
-        side without modifying Liquid. If it exists with a btc_descriptor,
-        raises ValueError.
-        """
+        """Import a watch-only BIP84 Bitcoin wallet; adds BTC to an existing Liquid-only wallet if needed."""
         net = _network_bdk(network)
 
         ext_desc = bdk.Descriptor(descriptor, net)
@@ -253,6 +236,7 @@ class BitcoinWalletManager:
         existing = self.storage.load_wallet(wallet_name)
         if existing is not None and existing.btc_descriptor:
             raise ValueError(f"Wallet '{wallet_name}' already has a Bitcoin descriptor")
+        # Reachable via library layer when LiquidWalletManager.import_mnemonic is called without btc_manager.create_wallet.
         if existing is not None and existing.encrypted_mnemonic:
             raise ValueError(
                 f"Wallet '{wallet_name}' has a mnemonic; the Bitcoin descriptor is derived "
@@ -288,14 +272,7 @@ class BitcoinWalletManager:
         return wallet_data
 
     def export_descriptor(self, wallet_name: str) -> dict:
-        """Export Bitcoin descriptors + xpub metadata.
-
-        Returns:
-            wallet_name, network, external_descriptor, change_descriptor,
-            xpub (or None), fingerprint (or None), derivation_path (or None).
-
-        Raises ValueError if wallet not found or has no Bitcoin descriptors.
-        """
+        """Return external + change descriptors and parsed xpub metadata for a wallet."""
         wallet_data = self.storage.load_wallet(wallet_name)
         if wallet_data is None:
             raise ValueError(f"Wallet '{wallet_name}' not found")

--- a/src/aqua/bitcoin.py
+++ b/src/aqua/bitcoin.py
@@ -1,5 +1,6 @@
 """Bitcoin wallet management using BDK."""
 
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -8,6 +9,42 @@ from typing import Callable, Optional, TypeVar
 import bdkpython as bdk
 
 from .storage import Storage, WalletData
+
+_XPUB_RE = re.compile(
+    r"\[(?P<fp>[0-9a-fA-F]{8})/(?P<path>[^\]]+)\](?P<xpub>[xt]pub[A-Za-z0-9]+)"
+    r"|(?P<bare>[xt]pub[A-Za-z0-9]+)"
+)
+
+
+def _extract_xpub_metadata(descriptor: str) -> dict:
+    """Pull xpub, fingerprint, derivation path from a descriptor string.
+
+    Supports both '[fp/84'/0'/0']xpub.../0/*' and bare 'xpub.../0/*' forms.
+    Returns dict with keys xpub, fingerprint, derivation_path; missing keys are None.
+    """
+    m = _XPUB_RE.search(descriptor)
+    if not m:
+        return {"xpub": None, "fingerprint": None, "derivation_path": None}
+    if m.group("xpub"):
+        return {
+            "xpub": m.group("xpub"),
+            "fingerprint": m.group("fp"),
+            "derivation_path": m.group("path"),
+        }
+    return {"xpub": m.group("bare"), "fingerprint": None, "derivation_path": None}
+
+
+def _derive_change_from_external(external: str) -> str:
+    """Replace the last '/0/*' with '/1/*'.
+
+    Drops any trailing '#checksum' from the result, because the substitution
+    invalidates the original checksum. Raise ValueError if '/0/*' not found.
+    """
+    if "/0/*" not in external:
+        raise ValueError("External descriptor missing '/0/*'; cannot auto-derive change")
+    head, _sep, tail = external.rpartition("/0/*")
+    derived = head + "/1/*" + tail
+    return re.sub(r"#[a-zA-Z0-9]+$", "", derived)
 
 ESPLORA_URLS = {
     "mainnet": [
@@ -178,6 +215,103 @@ class BitcoinWalletManager:
         self.storage.save_wallet(wallet_data)
 
         return wallet_data
+
+    def import_descriptor(
+        self,
+        descriptor: str,
+        wallet_name: str,
+        network: str = "mainnet",
+        change_descriptor: Optional[str] = None,
+    ) -> WalletData:
+        """Import a watch-only Bitcoin wallet from a BIP84 external descriptor.
+
+        If change_descriptor is omitted, derives it from external by replacing
+        the last '/0/*' with '/1/*'. Both descriptors are validated by parsing
+        them through bdk.Descriptor().
+
+        If wallet_name does not exist, creates a new wallet (watch_only=True,
+        descriptor=""). If it exists and has no btc_descriptor, adds Bitcoin
+        side without modifying Liquid. If it exists with a btc_descriptor,
+        raises ValueError.
+        """
+        net = _network_bdk(network)
+
+        ext_desc = bdk.Descriptor(descriptor, net)
+
+        if change_descriptor is not None:
+            change_desc = bdk.Descriptor(change_descriptor, net)
+            change_desc_str = change_descriptor
+        else:
+            try:
+                change_desc_str = _derive_change_from_external(descriptor)
+            except ValueError:
+                raise ValueError(
+                    "Could not auto-derive change descriptor; provide change_descriptor explicitly"
+                )
+            change_desc = bdk.Descriptor(change_desc_str, net)
+
+        existing = self.storage.load_wallet(wallet_name)
+        if existing is not None and existing.btc_descriptor:
+            raise ValueError(f"Wallet '{wallet_name}' already has a Bitcoin descriptor")
+        if existing is not None and existing.encrypted_mnemonic:
+            raise ValueError(
+                f"Wallet '{wallet_name}' has a mnemonic; the Bitcoin descriptor is derived "
+                "from it automatically. Use a different wallet_name for a watch-only import."
+            )
+
+        if existing is not None:
+            wallet_data = existing
+            wallet_data.btc_descriptor = str(ext_desc)
+            wallet_data.btc_change_descriptor = str(change_desc)
+            wallet_data.watch_only = True
+        else:
+            wallet_data = WalletData(
+                name=wallet_name,
+                network=network,
+                descriptor="",
+                btc_descriptor=str(ext_desc),
+                btc_change_descriptor=str(change_desc),
+                encrypted_mnemonic=None,
+                watch_only=True,
+            )
+
+        cache_path = self._get_btc_cache_path(wallet_name)
+        persister = bdk.Persister.new_sqlite(str(cache_path))
+        wallet = bdk.Wallet(ext_desc, change_desc, net, persister)
+        wallet.persist(persister)
+
+        self._wallets[wallet_name] = wallet
+        self._persisters[wallet_name] = persister
+        self._networks[wallet_name] = network
+
+        self.storage.save_wallet(wallet_data)
+        return wallet_data
+
+    def export_descriptor(self, wallet_name: str) -> dict:
+        """Export Bitcoin descriptors + xpub metadata.
+
+        Returns:
+            wallet_name, network, external_descriptor, change_descriptor,
+            xpub (or None), fingerprint (or None), derivation_path (or None).
+
+        Raises ValueError if wallet not found or has no Bitcoin descriptors.
+        """
+        wallet_data = self.storage.load_wallet(wallet_name)
+        if wallet_data is None:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+        if not wallet_data.btc_descriptor or not wallet_data.btc_change_descriptor:
+            raise ValueError(f"Wallet '{wallet_name}' has no Bitcoin descriptors")
+
+        meta = _extract_xpub_metadata(wallet_data.btc_descriptor)
+        return {
+            "wallet_name": wallet_data.name,
+            "network": wallet_data.network,
+            "external_descriptor": wallet_data.btc_descriptor,
+            "change_descriptor": wallet_data.btc_change_descriptor,
+            "xpub": meta["xpub"],
+            "fingerprint": meta["fingerprint"],
+            "derivation_path": meta["derivation_path"],
+        }
 
     def _get_wallet(
         self,

--- a/src/aqua/cli/btc.py
+++ b/src/aqua/cli/btc.py
@@ -5,6 +5,8 @@ import click
 from ..tools import (
     btc_address,
     btc_balance,
+    btc_export_descriptor,
+    btc_import_descriptor,
     btc_send,
     btc_transactions,
 )
@@ -79,3 +81,49 @@ def send(ctx, wallet_name, address, amount, fee_rate, password_stdin):
             },
         ),
     )
+
+
+@btc.command("import-descriptor")
+@click.option(
+    "--descriptor",
+    required=True,
+    help="BIP84 external descriptor (with or without [fp/path] prefix).",
+)
+@click.option(
+    "--change-descriptor",
+    default=None,
+    help="Change descriptor. Auto-derived from external if omitted (replaces /0/* with /1/*).",
+)
+@click.option("--wallet-name", required=True, help="Name for the wallet.")
+@click.option(
+    "--network",
+    type=click.Choice(["mainnet", "testnet"]),
+    default="mainnet",
+    show_default=True,
+    help="Network to use.",
+)
+@click.pass_obj
+def import_descriptor(ctx, descriptor, change_descriptor, wallet_name, network):
+    """Import a watch-only Bitcoin wallet from a BIP84 descriptor.
+
+    Note: imports Bitcoin only. For Liquid watch-only, separately run
+    `aqua liquid import-descriptor`. The Liquid descriptor cannot be derived
+    from the Bitcoin xpub (different derivation paths + SLIP-77 blinding key
+    required).
+    """
+    run_tool(
+        ctx,
+        lambda: btc_import_descriptor(descriptor, wallet_name, network, change_descriptor),
+    )
+
+
+@btc.command("export-descriptor")
+@click.option("--wallet-name", default="default", show_default=True, help="Name of the wallet.")
+@click.pass_obj
+def export_descriptor(ctx, wallet_name):
+    """Export Bitcoin (BDK) descriptors + xpub.
+
+    Note: exports Bitcoin only. For the Liquid CT descriptor of the same
+    wallet, run `aqua liquid export-descriptor`.
+    """
+    run_tool(ctx, lambda: btc_export_descriptor(wallet_name))

--- a/src/aqua/cli/liquid.py
+++ b/src/aqua/cli/liquid.py
@@ -7,6 +7,8 @@ from ..tools import (
     get_manager,
     lw_address,
     lw_balance,
+    lw_export_descriptor,
+    lw_import_descriptor,
     lw_send,
     lw_send_asset,
     lw_transactions,
@@ -199,3 +201,36 @@ def assets(ctx, network):
 def tx_status(ctx, tx):
     """Get Liquid transaction status."""
     run_tool(ctx, lambda: lw_tx_status(tx))
+
+
+@liquid.command("import-descriptor")
+@click.option("--descriptor", required=True, help="CT descriptor string.")
+@click.option("--wallet-name", required=True, help="Name for the wallet.")
+@click.option(
+    "--network",
+    type=click.Choice(["mainnet", "testnet"]),
+    default="mainnet",
+    show_default=True,
+    help="Network to use.",
+)
+@click.pass_obj
+def import_descriptor(ctx, descriptor, wallet_name, network):
+    """Import a watch-only Liquid wallet from a CT descriptor.
+
+    Note: imports Liquid only. For Bitcoin watch-only, use
+    `aqua btc import-descriptor`. The Bitcoin descriptor cannot be derived
+    from this CT descriptor (different derivation path + xpub).
+    """
+    run_tool(ctx, lambda: lw_import_descriptor(descriptor, wallet_name, network))
+
+
+@liquid.command("export-descriptor")
+@click.option("--wallet-name", default="default", show_default=True, help="Name of the wallet.")
+@click.pass_obj
+def export_descriptor(ctx, wallet_name):
+    """Export the Liquid CT descriptor for watch-only import elsewhere.
+
+    Note: exports Liquid only. For the Bitcoin descriptor of the same wallet,
+    use `aqua btc export-descriptor`.
+    """
+    run_tool(ctx, lambda: lw_export_descriptor(wallet_name))

--- a/src/aqua/cli/wallet.py
+++ b/src/aqua/cli/wallet.py
@@ -9,9 +9,7 @@ from ..tools import (
 )
 from ..tools import (
     lw_balance,
-    lw_export_descriptor,
     lw_generate_mnemonic,
-    lw_import_descriptor,
     lw_import_mnemonic,
     lw_list_wallets,
 )
@@ -83,30 +81,6 @@ def import_mnemonic(ctx, mnemonic_stdin, wallet_name, network, password_stdin):
             },
         ),
     )
-
-
-@wallet.command("import-descriptor")
-@click.option("--descriptor", required=True, help="CT descriptor string.")
-@click.option("--wallet-name", required=True, help="Name for the wallet.")
-@click.option(
-    "--network",
-    type=click.Choice(["mainnet", "testnet"]),
-    default="mainnet",
-    show_default=True,
-    help="Network to use.",
-)
-@click.pass_obj
-def import_descriptor(ctx, descriptor, wallet_name, network):
-    """Import a watch-only wallet from a CT descriptor."""
-    run_tool(ctx, lambda: lw_import_descriptor(descriptor, wallet_name, network))
-
-
-@wallet.command("export-descriptor")
-@click.option("--wallet-name", default="default", show_default=True, help="Name of the wallet.")
-@click.pass_obj
-def export_descriptor(ctx, wallet_name):
-    """Export the CT descriptor for a wallet (watch-only import elsewhere)."""
-    run_tool(ctx, lambda: lw_export_descriptor(wallet_name))
 
 
 @wallet.command("list")

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -331,6 +331,58 @@ TOOL_SCHEMAS = {
             "required": ["wallet_name", "address", "amount"],
         },
     },
+    "btc_import_descriptor": {
+        "description": (
+            "Import a watch-only Bitcoin wallet from a BIP84 descriptor. "
+            "ONLY imports Bitcoin — to monitor the same seed's Liquid wallet, "
+            "the user must separately import its CT descriptor with "
+            "lw_import_descriptor (different derivation path + SLIP-77 key)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "descriptor": {
+                    "type": "string",
+                    "description": "BIP84 external descriptor (with or without [fp/path] prefix)",
+                },
+                "wallet_name": {
+                    "type": "string",
+                    "description": "Wallet name (may add Bitcoin to an existing Liquid-only wallet)",
+                },
+                "network": {
+                    "type": "string",
+                    "enum": ["mainnet", "testnet"],
+                    "default": "mainnet",
+                    "description": "Network to use",
+                },
+                "change_descriptor": {
+                    "type": "string",
+                    "description": (
+                        "Optional change descriptor; auto-derived from external "
+                        "if omitted (replaces /0/* with /1/*)"
+                    ),
+                },
+            },
+            "required": ["descriptor", "wallet_name"],
+        },
+    },
+    "btc_export_descriptor": {
+        "description": (
+            "Export the Bitcoin BIP84 descriptors + xpub for a wallet. "
+            "ONLY returns Bitcoin — for the Liquid CT descriptor (different "
+            "derivation path + SLIP-77 blinding key), use lw_export_descriptor."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "wallet_name": {
+                    "type": "string",
+                    "description": "Name of the wallet",
+                    "default": "default",
+                },
+            },
+        },
+    },
     "unified_balance": {
         "description": "Get balance for both Bitcoin and Liquid networks (unified wallet)",
         "inputSchema": {
@@ -467,6 +519,16 @@ LIGHTNING:
 - Use lightning_send to pay a BOLT11 invoice using L-BTC (submarine swap via Boltz)
   Fees: ~0.1% + miner fees, Limits: 100 - 25,000,000 sats
 - Use lightning_transaction_status to check status of any Lightning swap (send or receive)
+
+WATCH-ONLY WALLETS:
+- For a Bitcoin-only watch wallet: btc_import_descriptor (BIP84 wpkh xpub).
+- For a Liquid-only watch wallet: lw_import_descriptor (CT descriptor).
+- Bitcoin and Liquid descriptors are NOT interchangeable: Bitcoin uses path
+  m/84'/0'/0' and Liquid uses m/84'/1776'/0'; Liquid also requires the SLIP-77
+  master blinding key from the seed. If the user wants both networks watch-only,
+  both descriptors must be imported separately.
+- btc_export_descriptor / lw_export_descriptor return the public descriptors that
+  can be re-imported elsewhere as watch-only.
 
 WALLET DELETION:
 - ALWAYS use the delete_wallet prompt workflow (check balances, remind about seed backup, confirm)
@@ -993,7 +1055,31 @@ If you need convenience over security:
 - Liquid (L-BTC): `lw_send(wallet_name="default", address="lq1...", amount=10000, password="secret")`
 - Liquid (other assets): `lw_send_asset(..., asset_id="ce091c99...")`
 
-Note: If wallet mnemonic is not encrypted, omit the password parameter"""
+Note: If wallet mnemonic is not encrypted, omit the password parameter
+
+## Watch-Only Wallets
+
+Watch-only wallets monitor balances and generate addresses without exposing
+private keys. Bitcoin and Liquid descriptors are NOT interchangeable — to
+monitor both networks for the same seed, you must import each side separately.
+
+```python
+# Bitcoin watch-only (BIP84 wpkh xpub on m/84'/0'/0')
+btc_import_descriptor(
+    descriptor="wpkh([fp/84'/0'/0']xpub.../0/*)#cs",
+    wallet_name="cold",
+)
+
+# Liquid watch-only (CT descriptor on m/84'/1776'/0' + SLIP-77 blinding key)
+lw_import_descriptor(
+    descriptor="ct(slip77(...),elwpkh([fp/84'/1776'/0']xpub.../0/*))",
+    wallet_name="cold",
+)
+
+# Export the public descriptors of an existing wallet for re-import elsewhere
+btc_export_descriptor(wallet_name="cold")
+lw_export_descriptor(wallet_name="cold")
+```"""
 
         elif uri == "aqua://docs/networks":
             return """# Network Reference
@@ -1093,9 +1179,18 @@ lw_import_mnemonic(
 
 For monitoring without signing risk:
 
-1. Export descriptor: `lw_export_descriptor(wallet_name="main")`
-2. Import as watch-only: `lw_import_descriptor(descriptor="ct(...)", wallet_name="monitor")`
-3. Monitor balance without exposing private keys
+1. Export descriptors from a full wallet:
+   - Liquid: `lw_export_descriptor(wallet_name="main")`
+   - Bitcoin: `btc_export_descriptor(wallet_name="main")`
+2. Import them as watch-only on another instance:
+   - Liquid: `lw_import_descriptor(descriptor="ct(...)", wallet_name="monitor")`
+   - Bitcoin: `btc_import_descriptor(descriptor="wpkh(...)", wallet_name="monitor")`
+3. Monitor balances without exposing private keys
+
+⚠️ The Bitcoin descriptor and the Liquid CT descriptor cannot be derived from
+each other — Bitcoin uses derivation path `m/84'/0'/0'`, Liquid uses
+`m/84'/1776'/0'` and additionally requires a SLIP-77 master blinding key. To
+monitor both networks watch-only, both descriptors must be imported separately.
 
 ## Recovery
 

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -39,7 +39,7 @@ TOOL_SCHEMAS = {
         },
     },
     "lw_import_mnemonic": {
-        "description": "Import a wallet from a BIP39 mnemonic phrase",
+        "description": "Import a wallet from a BIP39 mnemonic phrase (creates both Liquid and Bitcoin wallets from the same mnemonic)",
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -473,32 +473,7 @@ def btc_import_descriptor(
     network: str = "mainnet",
     change_descriptor: str | None = None,
 ) -> dict[str, Any]:
-    """
-    Import a watch-only Bitcoin (BDK) wallet from a BIP84 descriptor.
-
-    IMPORTANT: This imports ONLY the Bitcoin on-chain side. The Liquid CT
-    descriptor cannot be derived from the Bitcoin xpub:
-      - Bitcoin uses derivation path m/84'/0'/0'
-      - Liquid uses derivation path m/84'/1776'/0'
-      - Liquid additionally requires the SLIP-77 master blinding key, which
-        is derived from the seed (private), not from any xpub.
-
-    To enable Liquid for the same wallet, separately import its CT
-    descriptor with `lw_import_descriptor`.
-
-    Args:
-        descriptor: BIP84 external descriptor (with or without [fp/path] prefix).
-        wallet_name: Wallet to attach the descriptor to. May refer to an
-            existing Liquid-only wallet (Bitcoin will be added without
-            touching Liquid). Errors if the wallet already has Bitcoin set.
-        network: "mainnet" or "testnet". Default: "mainnet".
-        change_descriptor: Optional change descriptor. If omitted, derived
-            from `descriptor` by replacing /0/* with /1/*.
-
-    Returns:
-        wallet_name, network, btc_descriptor, btc_change_descriptor,
-        watch_only=True, message (advising Liquid follow-up).
-    """
+    """Import a watch-only BIP84 Bitcoin wallet. Liquid side must be imported separately."""
     btc = get_btc_manager()
     w = btc.import_descriptor(descriptor, wallet_name, network, change_descriptor)
     return {
@@ -518,20 +493,7 @@ def btc_import_descriptor(
 
 
 def btc_export_descriptor(wallet_name: str = "default") -> dict[str, Any]:
-    """
-    Export the Bitcoin (BDK) BIP84 descriptors and xpub for a wallet.
-
-    NOTE: Returns ONLY the Bitcoin on-chain descriptor. To export the
-    Liquid CT descriptor (separate xpub on m/84'/1776'/0' + SLIP-77
-    blinding key), use `lw_export_descriptor`.
-
-    Args:
-        wallet_name: Wallet name. Default: "default".
-
-    Returns:
-        wallet_name, network, external_descriptor, change_descriptor,
-        xpub, fingerprint, derivation_path, note.
-    """
+    """Export BIP84 descriptors and xpub metadata. Liquid CT descriptor requires lw_export_descriptor."""
     btc = get_btc_manager()
     data = btc.export_descriptor(wallet_name)
     data["note"] = (

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -467,6 +467,81 @@ def btc_transactions(
     }
 
 
+def btc_import_descriptor(
+    descriptor: str,
+    wallet_name: str,
+    network: str = "mainnet",
+    change_descriptor: str | None = None,
+) -> dict[str, Any]:
+    """
+    Import a watch-only Bitcoin (BDK) wallet from a BIP84 descriptor.
+
+    IMPORTANT: This imports ONLY the Bitcoin on-chain side. The Liquid CT
+    descriptor cannot be derived from the Bitcoin xpub:
+      - Bitcoin uses derivation path m/84'/0'/0'
+      - Liquid uses derivation path m/84'/1776'/0'
+      - Liquid additionally requires the SLIP-77 master blinding key, which
+        is derived from the seed (private), not from any xpub.
+
+    To enable Liquid for the same wallet, separately import its CT
+    descriptor with `lw_import_descriptor`.
+
+    Args:
+        descriptor: BIP84 external descriptor (with or without [fp/path] prefix).
+        wallet_name: Wallet to attach the descriptor to. May refer to an
+            existing Liquid-only wallet (Bitcoin will be added without
+            touching Liquid). Errors if the wallet already has Bitcoin set.
+        network: "mainnet" or "testnet". Default: "mainnet".
+        change_descriptor: Optional change descriptor. If omitted, derived
+            from `descriptor` by replacing /0/* with /1/*.
+
+    Returns:
+        wallet_name, network, btc_descriptor, btc_change_descriptor,
+        watch_only=True, message (advising Liquid follow-up).
+    """
+    btc = get_btc_manager()
+    w = btc.import_descriptor(descriptor, wallet_name, network, change_descriptor)
+    return {
+        "wallet_name": w.name,
+        "network": w.network,
+        "btc_descriptor": w.btc_descriptor,
+        "btc_change_descriptor": w.btc_change_descriptor,
+        "watch_only": w.watch_only,
+        "message": (
+            "Bitcoin watch-only descriptor imported. To monitor the matching "
+            "Liquid wallet from the same seed, import its CT descriptor "
+            "separately with `lw_import_descriptor`. The Liquid descriptor "
+            "is NOT derivable from the Bitcoin xpub (different derivation "
+            "paths and SLIP-77 master blinding key required)."
+        ),
+    }
+
+
+def btc_export_descriptor(wallet_name: str = "default") -> dict[str, Any]:
+    """
+    Export the Bitcoin (BDK) BIP84 descriptors and xpub for a wallet.
+
+    NOTE: Returns ONLY the Bitcoin on-chain descriptor. To export the
+    Liquid CT descriptor (separate xpub on m/84'/1776'/0' + SLIP-77
+    blinding key), use `lw_export_descriptor`.
+
+    Args:
+        wallet_name: Wallet name. Default: "default".
+
+    Returns:
+        wallet_name, network, external_descriptor, change_descriptor,
+        xpub, fingerprint, derivation_path, note.
+    """
+    btc = get_btc_manager()
+    data = btc.export_descriptor(wallet_name)
+    data["note"] = (
+        "This is the Bitcoin on-chain descriptor only. For the Liquid CT "
+        "descriptor of the same wallet (different derivation path + "
+        "SLIP-77 blinding key), call `lw_export_descriptor`."
+    )
+    return data
+
+
 def btc_send(
     wallet_name: str,
     address: str,
@@ -733,6 +808,8 @@ TOOLS = {
     "btc_address": btc_address,
     "btc_transactions": btc_transactions,
     "btc_send": btc_send,
+    "btc_import_descriptor": btc_import_descriptor,
+    "btc_export_descriptor": btc_export_descriptor,
     "unified_balance": unified_balance,
     "lightning_receive": lightning_receive,
     "lightning_send": lightning_send,

--- a/tests/smoke/test_cli_read_only.py
+++ b/tests/smoke/test_cli_read_only.py
@@ -19,6 +19,8 @@ from aqua.cli.main import cli
 
 DEFAULT_MNEMONIC = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 SIGNER_MNEMONIC = os.getenv("SIGNER_MNEMONIC", DEFAULT_MNEMONIC)
+CT_DESCRIPTOR_LIQUID = os.getenv("CT_DESCRIPTOR_LIQUID")
+BTC_DESCRIPTOR = os.getenv("BTC_DESCRIPTOR")
 
 
 @pytest.fixture(scope="module")
@@ -148,6 +150,15 @@ class TestSmokeExportDescriptor:
         assert result["descriptor"].startswith("ct(")
 
 
+class TestSmokeExportBtcDescriptor:
+    def test_export_btc_descriptor(self, cli_runner, wallet_name):
+        """Export BTC descriptor returns external + change descriptors and xpub."""
+        result = cli_runner("btc", "export-descriptor", "--wallet-name", wallet_name)
+        assert "external_descriptor" in result
+        assert "change_descriptor" in result
+        assert result["external_descriptor"].startswith("wpkh(")
+
+
 class TestSmokeLightningReceive:
     def test_lightning_receive(self, cli_runner, wallet_name):
         """Generate a Lightning invoice for 500 sats."""
@@ -241,6 +252,46 @@ class TestSmokeSeedRestore:
 		assert restored_address == first_address
 
 		runner.invoke(cli, ["--format", "json", "wallet", "delete", "--wallet-name", name, "--yes"])
+
+
+class TestSmokeImportLiquidDescriptor:
+    def test_import_liquid_descriptor(self):
+        """Import a Liquid watch-only wallet from CT_DESCRIPTOR_LIQUID env var."""
+        if not CT_DESCRIPTOR_LIQUID:
+            pytest.skip("CT_DESCRIPTOR_LIQUID not set")
+        name = f"smoke_liq_desc_{int(time.time())}"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "liquid", "import-descriptor",
+             "--descriptor", CT_DESCRIPTOR_LIQUID, "--wallet-name", name],
+        )
+        assert result.exit_code == 0, result.stdout
+        data = json.loads(result.stdout)
+        assert data["wallet_name"] == name
+        assert data["watch_only"] is True
+
+        runner.invoke(cli, ["--format", "json", "wallet", "delete", "--wallet-name", name, "--yes"])
+
+
+class TestSmokeImportBtcDescriptor:
+    def test_import_btc_descriptor(self):
+        """Import a Bitcoin watch-only wallet from BTC_DESCRIPTOR env var."""
+        if not BTC_DESCRIPTOR:
+            pytest.skip("BTC_DESCRIPTOR not set")
+        name = f"smoke_btc_desc_{int(time.time())}"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "btc", "import-descriptor",
+             "--descriptor", BTC_DESCRIPTOR, "--wallet-name", name],
+        )
+        assert result.exit_code == 0, result.stdout
+        data = json.loads(result.stdout)
+        assert data["wallet_name"] == name
+        assert data["watch_only"] is True
+
+        runner.invoke(cli, ["--format", "json", "wallet", "delete", "--wallet-name", name, "--yes"])
 
 
 class TestSmokeCleanup:

--- a/tests/smoke/test_cli_read_only.py
+++ b/tests/smoke/test_cli_read_only.py
@@ -143,7 +143,7 @@ class TestSmokeListWallets:
 class TestSmokeExportDescriptor:
     def test_export_descriptor(self, cli_runner, wallet_name):
         """Export descriptor returns a CT descriptor string."""
-        result = cli_runner("wallet", "export-descriptor", "--wallet-name", wallet_name)
+        result = cli_runner("liquid", "export-descriptor", "--wallet-name", wallet_name)
         assert "descriptor" in result
         assert result["descriptor"].startswith("ct(")
 

--- a/tests/test_bitcoin.py
+++ b/tests/test_bitcoin.py
@@ -1,5 +1,6 @@
 """Tests for Bitcoin (BDK) wallet and btc_* / unified_balance tools."""
 
+import re
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -7,7 +8,12 @@ from unittest.mock import patch
 import lwk
 import pytest
 
-from aqua.bitcoin import BitcoinWalletManager, _extract_confirmation_height
+from aqua.bitcoin import (
+    BitcoinWalletManager,
+    _derive_change_from_external,
+    _extract_confirmation_height,
+    _extract_xpub_metadata,
+)
 from aqua.storage import Storage, WalletData
 from aqua.tools import (
     btc_address,
@@ -270,3 +276,223 @@ class TestBitcoinToolRegistry:
 
         for name in ("btc_balance", "btc_address", "btc_transactions", "btc_send", "unified_balance"):
             assert callable(TOOLS[name]), f"{name} is not callable"
+
+
+# ---------------------------------------------------------------------------
+# import_descriptor / export_descriptor (BIP84 watch-only)
+# ---------------------------------------------------------------------------
+
+
+def _seed_btc_descriptors(isolated_managers, network: str = "mainnet"):
+    """Bootstrap canonical BIP84 ext + change descriptors via the create_wallet flow."""
+    manager, btc_manager = isolated_managers
+    seed_name = "_seed_btc"
+    manager.import_mnemonic(TEST_MNEMONIC, seed_name, network)
+    btc_manager.create_wallet(TEST_MNEMONIC, seed_name, network)
+    w = manager.storage.load_wallet(seed_name)
+    return w.btc_descriptor, w.btc_change_descriptor
+
+
+def _strip_fp(descriptor: str) -> str:
+    """Strip [fp/path] prefix and trailing #checksum so bdk re-checksums on parse."""
+    no_fp = re.sub(r"\[[0-9a-fA-F]{8}/[^\]]+\]", "", descriptor)
+    return re.sub(r"#[a-zA-Z0-9]+$", "", no_fp)
+
+
+class TestBitcoinImportExportDescriptor:
+    # --- import_descriptor ---
+
+    def test_import_descriptor_creates_watch_only_wallet(self, isolated_managers):
+        """Fresh wallet from descriptor: btc_descriptor stored, watch_only=True."""
+        ext, chg = _seed_btc_descriptors(isolated_managers)
+        _, btc = isolated_managers
+        result = btc.import_descriptor(ext, "watch", "mainnet", chg)
+        assert result.name == "watch"
+        assert result.btc_descriptor.startswith("wpkh(")
+        assert result.btc_change_descriptor.startswith("wpkh(")
+        assert result.watch_only is True
+        assert result.encrypted_mnemonic is None
+
+    def test_import_descriptor_auto_derives_change(self, isolated_managers):
+        """Omitting change_descriptor auto-replaces /0/* with /1/*."""
+        ext, _ = _seed_btc_descriptors(isolated_managers)
+        _, btc = isolated_managers
+        result = btc.import_descriptor(ext, "auto_chg", "mainnet")
+        assert "/1/*" in result.btc_change_descriptor
+        assert "/0/*" in result.btc_descriptor
+
+    def test_import_descriptor_explicit_change(self, isolated_managers):
+        """Explicit change_descriptor is honored."""
+        ext, chg = _seed_btc_descriptors(isolated_managers)
+        _, btc = isolated_managers
+        result = btc.import_descriptor(ext, "explicit_chg", "mainnet", chg)
+        assert "/1/*" in result.btc_change_descriptor
+
+    def test_import_descriptor_invalid_external_raises(self, isolated_managers):
+        """bdk.Descriptor() failure surfaces as Exception."""
+        _, btc = isolated_managers
+        with pytest.raises(Exception):
+            btc.import_descriptor("not a descriptor", "bad_ext", "mainnet")
+
+    def test_import_descriptor_invalid_change_raises(self, isolated_managers):
+        """Bad change_descriptor surfaces as Exception."""
+        ext, _ = _seed_btc_descriptors(isolated_managers)
+        _, btc = isolated_managers
+        with pytest.raises(Exception):
+            btc.import_descriptor(ext, "bad_chg", "mainnet", "not a descriptor")
+
+    def test_import_descriptor_no_change_pattern_raises(self, isolated_managers):
+        """No /0/* and no change_descriptor: ValueError mentioning auto-derive."""
+        _, change = _seed_btc_descriptors(isolated_managers)
+        _, btc = isolated_managers
+        # change descriptor has /1/*, not /0/* — auto-derivation must fail
+        with pytest.raises(ValueError, match="auto-derive"):
+            btc.import_descriptor(change, "no_pat", "mainnet")
+
+    def test_import_descriptor_existing_btc_raises(self, isolated_managers):
+        """Wallet already has btc_descriptor: ValueError 'already has a Bitcoin descriptor'."""
+        ext, _ = _seed_btc_descriptors(isolated_managers)
+        _, btc = isolated_managers
+        with pytest.raises(ValueError, match="already has a Bitcoin descriptor"):
+            btc.import_descriptor(ext, "_seed_btc", "mainnet")
+
+    def test_import_descriptor_adds_to_liquid_only_wallet(self, isolated_managers):
+        """Liquid-only wallet gains BTC; Liquid descriptor untouched."""
+        manager, btc = isolated_managers
+        net = lwk.Network.mainnet()
+        m = lwk.Mnemonic(TEST_MNEMONIC)
+        signer = lwk.Signer(m, net)
+        liquid_desc = str(signer.wpkh_slip77_descriptor())
+        manager.import_descriptor(liquid_desc, "lq_only", "mainnet")
+        ext, _ = _seed_btc_descriptors(isolated_managers)
+        result = btc.import_descriptor(ext, "lq_only", "mainnet")
+        assert result.descriptor == liquid_desc
+        assert result.btc_descriptor is not None
+        assert result.btc_change_descriptor is not None
+
+    def test_import_descriptor_accepts_descriptor_without_fingerprint(self, isolated_managers):
+        """Bare 'wpkh(xpub.../0/*)' (no fingerprint prefix) imports cleanly."""
+        ext, _ = _seed_btc_descriptors(isolated_managers)
+        bare = _strip_fp(ext)
+        _, btc = isolated_managers
+        result = btc.import_descriptor(bare, "bare", "mainnet")
+        assert result.btc_descriptor is not None
+
+    def test_import_descriptor_enables_btc_address(self, isolated_managers):
+        """After import, btc_address() returns a bc1/tb1 address."""
+        ext, chg = _seed_btc_descriptors(isolated_managers)
+        _, btc = isolated_managers
+        btc.import_descriptor(ext, "addr_test", "mainnet", chg)
+        with patch.object(btc, "sync_wallet"):
+            addr = btc.get_address("addr_test", index=0)
+        assert addr.address.startswith(("bc1", "tb1"))
+
+    def test_import_descriptor_blocks_btc_send(self, isolated_managers):
+        """btc_send on imported watch-only raises 'watch-only'."""
+        ext, _ = _seed_btc_descriptors(isolated_managers)
+        _, btc = isolated_managers
+        btc.import_descriptor(ext, "no_send", "mainnet")
+        with pytest.raises(ValueError, match="watch-only"):
+            btc.send(
+                "no_send",
+                "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+                1000,
+            )
+
+    # --- export_descriptor ---
+
+    def test_export_descriptor_returns_all_fields(self, isolated_managers):
+        """Returns external_descriptor, change_descriptor, xpub, fingerprint, derivation_path, network, wallet_name."""
+        ext, chg = _seed_btc_descriptors(isolated_managers)
+        _, btc = isolated_managers
+        result = btc.export_descriptor("_seed_btc")
+        assert result["wallet_name"] == "_seed_btc"
+        assert result["network"] == "mainnet"
+        assert result["external_descriptor"] == ext
+        assert result["change_descriptor"] == chg
+        assert "xpub" in result
+        assert "fingerprint" in result
+        assert "derivation_path" in result
+
+    def test_export_descriptor_handles_descriptor_without_fingerprint(self, isolated_managers):
+        """When the wallet was imported without [fp/path], fingerprint and derivation_path are None."""
+        ext, _ = _seed_btc_descriptors(isolated_managers)
+        bare = _strip_fp(ext)
+        _, btc = isolated_managers
+        btc.import_descriptor(bare, "bare_exp", "mainnet")
+        result = btc.export_descriptor("bare_exp")
+        assert result["fingerprint"] is None
+        assert result["derivation_path"] is None
+
+    def test_export_descriptor_no_btc_raises(self, isolated_managers):
+        """Liquid-only wallet: ValueError 'has no Bitcoin descriptors'."""
+        manager, btc = isolated_managers
+        net = lwk.Network.mainnet()
+        m = lwk.Mnemonic(TEST_MNEMONIC)
+        signer = lwk.Signer(m, net)
+        desc = str(signer.wpkh_slip77_descriptor())
+        manager.import_descriptor(desc, "lq_export", "mainnet")
+        with pytest.raises(ValueError, match="no Bitcoin descriptors"):
+            btc.export_descriptor("lq_export")
+
+    def test_export_descriptor_unknown_wallet_raises(self, isolated_managers):
+        """Wallet not found: ValueError."""
+        _, btc = isolated_managers
+        with pytest.raises(ValueError, match="not found"):
+            btc.export_descriptor("ghost")
+
+    # --- round-trip ---
+
+    def test_export_then_import_round_trip_same_address(self, isolated_managers):
+        """Export from wallet 'A' -> import into wallet 'B' -> peek_address(0) matches."""
+        ext, chg = _seed_btc_descriptors(isolated_managers)
+        _, btc = isolated_managers
+        with patch.object(btc, "sync_wallet"):
+            addr_a = btc.get_address("_seed_btc", index=0)
+        btc.import_descriptor(ext, "round_trip", "mainnet", chg)
+        with patch.object(btc, "sync_wallet"):
+            addr_b = btc.get_address("round_trip", index=0)
+        assert addr_a.address == addr_b.address
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — no fixture needed
+# ---------------------------------------------------------------------------
+
+
+class TestDescriptorHelpers:
+    def test_derive_change_from_external_basic(self):
+        """_derive_change_from_external replaces last /0/* and drops the now-stale checksum."""
+        result = _derive_change_from_external("wpkh([abcd1234/84'/0'/0']xpub.../0/*)#cs")
+        assert result == "wpkh([abcd1234/84'/0'/0']xpub.../1/*)"
+
+    def test_derive_change_from_external_without_checksum(self):
+        """When the input has no checksum, the result has no checksum either."""
+        result = _derive_change_from_external("wpkh([abcd1234/84'/0'/0']xpub.../0/*)")
+        assert result == "wpkh([abcd1234/84'/0'/0']xpub.../1/*)"
+
+    def test_derive_change_from_external_no_pattern_raises(self):
+        """Missing /0/* raises ValueError."""
+        with pytest.raises(ValueError, match=r"missing '/0/\*'"):
+            _derive_change_from_external("wpkh(xpub.../*)")
+
+    def test_extract_xpub_metadata_with_prefix(self):
+        """Returns xpub, fingerprint, derivation_path for [fp/path]xpub form."""
+        s = "wpkh([73c5da0a/84'/0'/0']xpub6CatWdiZiodmUeTDpfoo/0/*)#cs"
+        meta = _extract_xpub_metadata(s)
+        assert meta["xpub"] == "xpub6CatWdiZiodmUeTDpfoo"
+        assert meta["fingerprint"] == "73c5da0a"
+        assert meta["derivation_path"] == "84'/0'/0'"
+
+    def test_extract_xpub_metadata_bare(self):
+        """Returns xpub only for bare-xpub descriptor; fingerprint and path are None."""
+        s = "wpkh(xpub6CatWdiZiodmUeTDp/0/*)"
+        meta = _extract_xpub_metadata(s)
+        assert meta["xpub"] == "xpub6CatWdiZiodmUeTDp"
+        assert meta["fingerprint"] is None
+        assert meta["derivation_path"] is None
+
+    def test_extract_xpub_metadata_no_match(self):
+        """Returns all-None dict for non-xpub descriptor strings."""
+        meta = _extract_xpub_metadata("wpkh(privkey-format/0/*)")
+        assert meta == {"xpub": None, "fingerprint": None, "derivation_path": None}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -356,34 +356,6 @@ class TestWalletCommands:
         data = json.loads(result.output)
         assert data["count"] >= 1
 
-    def test_export_descriptor(self, runner):
-        _import_wallet(runner)
-        result = runner.invoke(cli, ["--format", "json", "wallet", "export-descriptor"])
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert "descriptor" in data
-
-    def test_import_descriptor(self, runner):
-        _import_wallet(runner)
-        exp = runner.invoke(cli, ["--format", "json", "wallet", "export-descriptor"])
-        descriptor = json.loads(exp.output)["descriptor"]
-        result = runner.invoke(
-            cli,
-            [
-                "--format",
-                "json",
-                "wallet",
-                "import-descriptor",
-                "--descriptor",
-                descriptor,
-                "--wallet-name",
-                "watch_only",
-            ],
-        )
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["watch_only"] is True
-
     def test_delete_wallet_with_yes(self, runner):
         _import_wallet(runner)
         result = runner.invoke(
@@ -585,6 +557,49 @@ class TestLiquidCommands:
         assert "positive" in result.output.lower()
 
 
+# Liquid descriptor commands
+
+
+class TestLiquidDescriptorCli:
+    def test_export_descriptor(self, runner):
+        _import_wallet(runner)
+        result = runner.invoke(cli, ["--format", "json", "liquid", "export-descriptor"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "descriptor" in data
+
+    def test_import_descriptor(self, runner):
+        _import_wallet(runner)
+        exp = runner.invoke(cli, ["--format", "json", "liquid", "export-descriptor"])
+        descriptor = json.loads(exp.output)["descriptor"]
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "liquid",
+                "import-descriptor",
+                "--descriptor",
+                descriptor,
+                "--wallet-name",
+                "watch_only",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["watch_only"] is True
+
+    def test_wallet_import_descriptor_removed(self, runner):
+        result = runner.invoke(cli, ["wallet", "import-descriptor", "--help"])
+        assert result.exit_code != 0
+        assert "no such command" in result.output.lower()
+
+    def test_wallet_export_descriptor_removed(self, runner):
+        result = runner.invoke(cli, ["wallet", "export-descriptor", "--help"])
+        assert result.exit_code != 0
+        assert "no such command" in result.output.lower()
+
+
 # BTC commands
 
 
@@ -638,6 +653,96 @@ class TestBtcCommands:
         assert result.exit_code == 0, result.output
         mock_send.assert_called_once()
         assert mock_send.call_args.kwargs["password"] == "s3cret"
+
+
+# BTC descriptor commands
+
+
+class TestBtcDescriptorCli:
+    def test_btc_export_descriptor(self, runner):
+        _import_wallet(runner)
+        result = runner.invoke(cli, ["--format", "json", "btc", "export-descriptor"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        for key in (
+            "external_descriptor", "change_descriptor", "xpub",
+            "fingerprint", "derivation_path", "note",
+        ):
+            assert key in data
+
+    def test_btc_export_descriptor_includes_note(self, runner):
+        _import_wallet(runner)
+        result = runner.invoke(cli, ["--format", "json", "btc", "export-descriptor"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "lw_export_descriptor" in data["note"]
+
+    def test_btc_import_descriptor_minimal(self, runner):
+        _import_wallet(runner)
+        exp = runner.invoke(cli, ["--format", "json", "btc", "export-descriptor"])
+        ext_descriptor = json.loads(exp.output)["external_descriptor"]
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "btc",
+                "import-descriptor",
+                "--descriptor",
+                ext_descriptor,
+                "--wallet-name",
+                "watch_btc",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["watch_only"] is True
+
+    def test_btc_import_descriptor_explicit_change(self, runner):
+        _import_wallet(runner)
+        exp = runner.invoke(cli, ["--format", "json", "btc", "export-descriptor"])
+        exp_data = json.loads(exp.output)
+        ext_descriptor = exp_data["external_descriptor"]
+        change_descriptor = exp_data["change_descriptor"]
+        result = runner.invoke(
+            cli,
+            [
+                "--format",
+                "json",
+                "btc",
+                "import-descriptor",
+                "--descriptor",
+                ext_descriptor,
+                "--change-descriptor",
+                change_descriptor,
+                "--wallet-name",
+                "watch_btc2",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["watch_only"] is True
+
+    def test_btc_import_descriptor_missing_descriptor_fails(self, runner):
+        result = runner.invoke(
+            cli,
+            ["btc", "import-descriptor", "--wallet-name", "watch_btc"],
+        )
+        assert result.exit_code == 2
+
+    def test_btc_import_descriptor_help_mentions_liquid(self, runner):
+        result = runner.invoke(cli, ["btc", "import-descriptor", "--help"])
+        assert result.exit_code == 0
+        # Click may wrap long lines; normalize whitespace before checking.
+        normalized = " ".join(result.output.split())
+        assert "aqua liquid import-descriptor" in normalized
+
+    def test_btc_export_descriptor_help_mentions_liquid(self, runner):
+        result = runner.invoke(cli, ["btc", "export-descriptor", "--help"])
+        assert result.exit_code == 0
+        # Click may wrap long lines; normalize whitespace before checking.
+        normalized = " ".join(result.output.split())
+        assert "aqua liquid export-descriptor" in normalized
 
 
 # Lightning commands

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -886,17 +886,3 @@ class TestBtcExportDescriptor:
 # ---------------------------------------------------------------------------
 
 
-class TestNewBitcoinToolsRegistry:
-    def test_btc_import_descriptor_registered(self):
-        """btc_import_descriptor is in TOOLS and is callable."""
-        from aqua.tools import TOOLS
-
-        assert "btc_import_descriptor" in TOOLS
-        assert callable(TOOLS["btc_import_descriptor"])
-
-    def test_btc_export_descriptor_registered(self):
-        """btc_export_descriptor is in TOOLS and is callable."""
-        from aqua.tools import TOOLS
-
-        assert "btc_export_descriptor" in TOOLS
-        assert callable(TOOLS["btc_export_descriptor"])

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,10 +7,14 @@ from unittest.mock import MagicMock, patch
 import lwk
 import pytest
 
+from aqua.bitcoin import BitcoinWalletManager
 from aqua.storage import Storage, WalletData
 from aqua.tools import (
     _manager,
+    btc_export_descriptor,
+    btc_import_descriptor,
     delete_wallet,
+    get_btc_manager,
     get_manager,
     lw_address,
     lw_balance,
@@ -714,6 +718,8 @@ class TestToolRegistry:
             "lightning_send",
             "lightning_transaction_status",
             "delete_wallet",
+            "btc_import_descriptor",
+            "btc_export_descriptor",
         }
         assert set(TOOLS.keys()) == expected
 
@@ -761,7 +767,6 @@ class TestDeleteWallet:
 
     def test_delete_clears_btc_manager_caches(self, isolated_manager):
         """Bitcoin manager caches (_wallets/_persisters/_networks) are cleared."""
-        import aqua.tools as tools_module
         from aqua.tools import get_btc_manager
 
         lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="btccached", network="testnet")
@@ -782,3 +787,116 @@ class TestDeleteWallet:
         result = delete_wallet(wallet_name="success")
         assert result["deleted"] is True
         assert result["wallet_name"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# Helper: bootstrap a real BIP84 descriptor pair via the unified import flow
+# ---------------------------------------------------------------------------
+
+
+def _seed_tool_btc_descriptors(network: str = "mainnet"):
+    """Bootstrap canonical BIP84 ext + change descriptors for tool-layer tests.
+
+    lw_import_mnemonic already calls btc_manager.create_wallet internally,
+    so we only need to call lw_import_mnemonic and then read back the stored
+    descriptors from storage.
+    """
+    lw_import_mnemonic(TEST_MNEMONIC, "seed_btc", network)
+    manager = get_btc_manager()
+    w = manager.storage.load_wallet("seed_btc")
+    return w.btc_descriptor, w.btc_change_descriptor
+
+
+# ---------------------------------------------------------------------------
+# btc_import_descriptor  # Significance: 5 (Essential)
+# ---------------------------------------------------------------------------
+
+
+class TestBtcImportDescriptor:
+    def test_returns_expected_keys(self):
+        """btc_import_descriptor returns all required keys."""
+        ext, chg = _seed_tool_btc_descriptors()
+        result = btc_import_descriptor(
+            descriptor=ext, wallet_name="import_test", change_descriptor=chg
+        )
+
+        assert "wallet_name" in result
+        assert "network" in result
+        assert "btc_descriptor" in result
+        assert "btc_change_descriptor" in result
+        assert "watch_only" in result
+        assert "message" in result
+        assert result["watch_only"] is True
+
+    def test_message_mentions_lw_import_descriptor(self):
+        """The message field advises using lw_import_descriptor for Liquid."""
+        ext, chg = _seed_tool_btc_descriptors()
+        result = btc_import_descriptor(
+            descriptor=ext, wallet_name="msg_test", change_descriptor=chg
+        )
+
+        assert "lw_import_descriptor" in result["message"]
+
+    def test_propagates_value_error(self):
+        """Importing a descriptor into a wallet that already has Bitcoin raises ValueError."""
+        ext, chg = _seed_tool_btc_descriptors()
+        btc_import_descriptor(descriptor=ext, wallet_name="dup_btc", change_descriptor=chg)
+
+        with pytest.raises(ValueError, match="already has a Bitcoin descriptor"):
+            btc_import_descriptor(descriptor=ext, wallet_name="dup_btc", change_descriptor=chg)
+
+
+# ---------------------------------------------------------------------------
+# btc_export_descriptor  # Significance: 5 (Essential)
+# ---------------------------------------------------------------------------
+
+
+class TestBtcExportDescriptor:
+    def test_returns_expected_keys(self):
+        """btc_export_descriptor returns all required keys."""
+        lw_import_mnemonic(TEST_MNEMONIC, "exp_btc", "mainnet")
+
+        result = btc_export_descriptor(wallet_name="exp_btc")
+
+        assert "wallet_name" in result
+        assert "network" in result
+        assert "external_descriptor" in result
+        assert "change_descriptor" in result
+        assert "xpub" in result
+        assert "fingerprint" in result
+        assert "derivation_path" in result
+        assert "note" in result
+
+    def test_note_mentions_lw_export_descriptor(self):
+        """The note field references lw_export_descriptor for Liquid."""
+        lw_import_mnemonic(TEST_MNEMONIC, "note_btc", "mainnet")
+
+        result = btc_export_descriptor(wallet_name="note_btc")
+
+        assert "lw_export_descriptor" in result["note"]
+
+    def test_unknown_wallet_raises(self):
+        """Exporting descriptor for a non-existent wallet raises ValueError matching 'not found'."""
+        with pytest.raises(ValueError, match="not found"):
+            btc_export_descriptor(wallet_name="ghost_btc")
+
+
+# ---------------------------------------------------------------------------
+# TOOLS registry — btc_import_descriptor / btc_export_descriptor
+# ---------------------------------------------------------------------------
+
+
+class TestNewBitcoinToolsRegistry:
+    def test_btc_import_descriptor_registered(self):
+        """btc_import_descriptor is in TOOLS and is callable."""
+        from aqua.tools import TOOLS
+
+        assert "btc_import_descriptor" in TOOLS
+        assert callable(TOOLS["btc_import_descriptor"])
+
+    def test_btc_export_descriptor_registered(self):
+        """btc_export_descriptor is in TOOLS and is callable."""
+        from aqua.tools import TOOLS
+
+        assert "btc_export_descriptor" in TOOLS
+        assert callable(TOOLS["btc_export_descriptor"])


### PR DESCRIPTION
### Purpose

Add Bitcoin descriptor import/export functionality to match Liquid capability. Returns BTC xpub via new CLI commands and MCP tools. Closes #21.

#### Description

Bitcoin wallets now support watch-only imports via BIP84 descriptors. The change descriptor is auto-derived from the external descriptor (replacing `/0/*` with `/1/*`) unless explicitly provided. Both Bitcoin and Liquid descriptors can now be exported separately from their respective CLI commands.

#### Main Changes

- ✨ Added `btc_import_descriptor` tool to import watch-only Bitcoin wallets from BIP84 descriptors
- ✨ Added `btc_export_descriptor` tool to export Bitcoin descriptors + xpub metadata
- ✨ New `aqua btc import-descriptor` CLI command with auto-derivation of change descriptor
- ✨ New `aqua btc export-descriptor` CLI command
- ✨ New `aqua liquid export-descriptor` CLI command (separated from wallet command)
- 🐛 Fixed smoke tests to cover descriptor import/export workflows
- ♻️ Refactored wallet commands to support separate Bitcoin and Liquid operations
- 📝 Updated AGENTS.md and README.md with descriptor tool documentation

### Checklist

- [x] No hardcoded values (they should go in constants.py, .env, or our database)
- [x] Added/updated tests (if necessary)
- [x] Added/updated relevant documentation (if necessary)