### PR TITLE
Add SideSwap integration: BTC \xe2\x86\x94 L-BTC pegs and asset swap quoting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ AI Assistant ←→ MCP Server (Python) ←→ LWK (Liquid) ──→ Electrum/E
 
 No local server required. Liquid uses Electrum/Esplora; Bitcoin uses Esplora only. All via Blockstream's public infrastructure.
 
-## Tools (30 total)
+## Tools (32 total)
 
 Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`; SideSwap tools are `sideswap_*`.
 
@@ -85,7 +85,9 @@ Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified 
 | `sideswap_peg_status` | Check status of a peg order (peg-in or peg-out). Returns confs, tx_state, lockup_txid, payout_txid. | `order_id`: string |
 | `sideswap_recommend` | Recommend peg vs swap-market for a BTC ↔ L-BTC conversion. Surfaces time-vs-fee trade-off and warns if amount exceeds hot-wallet liquidity. | `amount` (sats), `direction`: btc_to_lbtc/lbtc_to_btc, `network`: optional |
 | `sideswap_list_assets` | List Liquid assets supported by SideSwap (USDt, EURx, MEX, DePix, etc.). | `network`: optional |
-| `sideswap_quote` | **Read-only.** Get a price quote for a Liquid asset swap (e.g. L-BTC ↔ USDt). Execution is NOT yet implemented in agentic-aqua — direct user to AQUA mobile or sideswap.io. | `asset_id`, `send_amount` (sats) OR `recv_amount` (sats), `send_bitcoins`: optional, `network`: optional |
+| `sideswap_quote` | Read-only price quote for a Liquid asset swap (e.g. L-BTC ↔ USDt). Use BEFORE `sideswap_execute_swap` to confirm price with user. | `asset_id`, `send_amount` (sats) OR `recv_amount` (sats), `send_bitcoins`: optional, `network`: optional |
+| `sideswap_execute_swap` | Execute an atomic Liquid swap. Both directions supported via `send_bitcoins`: True = L-BTC → asset; False = asset → L-BTC. PSET verified locally against the agreed quote before signing; fee tolerance pinned to L-BTC so the asset side is always strict equality. | `asset_id`, `send_amount` (sats), `send_bitcoins`: optional (default true), `wallet_name`: optional, `password`: optional |
+| `sideswap_swap_status` | Get persisted status of an atomic swap. Pass the txid to `lw_tx_status` for on-chain confirmation. | `order_id`: string |
 
 > ⚠️ **Pegs vs swaps**: pegs charge 0.1% (vs 0.2% for instant swap-market trades) but require waiting for confirmations. Always call `sideswap_recommend` for amounts ≥ 0.01 BTC and surface the trade-off (and any 102-confirmation cold-wallet warning) before initiating a peg-in.
 
@@ -140,6 +142,8 @@ Wallet data stored in `~/.aqua/`:
 │   └── {swap_id}.json   # Contains swap details + status + optional preimage
 ├── sideswap_pegs/       # SideSwap peg orders (peg-in and peg-out)
 │   └── {order_id}.json  # Contains order, addresses, status, tx_state, payout_txid
+├── sideswap_swaps/      # SideSwap atomic asset swap orders (L-BTC → asset)
+│   └── {order_id}.json  # Contains quote, submit_id, status, txid, optional last_error
 └── cache/
     └── <wallet_name>/
         └── btc/
@@ -328,6 +332,7 @@ SideSwap (`sideswap.io`) provides BTC ↔ L-BTC pegs and Liquid asset swaps via 
 - `server_status` — fees, mins, hot-wallet balances
 - `peg_fee`, `peg`, `peg_status` — peg flow
 - `assets`, `subscribe_price_stream`, `unsubscribe_price_stream` — asset swap quoting
+- `market.list_markets`, `market.start_quotes`, `market.get_quote`, `market.taker_sign` — atomic asset swap execution (the modern `mkt::*` flow). Wire format wraps the inner variant in a single-key object: `{"id": N, "method": "market", "params": {"<variant_in_snake_case>": {...}}}`. `AssetType` and `TradeDir` are PascalCase on the wire (`"Base"|"Quote"`, `"Buy"|"Sell"`).
 
 **Fees**:
 - Pegs: 0.1% on send amount + small second-chain fee (~286 sats Liquid claim on peg-in)
@@ -341,7 +346,31 @@ SideSwap (`sideswap.io`) provides BTC ↔ L-BTC pegs and Liquid asset swaps via 
 - Peg-in: 2 BTC confs (~20 min) hot-wallet path; 102 BTC confs (~17 hours) if amount exceeds `PegInWalletBalance`
 - Peg-out: 2 Liquid confs + federation BTC sweep (typically 15–60 min total)
 
-**Asset swap execution is NOT implemented** in agentic-aqua: the legacy `start_swap_web` + HTTP `swap_start`/`swap_sign` flow requires local PSET output verification before signing (the server is trusted-but-verify; an unaudited verifier could be tricked into signing a PSET that pays the user nothing). `sideswap_quote` returns a price quote only; users execute via the AQUA mobile wallet or sideswap.io.
+**Asset swap execution** (`sideswap_execute_swap`) uses SideSwap's modern `mkt::*` flow over WebSocket only (no HTTP dance) and supports **both directions**:
+
+- **L-BTC → asset** (`send_bitcoins=True`): user's L-BTC change pays the network fee. Wallet net effect: `L-BTC: -(send_amount + fee)`, `asset: +recv_amount`.
+- **asset → L-BTC** (`send_bitcoins=False`): SideSwap dealer absorbs the network fee from their L-BTC contribution. Wallet net effect: `asset: -send_amount` (exact), `L-BTC: +recv_amount` (exact).
+
+**mkt::* flow steps**:
+1. `market.list_markets` — fetch available pairs and find one matching ours
+2. Resolve `(asset_type, trade_dir)` via `resolve_market` — always `Sell` with the asset_type matching the side we're sending
+3. `market.start_quotes` with our UTXOs + receive/change addresses + `instant_swap=true`
+4. Wait for a `quote` notification with `status=Success`; `parse_quote_status` raises on `LowBalance` / `Error`
+5. `market.get_quote {quote_id}` → returns the half-built PSET
+6. **Verify** with `wollet.pset_details(pset)` against the agreed quote — refuses to sign on mismatch
+7. `signer.sign(pset)` locally
+8. `market.taker_sign {quote_id, pset}` → server merges & broadcasts; returns the txid
+
+**Verification rules** (`verify_pset_balances` in `src/aqua/sideswap.py`):
+1. Wallet must gain *exactly* `recv_amount` of `recv_asset`.
+2. Wallet must lose at most `send_amount + fee_tolerance_sats` (default 1000) of `send_asset` *if* `send_asset == fee_asset`; otherwise strict equality.
+3. No other asset may have a non-zero balance change.
+
+The manager always passes `fee_asset = policy_asset` (L-BTC) regardless of direction, so the fee tolerance only relaxes constraints on the L-BTC side — never on a non-L-BTC asset, which would otherwise be a siphon vector on the reverse path.
+
+If any rule fails, `PsetVerificationError` is raised and signing is aborted — the order is persisted as `failed` for forensics. The order is also persisted at every flow step (`pending` → `verified` → `signed` → `broadcast`) for crash recovery.
+
+UTXO selection (`select_swap_utxos`): confidential (asset_bf and value_bf both non-zero), holding the requested send_asset, sorted descending by value, accumulated to cover `send_amount`. wpkh-only (matching the wallet's BIP84 m/84'/1776'/0' descriptor). No separate L-BTC fee inputs are required on either direction (mirroring AQUA Flutter's `swap_provider.dart`).
 
 ## Bitcoin Implementation Details
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,63 @@ Or for send swaps (Boltz):
 
 File permissions: `0o600`. Status values: `pending` | `processing` | `completed` | `failed`. The `lightning_transaction_status` tool auto-claims settled receive swaps.
 
+### SideSwap Peg File Structure
+
+Stored at `~/.aqua/sideswap_pegs/{order_id}.json`:
+
+```json
+{
+  "order_id": "abc123",
+  "peg_in": true,
+  "peg_addr": "bc1q...",
+  "recv_addr": "lq1...",
+  "amount": null,
+  "expected_recv": null,
+  "wallet_name": "default",
+  "network": "mainnet",
+  "status": "pending",
+  "created_at": "2026-05-08T12:00:00Z",
+  "expires_at": null,
+  "lockup_txid": null,
+  "payout_txid": null,
+  "detected_confs": null,
+  "total_confs": null,
+  "tx_state": null,
+  "last_checked_at": null,
+  "return_address": null
+}
+```
+
+`peg_in: true` = BTC → L-BTC; `peg_in: false` = L-BTC → BTC. `peg_addr` is where the user sends funds; `recv_addr` is where they receive. `amount` is set for peg-out (user specifies send amount), may be `null` for peg-in. `tx_state` mirrors SideSwap server values: `Detected` | `Processing` | `Done` | `InsufficientAmount`. File written before broadcast and updated on each `sideswap_peg_status` poll.
+
+File permissions: `0o600`. Status values: `pending` → `detected` → `processing` → `completed` | `failed`.
+
+### SideSwap Swap File Structure
+
+Stored at `~/.aqua/sideswap_swaps/{order_id}.json`:
+
+```json
+{
+  "order_id": "mkt_42",
+  "submit_id": "42",
+  "send_asset": "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d",
+  "send_amount": 100000,
+  "recv_asset": "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2",
+  "recv_amount": 9950000,
+  "price": 99.5,
+  "wallet_name": "default",
+  "network": "mainnet",
+  "status": "pending",
+  "created_at": "2026-05-08T12:00:00Z",
+  "txid": null,
+  "last_error": null
+}
+```
+
+`order_id` is `mkt_{quote_id}`. `send_asset` / `recv_asset` are Liquid asset IDs (hex). File written before PSET verification and updated at each step for crash recovery.
+
+File permissions: `0o600`. Status values: `pending` → `verified` → `signed` → `submitted` → `broadcast` | `failed`.
+
 ### Config Structure
 
 ```json
@@ -371,6 +428,22 @@ The manager always passes `fee_asset = policy_asset` (L-BTC) regardless of direc
 If any rule fails, `PsetVerificationError` is raised and signing is aborted — the order is persisted as `failed` for forensics. The order is also persisted at every flow step (`pending` → `verified` → `signed` → `broadcast`) for crash recovery.
 
 UTXO selection (`select_swap_utxos`): confidential (asset_bf and value_bf both non-zero), holding the requested send_asset, sorted descending by value, accumulated to cover `send_amount`. wpkh-only (matching the wallet's BIP84 m/84'/1776'/0' descriptor). No separate L-BTC fee inputs are required on either direction (mirroring AQUA Flutter's `swap_provider.dart`).
+**CLI surface** (`aqua sideswap …`, mirrors the MCP tool surface):
+
+```
+aqua sideswap status [--network mainnet|testnet]
+aqua sideswap recommend --amount <sats> --direction btc_to_lbtc|lbtc_to_btc
+aqua sideswap peg-quote --amount <sats> [--peg-out]
+aqua sideswap peg-in [--wallet-name NAME]
+aqua sideswap peg-out --amount <sats> --btc-address bc1q… [--wallet-name NAME]
+aqua sideswap peg-status --order-id ORD
+aqua sideswap assets [--network mainnet|testnet]
+aqua sideswap quote --asset-ticker USDt --send-amount <sats> [--reverse]
+aqua sideswap swap   --asset-ticker USDt --amount <sats> [--reverse] [--yes]
+aqua sideswap swap-status --order-id ORD
+```
+
+The `swap` subcommand fetches a fresh quote and prompts for confirmation by default; pass `--yes` to skip the prompt. Password resolution follows the same pattern as the rest of the CLI: `--password-stdin` flag → `AQUA_PASSWORD` env var → no password.
 
 ## Bitcoin Implementation Details
 
@@ -491,7 +564,18 @@ agentic-aqua/
 │       ├── ankara.py   # Ankara backend integration (Lightning receive)
 │       ├── sideswap.py # SideSwap WS+HTTP client, peg manager, swap quoting
 │       ├── assets.py   # Asset registry
-│       └── storage.py  # Persistence layer (encryption, config, wallet data)
+│       ├── storage.py  # Persistence layer (encryption, config, wallet data)
+│       └── cli/
+│           ├── main.py       # Root `aqua` Click group
+│           ├── commands.py   # Subcommand registration
+│           ├── liquid.py     # `aqua liquid …`
+│           ├── btc.py        # `aqua btc …`
+│           ├── lightning.py  # `aqua lightning …`
+│           ├── sideswap.py   # `aqua sideswap …` (pegs + atomic swaps)
+│           ├── wallet.py     # `aqua wallet …`
+│           ├── serve.py      # `aqua serve` (MCP server)
+│           ├── output.py     # JSON / pretty rendering
+│           └── password.py   # Secret resolution helpers
 └── tests/
     ├── test_tools.py
     ├── test_lightning.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,9 @@ AI Assistant ←→ MCP Server (Python) ←→ LWK (Liquid) ──→ Electrum/E
 
 No local server required. Liquid uses Electrum/Esplora; Bitcoin uses Esplora only. All via Blockstream's public infrastructure.
 
-## Tools (22 total)
+## Tools (30 total)
 
-Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`.
+Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`; SideSwap tools are `sideswap_*`.
 
 ### Wallet Management
 
@@ -74,6 +74,21 @@ Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified 
 | `lightning_send` | Pay a Lightning invoice using L-BTC via Boltz submarine swap. Fees: ~0.1% + miner fees. Limits: 100 – 25,000,000 sats | `invoice`: BOLT11 string (lnbc... or lntb...), `wallet_name`: optional, `password`: optional |
 | `lightning_transaction_status` | Check status of a Lightning swap (send or receive). For receive: auto-claims L-BTC when settled. For send: retrieves preimage when claimed. | `swap_id`: string |
 
+### SideSwap (BTC ↔ L-BTC Pegs and Liquid Asset Swaps)
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `sideswap_server_status` | Fetch SideSwap server status: live fees, minimums, hot-wallet balances. Call BEFORE recommending or initiating a peg. | `network`: optional (mainnet/testnet) |
+| `sideswap_peg_quote` | Quote receive amount for a peg at current fees (0.1% + ~286 sats Liquid claim fee on peg-in). | `amount`: sats, `peg_in`: optional (default: true), `network`: optional |
+| `sideswap_peg_in` | Initiate a peg-in (BTC → L-BTC). Returns BTC deposit address. After 2 BTC confs (~20 min hot path; up to ~17 hours cold path for very large amounts) L-BTC arrives. Recommended for amounts ≥ ~0.01 BTC. | `wallet_name`: optional, `password`: optional |
+| `sideswap_peg_out` | Initiate a peg-out (L-BTC → BTC) and broadcast the L-BTC send. After 2 Liquid confs and federation BTC sweep (~15-60 min total), BTC arrives. Standard path for L-BTC → BTC. | `wallet_name`, `amount` (sats), `btc_address`, `password`: optional |
+| `sideswap_peg_status` | Check status of a peg order (peg-in or peg-out). Returns confs, tx_state, lockup_txid, payout_txid. | `order_id`: string |
+| `sideswap_recommend` | Recommend peg vs swap-market for a BTC ↔ L-BTC conversion. Surfaces time-vs-fee trade-off and warns if amount exceeds hot-wallet liquidity. | `amount` (sats), `direction`: btc_to_lbtc/lbtc_to_btc, `network`: optional |
+| `sideswap_list_assets` | List Liquid assets supported by SideSwap (USDt, EURx, MEX, DePix, etc.). | `network`: optional |
+| `sideswap_quote` | **Read-only.** Get a price quote for a Liquid asset swap (e.g. L-BTC ↔ USDt). Execution is NOT yet implemented in agentic-aqua — direct user to AQUA mobile or sideswap.io. | `asset_id`, `send_amount` (sats) OR `recv_amount` (sats), `send_bitcoins`: optional, `network`: optional |
+
+> ⚠️ **Pegs vs swaps**: pegs charge 0.1% (vs 0.2% for instant swap-market trades) but require waiting for confirmations. Always call `sideswap_recommend` for amounts ≥ 0.01 BTC and surface the trade-off (and any 102-confirmation cold-wallet warning) before initiating a peg-in.
+
 ## Resources (3 total)
 
 MCP resources provide static documentation to AI assistants.
@@ -84,7 +99,7 @@ MCP resources provide static documentation to AI assistants.
 | `aqua://docs/networks` | Network Reference | Bitcoin and Liquid network details, address formats, explorers, common assets |
 | `aqua://docs/security` | Security Best Practices | Password usage, at-rest encryption, backup, watch-only wallets, recovery |
 
-## Prompts (14 total)
+## Prompts (17 total)
 
 MCP prompts provide pre-built conversation starters for common workflows.
 
@@ -104,6 +119,9 @@ MCP prompts provide pre-built conversation starters for common workflows.
 | `export_descriptor` | Export descriptor for watch-only wallet | `wallet_name`: optional |
 | `delete_wallet` | Safely delete a wallet with balance check and seed backup reminder | `wallet_name`: required |
 | `pay_lightning` | Pay a Lightning invoice using Liquid Bitcoin | `wallet_name`: optional |
+| `peg_in` | Move BTC to Liquid (BTC → L-BTC) via SideSwap peg-in, with quote, recommendation, and time warning | `wallet_name`: optional |
+| `peg_out` | Move L-BTC to Bitcoin (L-BTC → BTC) via SideSwap peg-out, with quote and time estimate | `wallet_name`: optional |
+| `swap_assets` | Quote a Liquid asset swap (e.g. L-BTC ↔ USDt) via SideSwap (read-only; execution requires AQUA mobile or sideswap.io) | (none) |
 
 ## Data Storage
 
@@ -120,6 +138,8 @@ Wallet data stored in `~/.aqua/`:
 │   └── {swap_id}.json   # Contains swap details + preimage when settled
 ├── lightning_swaps/     # Unified Lightning swap data (send & receive)
 │   └── {swap_id}.json   # Contains swap details + status + optional preimage
+├── sideswap_pegs/       # SideSwap peg orders (peg-in and peg-out)
+│   └── {order_id}.json  # Contains order, addresses, status, tx_state, payout_txid
 └── cache/
     └── <wallet_name>/
         └── btc/
@@ -269,6 +289,7 @@ File permissions: `0o600`. Status values: `pending` | `processing` | `completed`
 - `mcp` - Model Context Protocol SDK
 - `cryptography` - For mnemonic encryption (PBKDF2 + Fernet)
 - `coincurve` - secp256k1 for Boltz swap keypair generation
+- `websockets` - WebSocket client for SideSwap JSON-RPC (>=12.0)
 
 ## Ankara Integration
 
@@ -282,6 +303,45 @@ Ankara backend (`test.aquabtc.com`) provides Lightning → L-BTC swaps (receive 
 - `GET /api/v1/lightning/lnurlp/verify/{swap_id}` - Verify settlement status
 
 **Amount Limits**: 100 – 25,000,000 sats (no authentication required)
+
+## SideSwap Integration
+
+SideSwap (`sideswap.io`) provides BTC ↔ L-BTC pegs and Liquid asset swaps via WebSocket JSON-RPC.
+
+**WebSocket endpoints**:
+- Mainnet: `wss://api.sideswap.io/json-rpc-ws`
+- Testnet: `wss://api-testnet.sideswap.io/json-rpc-ws`
+
+**Wire format** (mirrors AQUA Flutter wallet):
+```json
+// Request
+{"id": <int>, "method": "<snake_case>", "params": {...}}
+// Response
+{"id": <int>, "method": "<method>", "result": {...}}
+{"id": <int>, "error": {"code": <int>, "message": "<str>"}}
+// Notification (no id)
+{"method": "<method>", "params": {...}}
+```
+
+**Methods used**:
+- `login_client` (anonymous, `user_agent: "agentic-aqua"`)
+- `server_status` — fees, mins, hot-wallet balances
+- `peg_fee`, `peg`, `peg_status` — peg flow
+- `assets`, `subscribe_price_stream`, `unsubscribe_price_stream` — asset swap quoting
+
+**Fees**:
+- Pegs: 0.1% on send amount + small second-chain fee (~286 sats Liquid claim on peg-in)
+- Swap-market taker: 0.2% (or 500 sats minimum, whichever higher)
+
+**Peg minimums** (read live values from `server_status`):
+- Peg-in: 1,286 sats (~0.00001286 BTC)
+- Peg-out: 100,000 sats (0.001 BTC) on the SideSwap server, 25,000 sats in the AQUA app
+
+**Peg timing**:
+- Peg-in: 2 BTC confs (~20 min) hot-wallet path; 102 BTC confs (~17 hours) if amount exceeds `PegInWalletBalance`
+- Peg-out: 2 Liquid confs + federation BTC sweep (typically 15–60 min total)
+
+**Asset swap execution is NOT implemented** in agentic-aqua: the legacy `start_swap_web` + HTTP `swap_start`/`swap_sign` flow requires local PSET output verification before signing (the server is trusted-but-verify; an unaudited verifier could be tricked into signing a PSET that pays the user nothing). `sideswap_quote` returns a price quote only; users execute via the AQUA mobile wallet or sideswap.io.
 
 ## Bitcoin Implementation Details
 
@@ -394,12 +454,13 @@ agentic-aqua/
 │   └── aqua/
 │       ├── __init__.py
 │       ├── server.py   # MCP server entry point (tools, resources, prompts)
-│       ├── tools.py    # Tool implementations (lw_*, btc_*, unified_*, lightning_*)
+│       ├── tools.py    # Tool implementations (lw_*, btc_*, unified_*, lightning_*, sideswap_*)
 │       ├── wallet.py   # Liquid wallet (LWK)
 │       ├── bitcoin.py  # Bitcoin wallet (BDK)
 │       ├── lightning.py # Lightning abstraction layer (unified send/receive manager)
 │       ├── boltz.py    # Boltz Exchange integration (submarine swaps, send)
 │       ├── ankara.py   # Ankara backend integration (Lightning receive)
+│       ├── sideswap.py # SideSwap WS+HTTP client, peg manager, swap quoting
 │       ├── assets.py   # Asset registry
 │       └── storage.py  # Persistence layer (encryption, config, wallet data)
 └── tests/
@@ -409,6 +470,7 @@ agentic-aqua/
     ├── test_bitcoin.py
     ├── test_boltz.py
     ├── test_ankara.py
+    ├── test_sideswap.py
     └── test_server.py
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "coincurve>=21.0.0",
     "python-dotenv>=1.0.0",
     "click>=8.1",
+    "websockets>=12.0",
 ]
 
 [project.optional-dependencies]

--- a/src/aqua/cli/commands.py
+++ b/src/aqua/cli/commands.py
@@ -12,12 +12,14 @@ def register_commands(cli):
     from .lightning import lightning
     from .liquid import liquid
     from .serve import serve
+    from .sideswap import sideswap
     from .wallet import wallet
 
     cli.add_command(wallet)
     cli.add_command(liquid)
     cli.add_command(btc)
     cli.add_command(lightning)
+    cli.add_command(sideswap)
     cli.add_command(serve)
     cli.add_command(balance)
 

--- a/src/aqua/cli/sideswap.py
+++ b/src/aqua/cli/sideswap.py
@@ -1,0 +1,376 @@
+"""SideSwap CLI commands — pegs (BTC ↔ L-BTC) and atomic Liquid asset swaps.
+
+Wraps the SideSwap MCP tools so users can drive pegs and swaps from a shell
+without spinning up the MCP server. Mirrors the tool surface 1:1 — the
+security-critical layer (PSET verification, fee_asset pinning) lives in the
+manager and is unchanged here; this file is just argument parsing + output.
+"""
+
+from __future__ import annotations
+
+import click
+
+from ..tools import (
+    sideswap_execute_swap,
+    sideswap_list_assets,
+    sideswap_peg_in,
+    sideswap_peg_out,
+    sideswap_peg_quote,
+    sideswap_peg_status,
+    sideswap_quote,
+    sideswap_recommend,
+    sideswap_server_status,
+    sideswap_swap_status,
+)
+from .output import run_tool
+from .password import handle_password_retry, resolve_secret
+
+
+_NETWORK_OPTION = click.Choice(["mainnet", "testnet"])
+_DIRECTION_OPTION = click.Choice(["btc_to_lbtc", "lbtc_to_btc"])
+
+_PASSWORD_HELP = (
+    "Read wallet password from stdin (piped) or prompt interactively. "
+    "Without this flag, falls back to the AQUA_PASSWORD environment variable, "
+    "then to no password."
+)
+
+
+@click.group()
+def sideswap():
+    """SideSwap operations — BTC ↔ L-BTC pegs and atomic Liquid asset swaps.
+
+    Pegs charge ~0.1% (vs 0.2% on instant atomic swaps) and take ~20-60 minutes
+    depending on direction and size. Swaps complete in seconds but pay slightly
+    more in fees. Use `aqua sideswap recommend` for a quick decision-helper
+    when converting between BTC and L-BTC.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Server / general info
+# ---------------------------------------------------------------------------
+
+
+@sideswap.command("status")
+@click.option(
+    "--network", type=_NETWORK_OPTION, default="mainnet", show_default=True,
+    help="SideSwap network to query.",
+)
+@click.pass_obj
+def status(ctx, network):
+    """Show SideSwap server status — live fees, peg minimums, hot-wallet balance."""
+    run_tool(ctx, lambda: sideswap_server_status(network))
+
+
+@sideswap.command("recommend")
+@click.option(
+    "--amount", required=True, type=click.IntRange(min=1),
+    help="Amount in satoshis to convert.",
+)
+@click.option(
+    "--direction", required=True, type=_DIRECTION_OPTION,
+    help="Direction of conversion (btc_to_lbtc or lbtc_to_btc).",
+)
+@click.option("--network", type=_NETWORK_OPTION, default="mainnet", show_default=True)
+@click.pass_obj
+def recommend(ctx, amount, direction, network):
+    """Recommend peg vs swap-market trade for a BTC ↔ L-BTC conversion.
+
+    Surfaces the time-vs-fee trade-off and warns if the amount exceeds
+    SideSwap's hot-wallet liquidity (which would force the 102-confirmation
+    cold-wallet path on peg-in).
+    """
+    run_tool(ctx, lambda: sideswap_recommend(amount, direction, network))
+
+
+# ---------------------------------------------------------------------------
+# Pegs
+# ---------------------------------------------------------------------------
+
+
+@sideswap.command("peg-quote")
+@click.option(
+    "--amount", required=True, type=click.IntRange(min=1),
+    help="Send amount in satoshis.",
+)
+@click.option(
+    "--peg-out", "peg_out", is_flag=True, default=False,
+    help="Quote peg-out (L-BTC → BTC). Default: peg-in (BTC → L-BTC).",
+)
+@click.option("--network", type=_NETWORK_OPTION, default="mainnet", show_default=True)
+@click.pass_obj
+def peg_quote(ctx, amount, peg_out, network):
+    """Quote receive amount for a peg at current SideSwap fees (0.1%)."""
+    run_tool(ctx, lambda: sideswap_peg_quote(amount, not peg_out, network))
+
+
+@sideswap.command("peg-in")
+@click.option(
+    "--wallet-name", default="default", show_default=True,
+    help="Liquid wallet to receive L-BTC into.",
+)
+@click.option(
+    "--password-stdin", "password_stdin", is_flag=True, default=False,
+    help=_PASSWORD_HELP,
+)
+@click.pass_obj
+def peg_in(ctx, wallet_name, password_stdin):
+    """Initiate a peg-in (BTC → L-BTC). Prints the BTC deposit address.
+
+    After this command, send BTC to the printed `peg_addr` from any Bitcoin
+    wallet (including `aqua btc send`). Track progress with
+    `aqua sideswap peg-status --order-id <id>`.
+
+    Hot-wallet path: ~20 min for 2 BTC confirmations. For very large amounts
+    that exceed SideSwap's hot-wallet liquidity, the cold-wallet path takes
+    102 BTC confirmations (~17 hours). Run `aqua sideswap recommend` first
+    to see which path applies.
+    """
+    password = resolve_secret(
+        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
+    )
+    run_tool(
+        ctx,
+        lambda: handle_password_retry(
+            sideswap_peg_in,
+            {"wallet_name": wallet_name, "password": password},
+        ),
+    )
+
+
+@sideswap.command("peg-out")
+@click.option(
+    "--amount", required=True, type=click.IntRange(min=1),
+    help="L-BTC sats to peg out.",
+)
+@click.option(
+    "--btc-address", required=True,
+    help="Destination Bitcoin address (bc1...).",
+)
+@click.option(
+    "--wallet-name", default="default", show_default=True,
+    help="Liquid wallet to send L-BTC from.",
+)
+@click.option(
+    "--password-stdin", "password_stdin", is_flag=True, default=False,
+    help=_PASSWORD_HELP,
+)
+@click.pass_obj
+def peg_out(ctx, amount, btc_address, wallet_name, password_stdin):
+    """Initiate a peg-out (L-BTC → BTC) and broadcast the L-BTC send.
+
+    After 2 Liquid confirmations (~2 min) and the federation BTC sweep
+    (typically 15-60 min total), BTC arrives at the destination address.
+    Track progress with `aqua sideswap peg-status --order-id <id>`.
+    """
+    password = resolve_secret(
+        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
+    )
+    run_tool(
+        ctx,
+        lambda: handle_password_retry(
+            sideswap_peg_out,
+            {
+                "wallet_name": wallet_name,
+                "amount": amount,
+                "btc_address": btc_address,
+                "password": password,
+            },
+        ),
+    )
+
+
+@sideswap.command("peg-status")
+@click.option("--order-id", required=True, help="Order ID returned from peg-in or peg-out.")
+@click.pass_obj
+def peg_status(ctx, order_id):
+    """Check status of a peg order — confirmations, tx_state, payout txid."""
+    run_tool(ctx, lambda: sideswap_peg_status(order_id))
+
+
+# ---------------------------------------------------------------------------
+# Asset swaps
+# ---------------------------------------------------------------------------
+
+
+def _resolve_asset(asset_id_arg: str | None, ticker_arg: str | None, network: str) -> str:
+    """Mirror `aqua liquid send-asset`'s asset_id/ticker resolution."""
+    from ..assets import lookup_asset_by_ticker
+
+    if bool(asset_id_arg) == bool(ticker_arg):
+        raise click.UsageError("Provide exactly one of --asset-id or --asset-ticker.")
+    if asset_id_arg:
+        return asset_id_arg
+    info = lookup_asset_by_ticker(ticker_arg, network)
+    if info is None:
+        raise click.UsageError(
+            f"Unknown ticker '{ticker_arg}' on {network}. "
+            "Run 'aqua sideswap assets' to list known tickers."
+        )
+    return info.asset_id
+
+
+@sideswap.command("assets")
+@click.option("--network", type=_NETWORK_OPTION, default="mainnet", show_default=True)
+@click.pass_obj
+def assets(ctx, network):
+    """List Liquid assets that SideSwap supports for atomic swaps."""
+    run_tool(ctx, lambda: sideswap_list_assets(network))
+
+
+@sideswap.command("quote")
+@click.option("--asset-id", default=None, help="Asset ID (hex). One of --asset-id or --asset-ticker required.")
+@click.option(
+    "--asset-ticker", default=None,
+    help="Asset ticker (case-insensitive, e.g. USDt). Resolved via the registry.",
+)
+@click.option(
+    "--send-amount", default=None, type=click.IntRange(min=1),
+    help="Amount the user sends (sats). Provide one of send/recv.",
+)
+@click.option(
+    "--recv-amount", default=None, type=click.IntRange(min=1),
+    help="Amount the user receives (sats). Provide one of send/recv.",
+)
+@click.option(
+    "--reverse", is_flag=True, default=False,
+    help="Reverse direction: sending the asset for L-BTC. Default: sending L-BTC for the asset.",
+)
+@click.option("--network", type=_NETWORK_OPTION, default="mainnet", show_default=True)
+@click.pass_obj
+def quote(ctx, asset_id, asset_ticker, send_amount, recv_amount, reverse, network):
+    """Read-only price quote for a Liquid asset swap. No execution."""
+    if (send_amount is None) == (recv_amount is None):
+        raise click.UsageError("Provide exactly one of --send-amount or --recv-amount.")
+    asset_id = _resolve_asset(asset_id, asset_ticker, network)
+    run_tool(
+        ctx,
+        lambda: sideswap_quote(
+            asset_id=asset_id,
+            send_amount=send_amount,
+            recv_amount=recv_amount,
+            send_bitcoins=not reverse,
+            network=network,
+        ),
+    )
+
+
+@sideswap.command("swap")
+@click.option("--asset-id", default=None, help="Non-L-BTC asset ID (hex). One of --asset-id or --asset-ticker required.")
+@click.option(
+    "--asset-ticker", default=None,
+    help="Asset ticker (case-insensitive, e.g. USDt). Resolved via the registry.",
+)
+@click.option(
+    "--amount", required=True, type=click.IntRange(min=1),
+    help="Send amount in satoshis (L-BTC if forward, asset if --reverse).",
+)
+@click.option(
+    "--reverse", is_flag=True, default=False,
+    help="Reverse direction: sending the asset for L-BTC. Default: sending L-BTC for the asset.",
+)
+@click.option(
+    "--wallet-name", default="default", show_default=True,
+    help="Liquid wallet to sign with.",
+)
+@click.option(
+    "--yes", "-y", "skip_confirm", is_flag=True, default=False,
+    help="Skip the interactive confirmation prompt.",
+)
+@click.option(
+    "--password-stdin", "password_stdin", is_flag=True, default=False,
+    help=_PASSWORD_HELP,
+)
+@click.pass_obj
+def swap(ctx, asset_id, asset_ticker, amount, reverse, wallet_name, skip_confirm, password_stdin):
+    """Execute an atomic Liquid asset swap on SideSwap.
+
+    Both directions are supported via --reverse. The PSET returned by SideSwap
+    is verified locally against the agreed quote BEFORE signing — refuses to
+    sign if the wallet's net balance change does not match exactly.
+
+    Without --yes, prompts for explicit confirmation showing the quote and the
+    direction. Without --password-stdin, falls back to AQUA_PASSWORD env var
+    or no password.
+    """
+    from ..assets import lookup_asset
+
+    # Resolve asset using the wallet's network so testnet tickers resolve correctly
+    network = "mainnet"
+    try:
+        from ..tools import get_manager
+
+        wallet_data = get_manager().storage.load_wallet(wallet_name)
+        if wallet_data is not None:
+            network = wallet_data.network
+    except Exception:
+        pass
+
+    asset_id = _resolve_asset(asset_id, asset_ticker, network)
+
+    # Resolve a human-readable label for the non-L-BTC side once.
+    asset_info = lookup_asset(asset_id, network)
+    asset_label = (
+        asset_ticker
+        if asset_ticker is not None
+        else (asset_info.ticker if asset_info is not None else asset_id[:8] + "…")
+    )
+    send_label = asset_label if reverse else "L-BTC"
+    recv_label = "L-BTC" if reverse else asset_label
+
+    # Confirmation: show a fresh quote unless the user opted out, and pin the
+    # confirmed recv_amount as a floor for the executor — protects against
+    # rate drift between this price-stream preview and the mkt::* quote that
+    # actually executes the swap.
+    min_recv_amount: int | None = None
+    if not skip_confirm:
+        click.echo("Fetching quote from SideSwap…", err=True)
+        try:
+            preview = sideswap_quote(
+                asset_id=asset_id,
+                send_amount=amount,
+                send_bitcoins=not reverse,
+                network=network,
+            )
+        except Exception as e:
+            raise click.ClickException(f"Could not fetch quote: {e}") from e
+        click.echo(
+            f"Send: {preview.get('send_amount')} sats of {send_label}\n"
+            f"Recv: {preview.get('recv_amount')} sats of {recv_label}\n"
+            f"Price: {preview.get('price')}\n"
+            f"Fixed fee: {preview.get('fixed_fee')} sats",
+            err=True,
+        )
+        if preview.get("error_msg"):
+            raise click.ClickException(f"SideSwap quote error: {preview['error_msg']}")
+        click.confirm("Proceed with this swap?", abort=True, err=True)
+        recv = preview.get("recv_amount")
+        if isinstance(recv, int) and recv > 0:
+            min_recv_amount = recv
+
+    password = resolve_secret(
+        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
+    )
+    run_tool(
+        ctx,
+        lambda: handle_password_retry(
+            sideswap_execute_swap,
+            {
+                "asset_id": asset_id,
+                "send_amount": amount,
+                "wallet_name": wallet_name,
+                "password": password,
+                "send_bitcoins": not reverse,
+                "min_recv_amount": min_recv_amount,
+            },
+        ),
+    )
+
+
+@sideswap.command("swap-status")
+@click.option("--order-id", required=True, help="Order ID returned from `aqua sideswap swap`.")
+@click.pass_obj
+def swap_status(ctx, order_id):
+    """Check status of an atomic asset swap order."""
+    run_tool(ctx, lambda: sideswap_swap_status(order_id))

--- a/src/aqua/cli/sideswap.py
+++ b/src/aqua/cli/sideswap.py
@@ -346,8 +346,12 @@ def swap(ctx, asset_id, asset_ticker, amount, reverse, wallet_name, skip_confirm
             raise click.ClickException(f"SideSwap quote error: {preview['error_msg']}")
         click.confirm("Proceed with this swap?", abort=True, err=True)
         recv = preview.get("recv_amount")
-        if isinstance(recv, int) and recv > 0:
-            min_recv_amount = recv
+        if not isinstance(recv, int) or recv <= 0:
+            raise click.ClickException(
+                f"SideSwap returned an invalid recv_amount in the quote preview: {recv!r}. "
+                "Refusing to proceed without a confirmed rate."
+            )
+        min_recv_amount = recv
 
     password = resolve_secret(
         "Password", password_stdin, env_var="AQUA_PASSWORD", required=False

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -453,6 +453,205 @@ TOOL_SCHEMAS = {
             "required": ["swap_id"],
         },
     },
+    "sideswap_server_status": {
+        "description": (
+            "Fetch SideSwap server status: live fees, minimum amounts, and "
+            "hot-wallet balances. Call this BEFORE recommending a peg or swap "
+            "so values reflect current SideSwap state."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "network": {
+                    "type": "string",
+                    "enum": ["mainnet", "testnet"],
+                    "default": "mainnet",
+                },
+            },
+        },
+    },
+    "sideswap_peg_quote": {
+        "description": (
+            "Quote the receive amount for a SideSwap peg (BTC ↔ L-BTC) at "
+            "current fees (0.1% + ~286 sats Liquid claim fee on peg-in). "
+            "Returns send_amount, recv_amount, fee_amount."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer",
+                    "description": "Send amount in Satoshis",
+                },
+                "peg_in": {
+                    "type": "boolean",
+                    "description": "True for BTC → L-BTC, False for L-BTC → BTC",
+                    "default": True,
+                },
+                "network": {
+                    "type": "string",
+                    "enum": ["mainnet", "testnet"],
+                    "default": "mainnet",
+                },
+            },
+            "required": ["amount"],
+        },
+    },
+    "sideswap_peg_in": {
+        "description": (
+            "Initiate a SideSwap peg-in (BTC → L-BTC). Returns a Bitcoin deposit "
+            "address; the user (or btc_send) must send BTC to it. After 2 BTC "
+            "confirmations (~20 min hot path; up to ~17 hours cold path for "
+            "very large amounts), L-BTC arrives in the Liquid wallet. "
+            "Recommended over a swap-market trade for amounts ≥ ~0.01 BTC: "
+            "lower fee (0.1% vs 0.2%) at the cost of waiting. "
+            "ALWAYS call sideswap_recommend first for large amounts so the user "
+            "understands the trade-off."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "wallet_name": {
+                    "type": "string",
+                    "description": "Liquid wallet to receive L-BTC",
+                    "default": "default",
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password to decrypt mnemonic (if encrypted at rest)",
+                },
+            },
+        },
+    },
+    "sideswap_peg_out": {
+        "description": (
+            "Initiate a SideSwap peg-out (L-BTC → BTC) and broadcast the L-BTC "
+            "send. After 2 Liquid confirmations (~2 min) and the federation BTC "
+            "sweep (typically 15–60 min total), BTC arrives at the user's "
+            "Bitcoin address. Fees: 0.1% + Bitcoin network fee. Standard way to "
+            "move L-BTC back to Bitcoin mainchain."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "wallet_name": {
+                    "type": "string",
+                    "description": "Liquid wallet to send L-BTC from",
+                },
+                "amount": {
+                    "type": "integer",
+                    "description": "Amount in Satoshis to peg out",
+                },
+                "btc_address": {
+                    "type": "string",
+                    "description": "Destination Bitcoin address (bc1...)",
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password to decrypt mnemonic (if encrypted at rest)",
+                },
+            },
+            "required": ["wallet_name", "amount", "btc_address"],
+        },
+    },
+    "sideswap_peg_status": {
+        "description": (
+            "Check the status of a SideSwap peg order (peg-in or peg-out). "
+            "Returns confirmations progress (X/Y), tx_state, lockup_txid, "
+            "payout_txid when complete."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "order_id": {
+                    "type": "string",
+                    "description": "Order ID from sideswap_peg_in or sideswap_peg_out",
+                },
+            },
+            "required": ["order_id"],
+        },
+    },
+    "sideswap_recommend": {
+        "description": (
+            "Recommend a peg vs an instant swap-market trade for a BTC ↔ L-BTC "
+            "conversion. Surfaces the trade-off (lower fee but slower) and "
+            "warns when the amount exceeds SideSwap's hot-wallet liquidity. "
+            "ALWAYS call this for large conversions before initiating a peg."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "integer",
+                    "description": "Amount in Satoshis to convert",
+                },
+                "direction": {
+                    "type": "string",
+                    "enum": ["btc_to_lbtc", "lbtc_to_btc"],
+                    "description": "Direction of conversion",
+                },
+                "network": {
+                    "type": "string",
+                    "enum": ["mainnet", "testnet"],
+                    "default": "mainnet",
+                },
+            },
+            "required": ["amount", "direction"],
+        },
+    },
+    "sideswap_list_assets": {
+        "description": (
+            "List Liquid assets that SideSwap supports for atomic swaps "
+            "(e.g. L-BTC, USDt, EURx, MEX, DePix)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "network": {
+                    "type": "string",
+                    "enum": ["mainnet", "testnet"],
+                    "default": "mainnet",
+                },
+            },
+        },
+    },
+    "sideswap_quote": {
+        "description": (
+            "Get a read-only price quote for a SideSwap Liquid asset swap "
+            "(e.g. L-BTC ↔ USDt). Provide exactly one of send_amount or "
+            "recv_amount. NOTE: this is a quote only — atomic swap execution "
+            "is not yet implemented in agentic-aqua (PSET output verification "
+            "needs an audit). To execute, use the AQUA mobile wallet or sideswap.io."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "asset_id": {
+                    "type": "string",
+                    "description": "Liquid asset ID (hex) to swap with L-BTC",
+                },
+                "send_amount": {
+                    "type": "integer",
+                    "description": "Amount the user is sending (Satoshis)",
+                },
+                "recv_amount": {
+                    "type": "integer",
+                    "description": "Amount the user wants to receive (Satoshis)",
+                },
+                "send_bitcoins": {
+                    "type": "boolean",
+                    "description": "True if sending L-BTC for the asset; False if sending the asset for L-BTC",
+                    "default": True,
+                },
+                "network": {
+                    "type": "string",
+                    "enum": ["mainnet", "testnet"],
+                    "default": "mainnet",
+                },
+            },
+            "required": ["asset_id"],
+        },
+    },
 }
 
 
@@ -519,6 +718,30 @@ LIGHTNING:
 - Use lightning_send to pay a BOLT11 invoice using L-BTC (submarine swap via Boltz)
   Fees: ~0.1% + miner fees, Limits: 100 - 25,000,000 Sats
 - Use lightning_transaction_status to check status of any Lightning swap (send or receive)
+
+SIDESWAP (BTC ↔ L-BTC pegs and Liquid asset swaps):
+- Pegs are the canonical way to move funds between Bitcoin mainchain and Liquid.
+- Peg-in (BTC → L-BTC): user sends BTC to a SideSwap deposit address; after 2
+  BTC confirmations (~20 min), L-BTC arrives in their Liquid wallet.
+- Peg-out (L-BTC → BTC): user sends L-BTC to a SideSwap deposit address; after
+  2 Liquid confs and the federation sweep (~15-60 min total), BTC arrives.
+- Fees: 0.1% on each peg + a small second-chain fee (~286 sats on peg-in).
+- BEFORE initiating a peg for ≥ 0.01 BTC (~1,000,000 sats), call
+  sideswap_recommend to surface the time-vs-fee trade-off and warn the user.
+- For VERY LARGE peg-ins that exceed SideSwap's hot-wallet balance, expect the
+  cold-wallet path: 102 BTC confirmations (~17 hours). Always check
+  sideswap_server_status first and warn the user when this applies.
+- For Liquid asset swaps (e.g. L-BTC ↔ USDt), sideswap_quote returns a quote
+  but does NOT execute the swap — direct the user to the AQUA mobile wallet
+  or sideswap.io to complete it.
+
+WHEN TO RECOMMEND A PEG:
+- "I want to move my BTC to Liquid" → if amount ≥ 0.01 BTC, recommend peg-in.
+  Below that, instant atomic swaps may be preferable for speed.
+- "I want to move my L-BTC to Bitcoin" → recommend peg-out (it is the standard
+  path; swap-market liquidity for L-BTC → BTC is shallow).
+- ALWAYS explain the time trade-off and ask the user to confirm they want to
+  wait the expected duration before broadcasting.
 
 WATCH-ONLY WALLETS:
 - For a Bitcoin-only watch wallet: btc_import_descriptor (BIP84 wpkh xpub).
@@ -650,6 +873,26 @@ WALLET DELETION:
                 arguments=[
                     PromptArgument(name="wallet_name", description="Wallet name", required=False),
                 ],
+            ),
+            # SideSwap
+            Prompt(
+                name="peg_in",
+                description="Move BTC to Liquid (BTC → L-BTC) via SideSwap peg-in",
+                arguments=[
+                    PromptArgument(name="wallet_name", description="Wallet name", required=False),
+                ],
+            ),
+            Prompt(
+                name="peg_out",
+                description="Move L-BTC to Bitcoin (L-BTC → BTC) via SideSwap peg-out",
+                arguments=[
+                    PromptArgument(name="wallet_name", description="Wallet name", required=False),
+                ],
+            ),
+            Prompt(
+                name="swap_assets",
+                description="Quote a Liquid asset swap (e.g. L-BTC ↔ USDt) via SideSwap (read-only)",
+                arguments=[],
             ),
         ]
 
@@ -952,6 +1195,98 @@ Please follow this safety workflow:
 5. Ask me for EXPLICIT confirmation: "Are you sure you want to delete wallet '{wallet_name}'? This cannot be undone."
 6. Only after I explicitly confirm, call delete_wallet with wallet_name='{wallet_name}'
 7. Confirm deletion was successful""",
+                        ),
+                    )
+                ]
+            )
+
+        elif name == "peg_in":
+            return GetPromptResult(
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(
+                            type="text",
+                            text=f"""I want to peg in (move BTC into L-BTC) using my '{wallet_name}' wallet.
+
+Please:
+1. Ask me how much BTC I want to peg in (in BTC or Sats)
+2. If I haven't given a clear amount yet, also show my current Bitcoin balance
+   (btc_balance) so I have context
+3. Call sideswap_server_status to fetch live fees, minimums, and hot-wallet balance
+4. Call sideswap_recommend with direction="btc_to_lbtc" and the amount to confirm
+   peg-in is appropriate, and surface the trade-off:
+   - Lower fee (0.1% vs ~0.2% on instant swaps)
+   - Slower: usually 20–40 min for 2 BTC confirmations
+   - For very large amounts: may require 102 confs (~17 hours) if it exceeds
+     SideSwap's hot-wallet liquidity. WARN clearly if this applies.
+5. Call sideswap_peg_quote to show the exact receive amount after fees
+6. Show me a summary BEFORE proceeding:
+   - Send amount (BTC) → Receive amount (L-BTC)
+   - Fee breakdown
+   - Expected time (and any 102-conf warning)
+7. Ask for explicit confirmation
+8. Call sideswap_peg_in to get the BTC deposit address (peg_addr)
+9. Ask me whether I want to fund it from my local Bitcoin wallet (btc_send) or
+   send manually from another wallet
+10. If from local: ask for password (if encrypted), then btc_send to peg_addr
+11. Show me the order_id and tell me to use sideswap_peg_status to track progress""",
+                        ),
+                    )
+                ]
+            )
+
+        elif name == "peg_out":
+            return GetPromptResult(
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(
+                            type="text",
+                            text=f"""I want to peg out (move L-BTC into Bitcoin) from my '{wallet_name}' wallet.
+
+Please:
+1. Show my current L-BTC balance (lw_balance)
+2. Ask me:
+   - How much L-BTC to peg out (Sats)
+   - Destination Bitcoin address (bc1...)
+3. Call sideswap_server_status to fetch live minimums and fees
+4. Call sideswap_recommend with direction="lbtc_to_btc" — peg-out is the
+   standard path for L-BTC → BTC and you should communicate that
+5. Call sideswap_peg_quote (peg_in=false) to show the exact receive amount
+6. Show me a summary BEFORE proceeding:
+   - Send: X L-BTC → Receive: Y BTC at {{btc_address}}
+   - Fee breakdown (0.1% + Bitcoin network fee, deducted from payout)
+   - Expected time: usually 15–60 minutes
+7. Ask for explicit confirmation
+8. If wallet is password-encrypted, ask for the password
+9. Call sideswap_peg_out — this broadcasts the L-BTC send to the SideSwap
+   deposit address. Show the order_id and lockup_txid
+10. Tell me to track progress with sideswap_peg_status""",
+                        ),
+                    )
+                ]
+            )
+
+        elif name == "swap_assets":
+            return GetPromptResult(
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(
+                            type="text",
+                            text="""I want to swap Liquid assets (e.g. L-BTC ↔ USDt) via SideSwap.
+
+Please:
+1. Call sideswap_list_assets to show what's tradeable on SideSwap right now
+2. Ask me what I want to swap and which direction (sending L-BTC for an asset
+   vs sending an asset for L-BTC)
+3. Ask me for an amount (either send amount or receive amount, not both)
+4. Call sideswap_quote to get a price quote
+5. Show me the result clearly: send X → receive Y at price P, with fixed_fee
+6. IMPORTANT: tell me that agentic-aqua does NOT yet execute SideSwap atomic
+   swaps (PSET output verification needs an audit before live signing). To
+   execute, I need to use the AQUA mobile wallet or sideswap.io.""",
                         ),
                     )
                 ]

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -689,6 +689,16 @@ TOOL_SCHEMAS = {
                     "type": "string",
                     "description": "Password to decrypt mnemonic (if encrypted at rest)",
                 },
+                "min_recv_amount": {
+                    "type": "integer",
+                    "description": (
+                        "Optional floor on the dealer's recv_amount in sats. "
+                        "Pass the recv_amount the user just confirmed in "
+                        "sideswap_quote — if the rate moved between preview "
+                        "and execution and the dealer offers less, the swap "
+                        "is rejected before signing."
+                    ),
+                },
                 "flexible_small_amount": {
                     "type": "boolean",
                     "description": (
@@ -1368,7 +1378,9 @@ Please:
 7. Ask for explicit confirmation
 8. If wallet is password-encrypted, ask me for the password
 9. Call sideswap_execute_swap with the same asset_id, send_amount, and
-   send_bitcoins flag.
+   send_bitcoins flag. ALSO pass min_recv_amount=<recv_amount from the
+   quote> so the swap aborts if the rate has drifted between the preview
+   I just confirmed and the mkt::* quote that actually executes.
    The tool will: capture a fresh quote (price may have moved by a few
    percent), request the PSET via SideSwap's market.get_quote, VERIFY it
    locally against the quote, sign it, and submit via market.taker_sign.

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -619,9 +619,8 @@ TOOL_SCHEMAS = {
         "description": (
             "Get a read-only price quote for a SideSwap Liquid asset swap "
             "(e.g. L-BTC ↔ USDt). Provide exactly one of send_amount or "
-            "recv_amount. NOTE: this is a quote only — atomic swap execution "
-            "is not yet implemented in agentic-aqua (PSET output verification "
-            "needs an audit). To execute, use the AQUA mobile wallet or sideswap.io."
+            "recv_amount. Use this BEFORE sideswap_execute_swap so the user "
+            "can confirm the price."
         ),
         "inputSchema": {
             "type": "object",
@@ -650,6 +649,76 @@ TOOL_SCHEMAS = {
                 },
             },
             "required": ["asset_id"],
+        },
+    },
+    "sideswap_execute_swap": {
+        "description": (
+            "Execute a Liquid atomic swap on SideSwap. Both directions are "
+            "supported via send_bitcoins: True = L-BTC → asset (default), "
+            "False = asset → L-BTC. The PSET returned by SideSwap is verified "
+            "locally against the agreed quote BEFORE signing — the swap is "
+            "aborted if the wallet's net balance change does not exactly match "
+            "(refusing to sign protects against a hostile server). The fee "
+            "tolerance is pinned to L-BTC, so on the asset → L-BTC direction "
+            "the asset side is checked at strict equality. Order is persisted "
+            "at every step for crash recovery. ALWAYS call sideswap_quote "
+            "first and confirm the price with the user before invoking this tool."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "asset_id": {
+                    "type": "string",
+                    "description": "Non-L-BTC Liquid asset (e.g. USDt). The L-BTC side is always the policy asset.",
+                },
+                "send_amount": {
+                    "type": "integer",
+                    "description": "Send amount in sats (L-BTC if send_bitcoins, else asset)",
+                },
+                "send_bitcoins": {
+                    "type": "boolean",
+                    "description": "True = send L-BTC to receive asset; False = send asset to receive L-BTC",
+                    "default": True,
+                },
+                "wallet_name": {
+                    "type": "string",
+                    "description": "Liquid wallet to sign with",
+                    "default": "default",
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password to decrypt mnemonic (if encrypted at rest)",
+                },
+                "flexible_small_amount": {
+                    "type": "boolean",
+                    "description": (
+                        "When True, accept dealer-rounded send_amount up to "
+                        "±3000 sats from what was requested. SideSwap's mkt::* "
+                        "dealer rounds internally; small swaps (e.g. 5k–25k "
+                        "sats) often come back at a slightly different amount. "
+                        "Off by default — strict equality is safer at scale."
+                    ),
+                    "default": False,
+                },
+            },
+            "required": ["asset_id", "send_amount"],
+        },
+    },
+    "sideswap_swap_status": {
+        "description": (
+            "Get persisted status of a SideSwap atomic asset swap. Once the "
+            "swap is broadcast, pass the txid to lw_tx_status to track "
+            "on-chain confirmations."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "order_id": {
+                    "type": "string",
+                    "description": "Order ID returned from sideswap_execute_swap",
+                },
+            },
+            "required": ["order_id"],
         },
     },
 }
@@ -732,8 +801,11 @@ SIDESWAP (BTC ↔ L-BTC pegs and Liquid asset swaps):
   cold-wallet path: 102 BTC confirmations (~17 hours). Always check
   sideswap_server_status first and warn the user when this applies.
 - For Liquid asset swaps (e.g. L-BTC ↔ USDt), sideswap_quote returns a quote
-  but does NOT execute the swap — direct the user to the AQUA mobile wallet
-  or sideswap.io to complete it.
+  and sideswap_execute_swap performs the swap. Both directions are supported
+  via the send_bitcoins flag. The PSET returned by SideSwap is verified
+  LOCALLY against the agreed quote before signing — refusing to sign if the
+  recv balance does not match exactly. The fee tolerance is pinned to L-BTC,
+  so the non-L-BTC asset side is always checked at strict equality.
 
 WHEN TO RECOMMEND A PEG:
 - "I want to move my BTC to Liquid" → if amount ≥ 0.01 BTC, recommend peg-in.
@@ -1280,14 +1352,31 @@ Please:
 
 Please:
 1. Call sideswap_list_assets to show what's tradeable on SideSwap right now
-2. Ask me what I want to swap and which direction (sending L-BTC for an asset
-   vs sending an asset for L-BTC)
-3. Ask me for an amount (either send amount or receive amount, not both)
-4. Call sideswap_quote to get a price quote
-5. Show me the result clearly: send X → receive Y at price P, with fixed_fee
-6. IMPORTANT: tell me that agentic-aqua does NOT yet execute SideSwap atomic
-   swaps (PSET output verification needs an audit before live signing). To
-   execute, I need to use the AQUA mobile wallet or sideswap.io.""",
+2. Ask me what I want to swap and which direction:
+   - L-BTC → asset (send_bitcoins=true): I send L-BTC, receive an asset
+   - asset → L-BTC (send_bitcoins=false): I send an asset, receive L-BTC
+3. Ask me for the send_amount in the corresponding sats (L-BTC sats if
+   sending L-BTC; asset sats otherwise). For L-BTC, accept input in BTC
+   and convert.
+4. Show me my current balance for the send asset (lw_balance) so I have context
+5. Call sideswap_quote with the right send_bitcoins flag to get a price quote
+6. Show me a summary clearly:
+   - Send: X sats of [send asset]
+   - Receive: Y sats of [recv asset]
+   - Price + fixed_fee
+   - Net effective rate
+7. Ask for explicit confirmation
+8. If wallet is password-encrypted, ask me for the password
+9. Call sideswap_execute_swap with the same asset_id, send_amount, and
+   send_bitcoins flag.
+   The tool will: capture a fresh quote (price may have moved by a few
+   percent), request the PSET via SideSwap's market.get_quote, VERIFY it
+   locally against the quote, sign it, and submit via market.taker_sign.
+   If the verification fails the tool aborts WITHOUT signing — that's a
+   safety feature, not a bug; relay the error message to me.
+10. On success show me txid + the explorer link
+11. Tell me to use sideswap_swap_status with the order_id to recall details
+    later, and lw_tx_status with the txid to check on-chain confirmation""",
                         ),
                     )
                 ]

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -726,7 +726,7 @@ SIDESWAP (BTC ↔ L-BTC pegs and Liquid asset swaps):
 - Peg-out (L-BTC → BTC): user sends L-BTC to a SideSwap deposit address; after
   2 Liquid confs and the federation sweep (~15-60 min total), BTC arrives.
 - Fees: 0.1% on each peg + a small second-chain fee (~286 sats on peg-in).
-- BEFORE initiating a peg for ≥ 0.01 BTC (~1,000,000 sats), call
+- BEFORE initiating a peg for ≥ 0.01 BTC (1,000,000 sats), call
   sideswap_recommend to surface the time-vs-fee trade-off and warn the user.
 - For VERY LARGE peg-ins that exceed SideSwap's hot-wallet balance, expect the
   cold-wallet path: 102 BTC confirmations (~17 hours). Always check
@@ -1214,8 +1214,9 @@ Please:
 2. If I haven't given a clear amount yet, also show my current Bitcoin balance
    (btc_balance) so I have context
 3. Call sideswap_server_status to fetch live fees, minimums, and hot-wallet balance
-4. Call sideswap_recommend with direction="btc_to_lbtc" and the amount to confirm
-   peg-in is appropriate, and surface the trade-off:
+4. If the amount is >= 0.01 BTC (1,000,000 sats), call sideswap_recommend with
+   direction="btc_to_lbtc" and the amount to confirm peg-in is appropriate,
+   and surface the trade-off:
    - Lower fee (0.1% vs ~0.2% on instant swaps)
    - Slower: usually 20–40 min for 2 BTC confirmations
    - For very large amounts: may require 102 confs (~17 hours) if it exceeds

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -14,7 +14,7 @@ Wire formats (mirroring the AQUA Flutter wallet's `sideswap_websocket_provider`)
 
 Methods used here:
 
-- `login_client`           — anonymous (api_key=None), identifies us as agentic-aqua
+- `login_client`           — authentication
 - `server_status`          — fees, min amounts, hot-wallet balances
 - `peg_fee`                — quote fee for a given amount and direction
 - `peg`                    — initiate peg-in (BTC→L-BTC) or peg-out (L-BTC→BTC)
@@ -73,6 +73,7 @@ SIDESWAP_WS_URL = {
 
 USER_AGENT = "agentic-aqua"
 PROTOCOL_VERSION = "1.0.0"
+SIDESWAP_API_KEY = "fee09b63c148b335ccd0c4641c47359c8a7a803c517487bc61ca18edc19a72d5"
 
 # Network defaults: SideSwap surfaces live values via `server_status`; these
 # are conservative fallbacks for when the WS is unreachable. Treat `server_status`
@@ -491,7 +492,7 @@ class SideSwapWSClient:
         return await self.call(
             "login_client",
             {
-                "api_key": None,
+                "api_key": SIDESWAP_API_KEY,
                 "cookie": None,
                 "user_agent": USER_AGENT,
                 "version": PROTOCOL_VERSION,
@@ -1364,6 +1365,7 @@ class SideSwapSwapManager:
         wallet_name: str = "default",
         password: Optional[str] = None,
         send_bitcoins: bool = True,
+        min_recv_amount: Optional[int] = None,
         flexible_small_amount: bool = False,
         *,
         fee_tolerance_sats: int = DEFAULT_FEE_TOLERANCE_SATS,
@@ -1506,6 +1508,19 @@ class SideSwapSwapManager:
                             "Pass flexible_small_amount=True to accept dealer "
                             f"adjustments up to ±{self.SMALL_AMOUNT_TOLERANCE_SATS} sats."
                         )
+                # Reject if the dealer's recv_amount is below the floor the
+                # caller confirmed (typically the price-stream preview the
+                # user just OK'd). mkt::* uses a different price source than
+                # subscribe_price_stream, so the rate can move between
+                # preview and execution; this guard ensures the user never
+                # settles for less than what they actually saw.
+                if min_recv_amount is not None and recv_amount_q < min_recv_amount:
+                    raise SideSwapWSError(
+                        f"Quote recv_amount below floor: dealer offered "
+                        f"{recv_amount_q} sats, caller required at least "
+                        f"{min_recv_amount}. The market moved between the "
+                        "preview and execution; refetch a quote and re-confirm."
+                    )
                 recv_amount = recv_amount_q
 
                 pset_b64 = get_quote_resp.get("pset")

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -1,0 +1,897 @@
+"""SideSwap integration for BTC ↔ L-BTC pegs and Liquid asset swap quoting.
+
+Wire formats (mirroring the AQUA Flutter wallet's `sideswap_websocket_provider`):
+
+- WebSocket JSON-RPC 2.0:
+    request:      {"id": <int>, "method": "<snake_case>", "params": {...}}
+    response:     {"id": <int>, "method": "<method>", "result": {...}}
+                  {"id": <int>, "error": {"code": <int>, "message": "<str>"}}
+    notification: {"method": "<method>", "params": {...}}   (no `id`)
+
+- WebSocket endpoints:
+    mainnet: wss://api.sideswap.io/json-rpc-ws
+    testnet: wss://api-testnet.sideswap.io/json-rpc-ws
+
+Methods used here:
+
+- `login_client`         — anonymous (api_key=None), identifies us as agentic-aqua
+- `server_status`        — fees, min amounts, hot-wallet balances
+- `peg_fee`              — quote fee for a given amount and direction
+- `peg`                  — initiate peg-in (BTC→L-BTC) or peg-out (L-BTC→BTC)
+- `peg_status`           — poll order status
+- `assets`               — list supported assets for swap quoting
+- `subscribe_price_stream` / `unsubscribe_price_stream`
+                         — get a price quote for a Liquid asset swap (read-only)
+
+Asset swap *execution* (`start_swap_web` + HTTP `swap_start`/`swap_sign` with
+local PSET verification) is intentionally NOT implemented in this module: the
+PSET output check is security-critical and must be audited against LWK's
+unblinding API before live signing. Use this module to fetch quotes and direct
+users to AQUA / SideSwap for execution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# WebSocket endpoints
+SIDESWAP_WS_URL = {
+    "mainnet": "wss://api.sideswap.io/json-rpc-ws",
+    "testnet": "wss://api-testnet.sideswap.io/json-rpc-ws",
+}
+
+# REST base for legacy `swap_start` / `swap_sign` (returned as `upload_url`
+# by `start_swap_web`; included here for documentation/fallback)
+SIDESWAP_HTTP_URL = {
+    "mainnet": "https://api.sideswap.io",
+    "testnet": "https://api-testnet.sideswap.io",
+}
+
+USER_AGENT = "agentic-aqua"
+PROTOCOL_VERSION = "1.0.0"
+
+# Network defaults: SideSwap surfaces live values via `server_status`; these
+# are conservative fallbacks for when the WS is unreachable. Treat `server_status`
+# return values as authoritative when available.
+FALLBACK_MIN_PEG_IN_SATS = 1_286
+FALLBACK_MIN_PEG_OUT_SATS = 100_000
+FALLBACK_PEG_IN_FEE_PERCENT = 0.1  # of send amount
+FALLBACK_PEG_OUT_FEE_PERCENT = 0.1
+
+# Threshold above which a BTC ↔ L-BTC peg saves enough on fees to justify the
+# wait over a swap-market trade. Pegs charge 0.1% versus the 0.2% taker fee on
+# the swap market, so above ~0.01 BTC the saving is ≥ 1,000 sats and grows
+# linearly. Below this, the user may prefer the speed of an instant swap.
+PEG_RECOMMENDATION_THRESHOLD_SATS = 1_000_000
+
+WS_TIMEOUT_SECONDS = 30.0
+QUOTE_WAIT_SECONDS = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SideSwapPeg:
+    """Persistent record of a SideSwap peg (peg-in or peg-out)."""
+
+    order_id: str
+    peg_in: bool  # True = BTC → L-BTC, False = L-BTC → BTC
+    peg_addr: str  # Where the user sends funds (BTC addr for peg-in, L-BTC addr for peg-out)
+    recv_addr: str  # Where the user receives funds (L-BTC for peg-in, BTC for peg-out)
+    amount: Optional[int]  # Send amount in sats (set for peg-out, may be None for peg-in)
+    expected_recv: Optional[int]  # Expected recv amount (after fees) when known
+    wallet_name: str
+    network: str  # "mainnet" | "testnet"
+    status: str  # "pending" | "detected" | "processing" | "completed" | "failed"
+    created_at: str
+    expires_at: Optional[int] = None  # Unix ms, from server
+    lockup_txid: Optional[str] = None  # User's send tx (peg-out only, local-broadcast)
+    payout_txid: Optional[str] = None  # Server's payout tx (set on completion)
+    detected_confs: Optional[int] = None
+    total_confs: Optional[int] = None
+    tx_state: Optional[str] = None  # InsufficientAmount | Detected | Processing | Done
+    last_checked_at: Optional[str] = None
+    return_address: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SideSwapPeg":
+        data = {**data}
+        for f in (
+            "expires_at",
+            "lockup_txid",
+            "payout_txid",
+            "detected_confs",
+            "total_confs",
+            "tx_state",
+            "last_checked_at",
+            "return_address",
+        ):
+            data.setdefault(f, None)
+        return cls(**data)
+
+
+@dataclass
+class SideSwapServerStatus:
+    """Subset of `server_status` response we surface to callers."""
+
+    elements_fee_rate: Optional[float] = None
+    min_peg_in_amount: Optional[int] = None
+    min_peg_out_amount: Optional[int] = None
+    server_fee_percent_peg_in: Optional[float] = None
+    server_fee_percent_peg_out: Optional[float] = None
+    peg_in_wallet_balance: Optional[int] = None
+    peg_out_wallet_balance: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class SideSwapAsset:
+    """A SideSwap-supported Liquid asset (subset of `assets` response fields)."""
+
+    asset_id: str
+    ticker: str
+    name: str
+    precision: int
+    instant_swaps: bool = False
+    icon_url: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class SideSwapPriceQuote:
+    """Snapshot of an `update_price_stream` notification."""
+
+    asset_id: str
+    send_bitcoins: bool  # If True, user sends L-BTC for the asset
+    send_amount: int
+    recv_amount: int
+    price: float
+    fixed_fee: int
+    error_msg: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket JSON-RPC client (async)
+# ---------------------------------------------------------------------------
+
+
+class SideSwapWSError(RuntimeError):
+    """Raised for SideSwap JSON-RPC error responses or connection failures."""
+
+
+class SideSwapWSClient:
+    """Minimal async JSON-RPC client over WebSocket.
+
+    One-shot usage pattern:
+
+        async with SideSwapWSClient(network) as client:
+            await client.login_client()
+            status = await client.server_status()
+
+    Keeps a per-call request-id counter and a queue of incoming notifications
+    so callers can `await client.next_notification(method=...)` for streaming
+    messages (e.g. `update_price_stream`).
+    """
+
+    def __init__(self, network: str = "mainnet") -> None:
+        if network not in SIDESWAP_WS_URL:
+            raise ValueError(f"Unknown network: {network}")
+        self.network = network
+        self.url = SIDESWAP_WS_URL[network]
+        self._ws = None  # type: ignore[assignment]
+        self._next_id = 1
+        self._pending: dict[int, asyncio.Future] = {}
+        self._notifications: asyncio.Queue = asyncio.Queue()
+        self._reader_task: Optional[asyncio.Task] = None
+        self._closed = False
+
+    async def __aenter__(self) -> "SideSwapWSClient":
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def connect(self) -> None:
+        # Imported lazily so tests that don't exercise the network never need
+        # the optional `websockets` dependency.
+        import websockets
+
+        self._ws = await asyncio.wait_for(
+            websockets.connect(self.url, max_size=4 * 1024 * 1024),
+            timeout=WS_TIMEOUT_SECONDS,
+        )
+        self._reader_task = asyncio.create_task(self._reader())
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._reader_task:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+
+    async def _reader(self) -> None:
+        assert self._ws is not None
+        try:
+            async for msg in self._ws:
+                try:
+                    data = json.loads(msg)
+                except json.JSONDecodeError:
+                    logger.warning("SideSwap: dropped malformed message: %r", msg[:200])
+                    continue
+                msg_id = data.get("id")
+                if msg_id is None:
+                    # Notification
+                    await self._notifications.put(data)
+                    continue
+                fut = self._pending.pop(msg_id, None)
+                if fut is None or fut.done():
+                    continue
+                if "error" in data:
+                    err = data["error"] or {}
+                    fut.set_exception(
+                        SideSwapWSError(
+                            f"SideSwap RPC error ({err.get('code')}): {err.get('message')}"
+                        )
+                    )
+                else:
+                    fut.set_result(data.get("result"))
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:  # pragma: no cover - defensive
+            for fut in self._pending.values():
+                if not fut.done():
+                    fut.set_exception(SideSwapWSError(f"WS reader failed: {e}"))
+            self._pending.clear()
+
+    async def call(self, method: str, params: Any = None, *, timeout: float = WS_TIMEOUT_SECONDS) -> Any:
+        """Send a JSON-RPC request and await the matching response."""
+        if self._ws is None:
+            raise SideSwapWSError("WebSocket is not connected")
+        request_id = self._next_id
+        self._next_id += 1
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future = loop.create_future()
+        self._pending[request_id] = fut
+        payload = {"id": request_id, "method": method, "params": params}
+        await self._ws.send(json.dumps(payload))
+        try:
+            return await asyncio.wait_for(fut, timeout=timeout)
+        except asyncio.TimeoutError as e:
+            self._pending.pop(request_id, None)
+            raise SideSwapWSError(f"SideSwap RPC '{method}' timed out after {timeout}s") from e
+
+    async def next_notification(
+        self, method: Optional[str] = None, *, timeout: float = WS_TIMEOUT_SECONDS
+    ) -> dict:
+        """Wait for the next notification, optionally filtered by `method`.
+
+        Notifications that don't match are dropped. For multi-stream consumers,
+        write a custom reader; this helper assumes one subscription at a time.
+        """
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise SideSwapWSError(
+                    f"Timed out waiting for notification (method={method!r})"
+                )
+            data = await asyncio.wait_for(self._notifications.get(), timeout=remaining)
+            if method is None or data.get("method") == method:
+                return data
+
+    # -- High-level method wrappers ------------------------------------------------
+
+    async def login_client(self) -> dict:
+        return await self.call(
+            "login_client",
+            {
+                "api_key": None,
+                "cookie": None,
+                "user_agent": USER_AGENT,
+                "version": PROTOCOL_VERSION,
+            },
+        )
+
+    async def server_status(self) -> dict:
+        return await self.call("server_status", None)
+
+    async def peg_fee(self, send_amount: int, peg_in: bool) -> dict:
+        return await self.call("peg_fee", {"send_amount": send_amount, "peg_in": peg_in})
+
+    async def peg(self, recv_addr: str, peg_in: bool) -> dict:
+        return await self.call("peg", {"recv_addr": recv_addr, "peg_in": peg_in})
+
+    async def peg_status(self, order_id: str, peg_in: bool) -> dict:
+        return await self.call("peg_status", {"order_id": order_id, "peg_in": peg_in})
+
+    async def assets(self, embedded_icons: bool = False) -> dict:
+        return await self.call("assets", {"all_assets": True, "embedded_icons": embedded_icons})
+
+    async def subscribe_price_stream(
+        self,
+        asset: str,
+        send_bitcoins: bool,
+        send_amount: Optional[int] = None,
+        recv_amount: Optional[int] = None,
+    ) -> dict:
+        params: dict[str, Any] = {"asset": asset, "send_bitcoins": send_bitcoins}
+        if send_amount is not None:
+            params["send_amount"] = send_amount
+        if recv_amount is not None:
+            params["recv_amount"] = recv_amount
+        return await self.call("subscribe_price_stream", params)
+
+    async def unsubscribe_price_stream(self, asset: str) -> dict:
+        return await self.call("unsubscribe_price_stream", {"asset": asset})
+
+
+# ---------------------------------------------------------------------------
+# Sync wrappers — internal asyncio.run() so existing sync tool code can call.
+# ---------------------------------------------------------------------------
+
+
+def _run(coro):
+    """Run an async coroutine from sync code, raising a clean error if a loop
+    is already running (e.g. inside the MCP server's async dispatch).
+
+    We call this from the synchronous tool functions; the MCP `call_tool`
+    handler awaits the tool result inside an asyncio loop, but the tool
+    function itself is invoked synchronously, so `asyncio.run` is safe.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    # If we're already in a loop, use a separate loop in a new thread to avoid
+    # deadlocking on the running loop. This is the case under pytest-asyncio
+    # auto mode and may apply to some MCP transports.
+    import threading
+
+    result_box: dict[str, Any] = {}
+    exc_box: dict[str, BaseException] = {}
+
+    def _runner() -> None:
+        try:
+            result_box["result"] = asyncio.run(coro)
+        except BaseException as e:  # noqa: BLE001
+            exc_box["exc"] = e
+
+    t = threading.Thread(target=_runner, daemon=True)
+    t.start()
+    t.join()
+    if "exc" in exc_box:
+        raise exc_box["exc"]
+    return result_box["result"]
+
+
+def fetch_server_status(network: str = "mainnet") -> SideSwapServerStatus:
+    """Connect, log in, fetch server_status, return a typed snapshot."""
+
+    async def _go() -> SideSwapServerStatus:
+        async with SideSwapWSClient(network) as client:
+            await client.login_client()
+            data = await client.server_status()
+            return _parse_server_status(data or {})
+
+    return _run(_go())
+
+
+def _parse_server_status(data: dict) -> SideSwapServerStatus:
+    return SideSwapServerStatus(
+        elements_fee_rate=data.get("elements_fee_rate"),
+        min_peg_in_amount=data.get("min_peg_in_amount"),
+        min_peg_out_amount=data.get("min_peg_out_amount"),
+        server_fee_percent_peg_in=data.get("server_fee_percent_peg_in"),
+        server_fee_percent_peg_out=data.get("server_fee_percent_peg_out"),
+        peg_in_wallet_balance=data.get("PegInWalletBalance"),
+        peg_out_wallet_balance=data.get("PegOutWalletBalance"),
+    )
+
+
+def fetch_peg_fee(amount: int, peg_in: bool, network: str = "mainnet") -> dict:
+    """Quote fee for a peg, returning {send_amount, recv_amount, fee_amount}."""
+    if amount <= 0:
+        raise ValueError("amount must be positive")
+
+    async def _go() -> dict:
+        async with SideSwapWSClient(network) as client:
+            await client.login_client()
+            resp = await client.peg_fee(amount, peg_in)
+            recv = resp.get("recv_amount") if resp else None
+            return {
+                "send_amount": amount,
+                "recv_amount": recv,
+                "fee_amount": (amount - recv) if isinstance(recv, int) else None,
+                "peg_in": peg_in,
+            }
+
+    return _run(_go())
+
+
+def fetch_assets(network: str = "mainnet") -> list[SideSwapAsset]:
+    """Fetch the SideSwap-supported asset list."""
+
+    async def _go() -> list[SideSwapAsset]:
+        async with SideSwapWSClient(network) as client:
+            await client.login_client()
+            resp = await client.assets()
+            raw = (resp or {}).get("assets", []) or []
+            out: list[SideSwapAsset] = []
+            for a in raw:
+                out.append(
+                    SideSwapAsset(
+                        asset_id=a.get("asset_id", ""),
+                        ticker=a.get("ticker", ""),
+                        name=a.get("name", ""),
+                        precision=a.get("precision", 8),
+                        instant_swaps=bool(a.get("instant_swaps", False)),
+                        icon_url=a.get("icon_url"),
+                    )
+                )
+            return out
+
+    return _run(_go())
+
+
+def fetch_swap_quote(
+    asset_id: str,
+    send_amount: Optional[int] = None,
+    recv_amount: Optional[int] = None,
+    send_bitcoins: bool = True,
+    network: str = "mainnet",
+    quote_wait_seconds: float = QUOTE_WAIT_SECONDS,
+) -> SideSwapPriceQuote:
+    """Get a one-shot price quote for a Liquid asset swap.
+
+    Subscribes to the price stream, waits for the first `update_price_stream`
+    notification (or uses the immediate `subscribe_price_stream` response if it
+    contains a price), unsubscribes, and returns the snapshot.
+
+    Args:
+        asset_id: Liquid asset to swap with L-BTC.
+        send_amount: Amount of L-BTC (if `send_bitcoins`) or asset to send. One of
+            `send_amount` or `recv_amount` is required.
+        recv_amount: Amount of asset (if `send_bitcoins`) or L-BTC to receive.
+        send_bitcoins: True if the user is sending L-BTC and receiving the asset.
+        network: "mainnet" or "testnet".
+        quote_wait_seconds: How long to wait for the first quote notification.
+    """
+    if (send_amount is None) == (recv_amount is None):
+        raise ValueError("exactly one of send_amount or recv_amount must be provided")
+
+    async def _go() -> SideSwapPriceQuote:
+        async with SideSwapWSClient(network) as client:
+            await client.login_client()
+            initial = await client.subscribe_price_stream(
+                asset=asset_id,
+                send_bitcoins=send_bitcoins,
+                send_amount=send_amount,
+                recv_amount=recv_amount,
+            )
+            quote_data = initial or {}
+            # First subscribe response often contains the quote already; if not,
+            # wait for the streamed notification.
+            if not quote_data.get("price"):
+                try:
+                    notif = await client.next_notification(
+                        "update_price_stream", timeout=quote_wait_seconds
+                    )
+                    quote_data = (notif or {}).get("params") or {}
+                except SideSwapWSError:
+                    pass
+            try:
+                await client.unsubscribe_price_stream(asset_id)
+            except Exception:
+                pass
+            return SideSwapPriceQuote(
+                asset_id=asset_id,
+                send_bitcoins=send_bitcoins,
+                send_amount=quote_data.get("send_amount") or send_amount or 0,
+                recv_amount=quote_data.get("recv_amount") or recv_amount or 0,
+                price=float(quote_data.get("price") or 0.0),
+                fixed_fee=int(quote_data.get("fixed_fee") or 0),
+                error_msg=quote_data.get("error_msg"),
+            )
+
+    return _run(_go())
+
+
+# ---------------------------------------------------------------------------
+# Peg manager — orchestrates peg-in / peg-out using existing wallet manager.
+# ---------------------------------------------------------------------------
+
+
+def map_peg_status(tx_state: Optional[str], list_empty: bool) -> str:
+    """Map SideSwap PegStatus.list[*].tx_state to local lifecycle status."""
+    if list_empty:
+        return "pending"
+    return {
+        "Detected": "processing",
+        "Processing": "processing",
+        "Done": "completed",
+        "InsufficientAmount": "failed",
+    }.get(tx_state or "", "pending")
+
+
+class SideSwapPegManager:
+    """High-level peg orchestration tied to AQUA's storage + wallet managers.
+
+    Exposes:
+
+    - `get_server_status()` for fee/min/balance info (drives recommendation logic)
+    - `quote_peg_in(amount)` / `quote_peg_out(amount)` for a fee preview
+    - `peg_in(wallet_name)` to start a BTC→L-BTC peg (returns deposit address)
+    - `peg_out(wallet_name, amount, btc_address, password)` to start a peg-out
+      and broadcast the L-BTC send to the deposit address
+    - `peg_status(order_id, peg_in)` to poll status
+    """
+
+    def __init__(self, storage, wallet_manager, btc_wallet_manager) -> None:
+        """
+        Args:
+            storage: Storage instance with `save_sideswap_peg`, `load_sideswap_peg`, etc.
+            wallet_manager: WalletManager (Liquid/LWK) — used for peg-in receive
+                addresses and peg-out send.
+            btc_wallet_manager: BitcoinWalletManager (BDK) — used to optionally
+                fund a peg-in directly from the user's local Bitcoin wallet.
+        """
+        self.storage = storage
+        self.wallet_manager = wallet_manager
+        self.btc_wallet_manager = btc_wallet_manager
+
+    # -- Read-only helpers ----------------------------------------------------
+
+    def get_server_status(self, network: str = "mainnet") -> dict:
+        try:
+            status = fetch_server_status(network)
+            return status.to_dict()
+        except Exception as e:
+            logger.warning("SideSwap server_status fetch failed: %s", e)
+            return {
+                "min_peg_in_amount": FALLBACK_MIN_PEG_IN_SATS,
+                "min_peg_out_amount": FALLBACK_MIN_PEG_OUT_SATS,
+                "server_fee_percent_peg_in": FALLBACK_PEG_IN_FEE_PERCENT,
+                "server_fee_percent_peg_out": FALLBACK_PEG_OUT_FEE_PERCENT,
+                "warning": f"Could not reach SideSwap; showing fallback values: {e}",
+            }
+
+    def quote_peg(self, amount: int, peg_in: bool, network: str = "mainnet") -> dict:
+        return fetch_peg_fee(amount, peg_in, network)
+
+    # -- Peg-in (BTC → L-BTC) -------------------------------------------------
+
+    def peg_in(
+        self,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+    ) -> SideSwapPeg:
+        """Initiate a peg-in. Returns the SideSwapPeg with `peg_addr` (BTC) where
+        the user must send funds. The user's Liquid wallet receives L-BTC after
+        ~2 BTC confirmations (~20 min, hot-wallet path) or up to 102 confs
+        (~17 hours, cold-wallet path) depending on hot-wallet liquidity.
+
+        We do NOT broadcast the BTC send here. The caller (or agent) must send
+        the BTC to `peg_addr` from any Bitcoin wallet (including the local
+        `btc_send` tool).
+        """
+        wallet_data = self.storage.load_wallet(wallet_name)
+        if not wallet_data:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+        if wallet_data.watch_only:
+            raise ValueError(
+                "Watch-only wallet cannot receive a peg-in (no Liquid receive address)"
+            )
+        # Decrypt mnemonic if needed; not strictly required to receive but matches
+        # the precondition pattern used by other flows.
+        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
+            wallet_data.encrypted_mnemonic
+        ):
+            if password:
+                self.wallet_manager.load_wallet(wallet_name, password)
+
+        addr = self.wallet_manager.get_address(wallet_name)
+        recv_addr = addr.address
+
+        async def _go() -> dict:
+            async with SideSwapWSClient(wallet_data.network) as client:
+                await client.login_client()
+                return await client.peg(recv_addr=recv_addr, peg_in=True)
+
+        resp = _run(_go())
+        if not resp or not resp.get("order_id") or not resp.get("peg_addr"):
+            raise SideSwapWSError(f"Unexpected peg response: {resp!r}")
+
+        peg = SideSwapPeg(
+            order_id=resp["order_id"],
+            peg_in=True,
+            peg_addr=resp["peg_addr"],
+            recv_addr=recv_addr,
+            amount=None,  # peg-in: user picks the amount when sending BTC
+            expected_recv=resp.get("recv_amount"),
+            wallet_name=wallet_name,
+            network=wallet_data.network,
+            status="pending",
+            created_at=datetime.now(UTC).isoformat(),
+            expires_at=resp.get("expires_at"),
+        )
+        self.storage.save_sideswap_peg(peg)
+        return peg
+
+    # -- Peg-out (L-BTC → BTC) ------------------------------------------------
+
+    def peg_out(
+        self,
+        wallet_name: str,
+        amount: int,
+        btc_address: str,
+        password: Optional[str] = None,
+    ) -> SideSwapPeg:
+        """Initiate a peg-out and broadcast the L-BTC send to the deposit address.
+
+        The flow:
+          1. Fetch SideSwap server_status for min_peg_out_amount and validate.
+          2. WS `peg(peg_in=False, recv_addr=<user BTC addr>)` → returns a Liquid
+             deposit address (`peg_addr`).
+          3. Send `amount` sats of L-BTC from the wallet to `peg_addr`.
+          4. Persist the peg with `lockup_txid` populated; status="processing".
+        """
+        if amount <= 0:
+            raise ValueError("amount must be positive")
+        wallet_data = self.storage.load_wallet(wallet_name)
+        if not wallet_data:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+        if wallet_data.watch_only:
+            raise ValueError("Watch-only wallet cannot peg out (cannot sign)")
+        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
+            wallet_data.encrypted_mnemonic
+        ):
+            if not password:
+                raise ValueError("Password required to decrypt mnemonic")
+
+        # Validate min/max against server
+        try:
+            status = fetch_server_status(wallet_data.network)
+            min_amt = status.min_peg_out_amount or FALLBACK_MIN_PEG_OUT_SATS
+            if amount < min_amt:
+                raise ValueError(
+                    f"Amount {amount} sats is below SideSwap peg-out minimum ({min_amt} sats)"
+                )
+        except SideSwapWSError as e:
+            logger.warning("Skipping min-amount check: %s", e)
+
+        # Balance check (best-effort)
+        try:
+            balances = self.wallet_manager.get_balance(wallet_name)
+            lbtc_balance = next((b.amount for b in balances if b.ticker == "L-BTC"), 0)
+            if lbtc_balance < amount:
+                raise ValueError(
+                    f"Insufficient L-BTC: have {lbtc_balance} sats, need at least {amount} sats"
+                )
+        except ValueError:
+            raise
+        except Exception as e:  # pragma: no cover - balance fetch best-effort
+            logger.warning("Balance check skipped: %s", e)
+
+        async def _start() -> dict:
+            async with SideSwapWSClient(wallet_data.network) as client:
+                await client.login_client()
+                return await client.peg(recv_addr=btc_address, peg_in=False)
+
+        resp = _run(_start())
+        if not resp or not resp.get("order_id") or not resp.get("peg_addr"):
+            raise SideSwapWSError(f"Unexpected peg response: {resp!r}")
+
+        peg = SideSwapPeg(
+            order_id=resp["order_id"],
+            peg_in=False,
+            peg_addr=resp["peg_addr"],
+            recv_addr=btc_address,
+            amount=amount,
+            expected_recv=resp.get("recv_amount"),
+            wallet_name=wallet_name,
+            network=wallet_data.network,
+            status="pending",
+            created_at=datetime.now(UTC).isoformat(),
+            expires_at=resp.get("expires_at"),
+        )
+        # Persist before broadcast so the order survives a crash mid-broadcast.
+        self.storage.save_sideswap_peg(peg)
+
+        # Broadcast L-BTC to the SideSwap deposit address.
+        try:
+            lockup_txid = self.wallet_manager.send(
+                wallet_name, peg.peg_addr, amount, password=password
+            )
+        except Exception as e:
+            peg.status = "failed"
+            peg.tx_state = "InsufficientAmount" if "insufficient" in str(e).lower() else None
+            self.storage.save_sideswap_peg(peg)
+            raise
+
+        peg.lockup_txid = lockup_txid
+        peg.status = "processing"
+        self.storage.save_sideswap_peg(peg)
+        return peg
+
+    # -- Status polling -------------------------------------------------------
+
+    def status(self, order_id: str) -> dict:
+        peg = self.storage.load_sideswap_peg(order_id)
+        if not peg:
+            raise ValueError(f"SideSwap peg not found: {order_id}")
+
+        warning = None
+        try:
+
+            async def _go() -> dict:
+                async with SideSwapWSClient(peg.network) as client:
+                    await client.login_client()
+                    return await client.peg_status(order_id, peg.peg_in)
+
+            resp = _run(_go())
+            txns = (resp or {}).get("list") or []
+            list_empty = len(txns) == 0
+            tx_state = txns[-1].get("tx_state") if txns else None
+            new_status = map_peg_status(tx_state, list_empty)
+            peg.status = new_status
+            peg.tx_state = tx_state
+            if txns:
+                last = txns[-1]
+                peg.detected_confs = last.get("detected_confs")
+                peg.total_confs = last.get("total_confs")
+                payout = last.get("payout_txid")
+                if payout:
+                    peg.payout_txid = payout
+            peg.last_checked_at = datetime.now(UTC).isoformat()
+            self.storage.save_sideswap_peg(peg)
+        except Exception as e:
+            warning = f"Could not refresh status: {e}"
+
+        result = {
+            "order_id": peg.order_id,
+            "peg_in": peg.peg_in,
+            "status": peg.status,
+            "amount": peg.amount,
+            "expected_recv": peg.expected_recv,
+            "wallet_name": peg.wallet_name,
+            "network": peg.network,
+            "peg_addr": peg.peg_addr,
+            "recv_addr": peg.recv_addr,
+            "created_at": peg.created_at,
+        }
+        if peg.tx_state is not None:
+            result["tx_state"] = peg.tx_state
+        if peg.detected_confs is not None and peg.total_confs is not None:
+            result["confirmations"] = f"{peg.detected_confs}/{peg.total_confs}"
+        if peg.lockup_txid:
+            result["lockup_txid"] = peg.lockup_txid
+        if peg.payout_txid:
+            result["payout_txid"] = peg.payout_txid
+        if peg.expires_at:
+            result["expires_at"] = peg.expires_at
+        if warning:
+            result["warning"] = warning
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Recommendation logic — used by tools and prompts.
+# ---------------------------------------------------------------------------
+
+
+def recommend_peg_or_swap(
+    amount_sats: int,
+    direction: str,
+    server_status: Optional[dict] = None,
+) -> dict:
+    """Decide whether to recommend a peg or a swap-market trade for a BTC↔L-BTC conversion.
+
+    Args:
+        amount_sats: Amount the user wants to convert (sats).
+        direction: "btc_to_lbtc" | "lbtc_to_btc".
+        server_status: Optional dict returned from `fetch_server_status` to honor
+            the live `peg_in_wallet_balance` (warns about 102-conf path).
+
+    Returns:
+        {
+          "recommendation": "peg" | "swap" | "either",
+          "reason": <human-readable explanation>,
+          "peg_pros": [...],
+          "peg_cons": [...],
+        }
+    """
+    if direction not in ("btc_to_lbtc", "lbtc_to_btc"):
+        raise ValueError("direction must be 'btc_to_lbtc' or 'lbtc_to_btc'")
+
+    peg_pros = [
+        "Lower fee (~0.1% via SideSwap peg vs ~0.2% via swap markets).",
+        "No order-book matching delay; deterministic flow.",
+    ]
+    peg_cons = [
+        "Slower than an instant swap (peg-in: usually 20–40 min for 2 BTC confs; "
+        "peg-out: usually 15–60 min after 2 Liquid confs).",
+        "Below SideSwap's per-direction minimum, peg is unavailable.",
+    ]
+
+    if direction == "lbtc_to_btc":
+        # Peg-out is the canonical L-BTC → BTC path; recommend it whenever the
+        # amount is above the min and the user can wait ~30–60 min.
+        return {
+            "recommendation": "peg",
+            "reason": (
+                "Peg-out is the standard SideSwap path for L-BTC → BTC. "
+                "Fee is 0.1% + Bitcoin network fee; settlement is usually "
+                "15–60 minutes (waits for 2 Liquid confs, then federation "
+                "releases BTC). Swap-market liquidity for L-BTC → BTC is "
+                "typically shallow."
+            ),
+            "peg_pros": peg_pros,
+            "peg_cons": peg_cons,
+        }
+
+    # btc_to_lbtc
+    if amount_sats >= PEG_RECOMMENDATION_THRESHOLD_SATS:
+        # Check hot-wallet capacity if we have it.
+        hot_wallet = (server_status or {}).get("peg_in_wallet_balance")
+        large_warning = ""
+        if isinstance(hot_wallet, int) and amount_sats > hot_wallet:
+            large_warning = (
+                " ⚠️ This amount exceeds SideSwap's hot-wallet liquidity, so the "
+                "peg will use the cold-wallet path (102 BTC confirmations, ~17 hours). "
+                "If the wait is too long, consider splitting into smaller amounts or "
+                "using a swap-market trade for the urgent portion."
+            )
+        return {
+            "recommendation": "peg",
+            "reason": (
+                f"For amounts at or above {PEG_RECOMMENDATION_THRESHOLD_SATS:,} sats, "
+                "peg-in is usually the cheaper option (0.1% vs 0.2%) and the "
+                "20–40 minute settlement is typically acceptable." + large_warning
+            ),
+            "peg_pros": peg_pros,
+            "peg_cons": peg_cons,
+        }
+    return {
+        "recommendation": "either",
+        "reason": (
+            f"Amount is below {PEG_RECOMMENDATION_THRESHOLD_SATS:,} sats. The peg-in "
+            "fee saving (0.1% vs 0.2%) is small here; if you want it instantly, an "
+            "atomic swap on SideSwap's market is fine. If you don't mind waiting "
+            "~20–40 min, peg-in is still slightly cheaper."
+        ),
+        "peg_pros": peg_pros,
+        "peg_cons": peg_cons,
+    }

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -35,11 +35,14 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import threading
 import urllib.error
 import urllib.request
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Optional
+
+import websockets
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +80,29 @@ PEG_RECOMMENDATION_THRESHOLD_SATS = 1_000_000
 WS_TIMEOUT_SECONDS = 30.0
 QUOTE_WAIT_SECONDS = 10.0
 
+# Reserved for the Liquid network fee on a peg-out broadcast. Liquid fees are
+# fixed-rate and tiny (~50–100 sats in practice); 200 sats is a comfortable
+# upper bound that prevents balance-check pass / broadcast-fail races without
+# blocking realistic peg-outs.
+LIQUID_FEE_RESERVE_SATS = 200
+
+
+def _validate_btc_address(address: str, network: str) -> None:
+    """Raise ValueError if `address` doesn't parse on the matching Bitcoin network.
+
+    Uses BDK's address parser since it's already a project dep and recognises
+    the same mainnet/testnet network names we use elsewhere.
+    """
+    import bdkpython as bdk
+
+    bdk_network = bdk.Network.BITCOIN if network == "mainnet" else bdk.Network.TESTNET
+    try:
+        bdk.Address(address, bdk_network)
+    except Exception as e:
+        raise ValueError(
+            f"Invalid Bitcoin {network} address {address!r}: {e}"
+        ) from e
+
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -102,7 +128,11 @@ class SideSwapPeg:
     payout_txid: Optional[str] = None  # Server's payout tx (set on completion)
     detected_confs: Optional[int] = None
     total_confs: Optional[int] = None
-    tx_state: Optional[str] = None  # InsufficientAmount | Detected | Processing | Done
+    # SideSwap server enum only — Detected | Processing | Done | InsufficientAmount.
+    # Local errors (insufficient L-BTC, broadcast failure, etc.) live in
+    # `local_error` so this field always reflects what SideSwap reports.
+    tx_state: Optional[str] = None
+    local_error: Optional[str] = None
     last_checked_at: Optional[str] = None
     return_address: Optional[str] = None
 
@@ -119,6 +149,7 @@ class SideSwapPeg:
             "detected_confs",
             "total_confs",
             "tx_state",
+            "local_error",
             "last_checked_at",
             "return_address",
         ):
@@ -216,10 +247,6 @@ class SideSwapWSClient:
         await self.close()
 
     async def connect(self) -> None:
-        # Imported lazily so tests that don't exercise the network never need
-        # the optional `websockets` dependency.
-        import websockets
-
         self._ws = await asyncio.wait_for(
             websockets.connect(self.url, max_size=4 * 1024 * 1024),
             timeout=WS_TIMEOUT_SECONDS,
@@ -378,8 +405,6 @@ def _run(coro):
     # If we're already in a loop, use a separate loop in a new thread to avoid
     # deadlocking on the running loop. This is the case under pytest-asyncio
     # auto mode and may apply to some MCP transports.
-    import threading
-
     result_box: dict[str, Any] = {}
     exc_box: dict[str, BaseException] = {}
 
@@ -503,15 +528,14 @@ def fetch_swap_quote(
             )
             quote_data = initial or {}
             # First subscribe response often contains the quote already; if not,
-            # wait for the streamed notification.
+            # wait for the streamed notification. Let any timeout/connection
+            # error propagate — silently returning a price=0.0 quote here
+            # would look like a free swap to the caller.
             if not quote_data.get("price"):
-                try:
-                    notif = await client.next_notification(
-                        "update_price_stream", timeout=quote_wait_seconds
-                    )
-                    quote_data = (notif or {}).get("params") or {}
-                except SideSwapWSError:
-                    pass
+                notif = await client.next_notification(
+                    "update_price_stream", timeout=quote_wait_seconds
+                )
+                quote_data = (notif or {}).get("params") or {}
             try:
                 await client.unsubscribe_price_stream(asset_id)
             except Exception:
@@ -544,6 +568,36 @@ def map_peg_status(tx_state: Optional[str], list_empty: bool) -> str:
         "Done": "completed",
         "InsufficientAmount": "failed",
     }.get(tx_state or "", "pending")
+
+
+# Higher number = more progressed. SideSwap returns one txn per detected
+# deposit on the peg address; if the user reuses the address, a completed
+# Done can sit alongside a fresh Detected and we want to surface the Done.
+# `InsufficientAmount` ranks above `Detected` because it's a terminal local
+# verdict (the user underpaid) rather than an in-flight state.
+_TX_STATE_RANK = {
+    "Done": 4,
+    "Processing": 3,
+    "InsufficientAmount": 2,
+    "Detected": 1,
+    None: 0,
+    "": 0,
+}
+
+
+def _pick_most_progressed_txn(txns: list[dict]) -> dict:
+    """Return the txns list entry whose tx_state is furthest along.
+
+    Ties go to the later entry (i.e. the txn the server reported last).
+    """
+    best_idx = 0
+    best_rank = -1
+    for i, t in enumerate(txns):
+        rank = _TX_STATE_RANK.get(t.get("tx_state"), 0)
+        if rank >= best_rank:
+            best_rank = rank
+            best_idx = i
+    return txns[best_idx]
 
 
 class SideSwapPegManager:
@@ -614,13 +668,9 @@ class SideSwapPegManager:
             raise ValueError(
                 "Watch-only wallet cannot receive a peg-in (no Liquid receive address)"
             )
-        # Decrypt mnemonic if needed; not strictly required to receive but matches
-        # the precondition pattern used by other flows.
-        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
-            wallet_data.encrypted_mnemonic
-        ):
-            if password:
-                self.wallet_manager.load_wallet(wallet_name, password)
+        # Receiving a peg-in only needs the wallet's next address — never the
+        # mnemonic, encrypted or not. The `password` kwarg is accepted for
+        # signature symmetry with peg_out and other flows that do need to sign.
 
         addr = self.wallet_manager.get_address(wallet_name)
         recv_addr = addr.address
@@ -662,11 +712,16 @@ class SideSwapPegManager:
         """Initiate a peg-out and broadcast the L-BTC send to the deposit address.
 
         The flow:
-          1. Fetch SideSwap server_status for min_peg_out_amount and validate.
-          2. WS `peg(peg_in=False, recv_addr=<user BTC addr>)` → returns a Liquid
+          1. Validate inputs and decrypt the mnemonic up-front (so a wrong
+             password fails fast, before any SideSwap order is created).
+          2. Fetch SideSwap server_status for min_peg_out_amount and validate.
+          3. Validate `btc_address` parses as a Bitcoin address on the matching
+             network, so the SideSwap server isn't asked to peg out to a string
+             we can't actually pay to.
+          4. WS `peg(peg_in=False, recv_addr=<user BTC addr>)` → returns a Liquid
              deposit address (`peg_addr`).
-          3. Send `amount` sats of L-BTC from the wallet to `peg_addr`.
-          4. Persist the peg with `lockup_txid` populated; status="processing".
+          5. Send `amount` sats of L-BTC from the wallet to `peg_addr`.
+          6. Persist the peg with `lockup_txid` populated; status="processing".
         """
         if amount <= 0:
             raise ValueError("amount must be positive")
@@ -675,11 +730,24 @@ class SideSwapPegManager:
             raise ValueError(f"Wallet '{wallet_name}' not found")
         if wallet_data.watch_only:
             raise ValueError("Watch-only wallet cannot peg out (cannot sign)")
+
+        # Decrypt the mnemonic BEFORE creating a SideSwap order. Without this,
+        # a wrong password would only surface at broadcast time — leaving an
+        # orphaned SideSwap peg order behind for every retry. Watch-only and
+        # unencrypted wallets skip this check (no mnemonic to decrypt).
         if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
             wallet_data.encrypted_mnemonic
         ):
             if not password:
                 raise ValueError("Password required to decrypt mnemonic")
+            # `load_wallet` raises on bad password; let that propagate before
+            # we contact SideSwap.
+            self.wallet_manager.load_wallet(wallet_name, password)
+
+        # Validate the recipient BTC address parses on the matching network.
+        # Catches typos and wrong-network addresses (e.g. mainnet bc1 sent to
+        # testnet) before SideSwap is involved.
+        _validate_btc_address(btc_address, wallet_data.network)
 
         # Validate min/max against server
         try:
@@ -692,13 +760,19 @@ class SideSwapPegManager:
         except SideSwapWSError as e:
             logger.warning("Skipping min-amount check: %s", e)
 
-        # Balance check (best-effort)
+        # Balance check: a peg-out broadcast pays a Liquid network fee on top
+        # of `amount`. Liquid fees are tiny and stable (~50–100 sats); use a
+        # small reservation so a wallet whose balance equals `amount` exactly
+        # doesn't fail at broadcast time with the actual-fee error.
         try:
             balances = self.wallet_manager.get_balance(wallet_name)
             lbtc_balance = next((b.amount for b in balances if b.ticker == "L-BTC"), 0)
-            if lbtc_balance < amount:
+            required = amount + LIQUID_FEE_RESERVE_SATS
+            if lbtc_balance < required:
                 raise ValueError(
-                    f"Insufficient L-BTC: have {lbtc_balance} sats, need at least {amount} sats"
+                    f"Insufficient L-BTC: have {lbtc_balance} sats, need at least "
+                    f"{required} sats ({amount} + {LIQUID_FEE_RESERVE_SATS} reserved "
+                    "for the Liquid network fee)"
                 )
         except ValueError:
             raise
@@ -737,7 +811,9 @@ class SideSwapPegManager:
             )
         except Exception as e:
             peg.status = "failed"
-            peg.tx_state = "InsufficientAmount" if "insufficient" in str(e).lower() else None
+            # Local broadcast failures live in `local_error`; `tx_state`
+            # is reserved for SideSwap server enums.
+            peg.local_error = str(e)
             self.storage.save_sideswap_peg(peg)
             raise
 
@@ -764,17 +840,38 @@ class SideSwapPegManager:
             resp = _run(_go())
             txns = (resp or {}).get("list") or []
             list_empty = len(txns) == 0
-            tx_state = txns[-1].get("tx_state") if txns else None
+
+            # SideSwap returns one entry per detected deposit on the peg
+            # address, so a completed `Done` deposit followed by a fresh
+            # `Detected` deposit (e.g. user reused the address) shows up as
+            # two entries. Picking just `txns[-1]` would let an earlier
+            # `Done` regress to `Detected` and lose its `payout_txid`.
+            #
+            # Rule: pick the most-progressed entry by `tx_state`, falling
+            # back to the most-recent. Preserve any already-known
+            # `payout_txid` — it's set once on completion and must never
+            # be cleared.
+            most_progressed = _pick_most_progressed_txn(txns) if txns else None
+            tx_state = most_progressed.get("tx_state") if most_progressed else None
             new_status = map_peg_status(tx_state, list_empty)
             peg.status = new_status
             peg.tx_state = tx_state
-            if txns:
-                last = txns[-1]
-                peg.detected_confs = last.get("detected_confs")
-                peg.total_confs = last.get("total_confs")
-                payout = last.get("payout_txid")
+            if most_progressed:
+                # confs come from the most-progressed entry too; if the
+                # latest `Detected` deposit hasn't accumulated confs yet,
+                # the completed `Done` value is more meaningful for callers.
+                peg.detected_confs = most_progressed.get("detected_confs")
+                peg.total_confs = most_progressed.get("total_confs")
+                payout = most_progressed.get("payout_txid")
                 if payout:
                     peg.payout_txid = payout
+                elif any(t.get("payout_txid") for t in txns):
+                    # No payout on the chosen entry but another entry has
+                    # one — keep what we already have rather than blanking.
+                    for t in txns:
+                        if t.get("payout_txid"):
+                            peg.payout_txid = peg.payout_txid or t["payout_txid"]
+                            break
             peg.last_checked_at = datetime.now(UTC).isoformat()
             self.storage.save_sideswap_peg(peg)
         except Exception as e:

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -1,4 +1,4 @@
-"""SideSwap integration for BTC ↔ L-BTC pegs and Liquid asset swap quoting.
+"""SideSwap integration for BTC ↔ L-BTC pegs and Liquid asset swaps.
 
 Wire formats (mirroring the AQUA Flutter wallet's `sideswap_websocket_provider`):
 
@@ -14,20 +14,38 @@ Wire formats (mirroring the AQUA Flutter wallet's `sideswap_websocket_provider`)
 
 Methods used here:
 
-- `login_client`         — anonymous (api_key=None), identifies us as agentic-aqua
-- `server_status`        — fees, min amounts, hot-wallet balances
-- `peg_fee`              — quote fee for a given amount and direction
-- `peg`                  — initiate peg-in (BTC→L-BTC) or peg-out (L-BTC→BTC)
-- `peg_status`           — poll order status
-- `assets`               — list supported assets for swap quoting
+- `login_client`           — anonymous (api_key=None), identifies us as agentic-aqua
+- `server_status`          — fees, min amounts, hot-wallet balances
+- `peg_fee`                — quote fee for a given amount and direction
+- `peg`                    — initiate peg-in (BTC→L-BTC) or peg-out (L-BTC→BTC)
+- `peg_status`             — poll order status
+- `assets`                 — list supported assets for swap quoting
 - `subscribe_price_stream` / `unsubscribe_price_stream`
-                         — get a price quote for a Liquid asset swap (read-only)
+                           — get a price quote for a Liquid asset swap
+- `market.list_markets`    — find the market for an asset pair
+- `market.start_quotes`    — open a quote stream with our UTXOs + addresses
+- `market.get_quote`       — receive the half-built PSET to sign
+- `market.taker_sign`      — submit the locally-signed PSET; server broadcasts
 
-Asset swap *execution* (`start_swap_web` + HTTP `swap_start`/`swap_sign` with
-local PSET verification) is intentionally NOT implemented in this module: the
-PSET output check is security-critical and must be audited against LWK's
-unblinding API before live signing. Use this module to fetch quotes and direct
-users to AQUA / SideSwap for execution.
+PSET verification (security-critical): before signing, we call
+`wollet.pset_details(pset).balance.balances()` and confirm the wallet's net
+balance change matches the agreed quote (recv_asset gains exactly recv_amount,
+send_asset loses no more than send_amount + fee_tolerance, no other assets
+move). The server is trusted-but-verify; without this check, a hostile or
+buggy server could craft a PSET that takes our funds and pays us nothing.
+
+Execution (`SideSwapSwapManager.execute_swap`) supports both directions:
+
+  - `send_bitcoins=True`: L-BTC → asset (e.g. L-BTC → USDt). The Liquid network
+    fee comes out of the user's L-BTC change output, so the wallet's L-BTC
+    delta is `-(send_amount + fee)`.
+  - `send_bitcoins=False`: asset → L-BTC (e.g. USDt → L-BTC). The dealer
+    absorbs the network fee from their L-BTC contribution, so the wallet's
+    asset delta is `-send_amount` and L-BTC delta is `+recv_amount` exactly.
+
+The verifier's `fee_asset` parameter is always pinned to the policy asset so
+the fee tolerance only relaxes constraints on the L-BTC side — never on a
+non-L-BTC asset, which would otherwise be a siphon vector on the reverse path.
 """
 
 from __future__ import annotations
@@ -51,13 +69,6 @@ logger = logging.getLogger(__name__)
 SIDESWAP_WS_URL = {
     "mainnet": "wss://api.sideswap.io/json-rpc-ws",
     "testnet": "wss://api-testnet.sideswap.io/json-rpc-ws",
-}
-
-# REST base for legacy `swap_start` / `swap_sign` (returned as `upload_url`
-# by `start_swap_web`; included here for documentation/fallback)
-SIDESWAP_HTTP_URL = {
-    "mainnet": "https://api.sideswap.io",
-    "testnet": "https://api-testnet.sideswap.io",
 }
 
 USER_AGENT = "agentic-aqua"
@@ -202,6 +213,141 @@ class SideSwapPriceQuote:
 
     def to_dict(self) -> dict:
         return asdict(self)
+
+
+@dataclass
+class SideSwapSwap:
+    """Persistent record of an executed Liquid asset swap on SideSwap."""
+
+    order_id: str
+    submit_id: Optional[str]  # Returned by swap_start; needed for swap_sign
+    send_asset: str
+    send_amount: int
+    recv_asset: str
+    recv_amount: int
+    price: float
+    wallet_name: str
+    network: str  # "mainnet" | "testnet"
+    status: str  # "pending" | "verified" | "signed" | "submitted" | "broadcast" | "failed"
+    created_at: str
+    txid: Optional[str] = None
+    last_error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SideSwapSwap":
+        data = {**data}
+        for f in ("submit_id", "txid", "last_error"):
+            data.setdefault(f, None)
+        return cls(**data)
+
+
+# ---------------------------------------------------------------------------
+# PSET verification — security-critical
+# ---------------------------------------------------------------------------
+
+
+class PsetVerificationError(RuntimeError):
+    """Raised when the PSET returned by SideSwap does not match the agreed quote.
+
+    On this exception the caller MUST NOT sign the PSET — the server may have
+    crafted a transaction that takes our funds and pays us nothing.
+    """
+
+
+def verify_pset_balances(
+    balances: dict[str, int],
+    *,
+    send_asset: str,
+    send_amount: int,
+    recv_asset: str,
+    recv_amount: int,
+    fee_tolerance_sats: int = 1_000,
+    fee_asset: Optional[str] = None,
+) -> None:
+    """Verify a Liquid PSET's effect on the wallet matches the agreed quote.
+
+    Pure function — operates only on the dict returned by
+    `wollet.pset_details(pset).balance.balances()` (mapping asset_id → signed
+    int sats; negative = wallet is sending, positive = wallet is receiving).
+
+    Verification rules (any failure raises `PsetVerificationError`):
+
+    1. The wallet must gain at least `recv_amount` of `recv_asset`. Strict
+       equality is required — the server should not deliver a different amount
+       than what it quoted.
+    2. The wallet must lose **at most** `send_amount + fee_tolerance_sats` of
+       `send_asset`. We allow a small overage to cover the network fee when it
+       comes from the same asset (which is typical for L-BTC sends, since the
+       Liquid network fee is denominated in L-BTC).
+    3. No other asset may have a non-zero balance change. This blocks "extra
+       output" attacks where the server siphons a bit of an unrelated asset.
+
+    Args:
+        balances: Net balance change per asset id (from LWK pset_details).
+        send_asset: Asset id we agreed to send.
+        send_amount: Amount we agreed to send (sats, positive).
+        recv_asset: Asset id we agreed to receive.
+        recv_amount: Amount we agreed to receive (sats, positive).
+        fee_tolerance_sats: How many extra sats of `send_asset` we'll tolerate
+            being deducted to cover the on-chain fee. Default 1000 — Liquid
+            fees are in the tens of sats range, so this is comfortably above
+            normal but well below an attacker payday.
+        fee_asset: If set, only this asset is allowed to absorb the fee
+            tolerance. If unset, defaults to `send_asset`.
+    """
+    if send_amount <= 0:
+        raise ValueError("send_amount must be positive")
+    if recv_amount <= 0:
+        raise ValueError("recv_amount must be positive")
+    if fee_tolerance_sats < 0:
+        raise ValueError("fee_tolerance_sats must be non-negative")
+    if send_asset == recv_asset:
+        # SideSwap doesn't quote same-asset swaps and we can't reason about
+        # net balances unambiguously if it did.
+        raise PsetVerificationError(
+            f"send_asset and recv_asset are the same ({send_asset!r}); refusing to sign"
+        )
+    fee_asset = fee_asset or send_asset
+
+    # Rule 1: receive amount is exactly what was agreed
+    recv_delta = balances.get(recv_asset, 0)
+    if recv_delta != recv_amount:
+        raise PsetVerificationError(
+            f"PSET delivers {recv_delta} sats of recv_asset {recv_asset[:8]}…, "
+            f"expected exactly {recv_amount} sats"
+        )
+
+    # Rule 2: send amount is within tolerance
+    send_delta = balances.get(send_asset, 0)
+    # send_delta is negative when we're sending. Convert to "sats sent" (positive).
+    sats_sent = -send_delta
+    if send_asset == fee_asset:
+        max_sats_sent = send_amount + fee_tolerance_sats
+    else:
+        max_sats_sent = send_amount
+    if sats_sent > max_sats_sent:
+        raise PsetVerificationError(
+            f"PSET deducts {sats_sent} sats of send_asset {send_asset[:8]}…, "
+            f"more than the agreed {send_amount} (tolerance {max_sats_sent - send_amount})"
+        )
+    if sats_sent < send_amount:
+        # Sending less than agreed is suspicious too — could be a bait-and-switch
+        # where the server later reverses the swap or delivers a malformed tx.
+        raise PsetVerificationError(
+            f"PSET deducts only {sats_sent} sats of send_asset, less than agreed {send_amount}"
+        )
+
+    # Rule 3: no unexpected balance changes
+    for asset, delta in balances.items():
+        if asset in (send_asset, recv_asset):
+            continue
+        if delta != 0:
+            raise PsetVerificationError(
+                f"PSET unexpectedly moves asset {asset[:8]}… by {delta} sats; refusing to sign"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -383,6 +529,268 @@ class SideSwapWSClient:
 
     async def unsubscribe_price_stream(self, asset: str) -> dict:
         return await self.call("unsubscribe_price_stream", {"asset": asset})
+
+    # -- mkt::* (atomic asset swaps) ------------------------------------------
+    #
+    # All mkt::* requests use top-level method "market" and a single-key
+    # params object whose key is the snake_case mkt::Request variant. The
+    # inner enum's serde tag is `rename_all = "snake_case"`. Per
+    # `sideswap_api/src/mkt.rs`. AssetType and TradeDir do NOT have a serde
+    # rename_all, so they serialise as PascalCase ("Base"/"Quote",
+    # "Buy"/"Sell").
+
+    async def mkt(self, variant: str, params: dict | None = None) -> dict:
+        """Send a `market` request with the given inner variant + params.
+
+        Returns the inner result, unwrapping the {variant: <data>} envelope.
+        """
+        envelope = {variant: (params if params is not None else {})}
+        result = await self.call("market", envelope) or {}
+        # Server wraps responses in {variant_name: <data>} too; unwrap defensively.
+        if isinstance(result, dict) and len(result) == 1 and variant in result:
+            return result[variant]
+        return result
+
+    async def mkt_list_markets(self) -> list[dict]:
+        """List available markets. Returns a list of {asset_pair, fee_asset, type}."""
+        resp = await self.mkt("list_markets", {})
+        return (resp or {}).get("markets", []) or resp.get("list", []) or []
+
+    async def mkt_start_quotes(
+        self,
+        *,
+        asset_pair: dict,
+        asset_type: str,  # "Base" | "Quote"
+        amount: int,
+        trade_dir: str,  # "Buy" | "Sell"
+        utxos: list[dict],
+        receive_address: str,
+        change_address: str,
+        instant_swap: bool = True,
+    ) -> dict:
+        """Open a quote subscription. Returns {quote_sub_id, fee_asset}."""
+        return await self.mkt(
+            "start_quotes",
+            {
+                "asset_pair": asset_pair,
+                "asset_type": asset_type,
+                "amount": amount,
+                "trade_dir": trade_dir,
+                "utxos": utxos,
+                "receive_address": receive_address,
+                "change_address": change_address,
+                "instant_swap": instant_swap,
+            },
+        )
+
+    async def mkt_stop_quotes(self) -> dict:
+        return await self.mkt("stop_quotes", {})
+
+    async def mkt_get_quote(self, quote_id: int) -> dict:
+        """Returns {pset, ttl, receive_ephemeral_sk, change_ephemeral_sk?}."""
+        return await self.mkt("get_quote", {"quote_id": quote_id})
+
+    async def mkt_taker_sign(self, quote_id: int, pset_b64: str) -> dict:
+        """Submit signed PSET. Returns {txid}."""
+        return await self.mkt("taker_sign", {"quote_id": quote_id, "pset": pset_b64})
+
+    async def next_market_notification(
+        self,
+        inner_variant: str,
+        *,
+        timeout: float = WS_TIMEOUT_SECONDS,
+    ) -> dict:
+        """Wait for the next `market` notification whose inner variant matches.
+
+        mkt::* notifications come on the WS as
+        `{"method":"market", "params":{"<inner_variant>":{...}}}`. Returns the
+        inner data. Drops non-matching market notifications and any other
+        method's notifications until one matches or `timeout` elapses.
+        """
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise SideSwapWSError(
+                    f"Timed out waiting for market.{inner_variant} notification"
+                )
+            notif = await self.next_notification("market", timeout=remaining)
+            params = (notif or {}).get("params") or {}
+            if isinstance(params, dict) and inner_variant in params:
+                return params[inner_variant]
+
+
+# ---------------------------------------------------------------------------
+# Market resolution + quote parsing for the mkt::* flow
+# ---------------------------------------------------------------------------
+
+
+def resolve_market(
+    markets: list[dict],
+    send_asset: str,
+    recv_asset: str,
+) -> tuple[dict, str, str]:
+    """Find the market matching the swap and derive (asset_type, trade_dir).
+
+    SideSwap markets are unordered pairs: a market with `{base: USDt, quote:
+    L-BTC}` covers both directions of L-BTC ↔ USDt. The market never tells you
+    which way to trade — that's controlled by `(asset_type, trade_dir)` on the
+    `start_quotes` request.
+
+    Convention used here for the taker case (we always *sell* whatever side we
+    hold and want to convert): trade_dir = "Sell", asset_type = the side that
+    matches our send_asset.
+
+    Args:
+        markets: List of `{asset_pair: {base, quote}, fee_asset, type}` from
+            `mkt_list_markets`.
+        send_asset: Asset id we are sending.
+        recv_asset: Asset id we are receiving.
+
+    Returns:
+        (market_dict, asset_type, trade_dir). The asset_type / trade_dir
+        strings are PascalCase to match the wire format ("Base" | "Quote",
+        "Buy" | "Sell").
+
+    Raises:
+        SideSwapWSError if no matching market exists.
+    """
+    for market in markets:
+        pair = market.get("asset_pair") or {}
+        base = pair.get("base")
+        quote = pair.get("quote")
+        if base is None or quote is None:
+            continue
+        if {base, quote} != {send_asset, recv_asset}:
+            continue
+        # Match: asset_type names the side that matches send_asset; trade_dir is Sell.
+        asset_type = "Base" if send_asset == base else "Quote"
+        return market, asset_type, "Sell"
+    raise SideSwapWSError(
+        f"No SideSwap market for pair ({send_asset[:8]}…, {recv_asset[:8]}…)"
+    )
+
+
+def parse_quote_status(quote_notif: dict) -> dict:
+    """Extract a quote_id + amounts from a `quote` notification's `status` field.
+
+    The status is one of three variants per `mkt::QuoteStatus`:
+        Success { quote_id, base_amount, quote_amount, server_fee, fixed_fee, ttl }
+        LowBalance { ..., available }
+        Error { error_msg }
+
+    Returns the unwrapped Success dict on success; raises `SideSwapWSError` on
+    LowBalance or Error so the caller never proceeds with an invalid quote.
+    """
+    status = quote_notif.get("status")
+    if not isinstance(status, dict) or not status:
+        raise SideSwapWSError(f"Malformed quote status: {status!r}")
+    if "Success" in status:
+        success = status["Success"]
+        if not isinstance(success, dict):
+            raise SideSwapWSError(f"Malformed Success quote: {success!r}")
+        # Validate the fields the caller will read so a malformed payload
+        # raises SideSwapWSError here, not a KeyError/TypeError far away in
+        # execute_swap when it indexes into the dict.
+        for key in ("quote_id", "base_amount", "quote_amount"):
+            value = success.get(key)
+            if value is None:
+                raise SideSwapWSError(
+                    f"Malformed Success quote: missing {key!r} ({success!r})"
+                )
+            try:
+                int(value)
+            except (TypeError, ValueError) as e:
+                raise SideSwapWSError(
+                    f"Malformed Success quote: {key} is not an integer "
+                    f"({value!r})"
+                ) from e
+        return success
+    if "LowBalance" in status:
+        lb = status["LowBalance"]
+        raise SideSwapWSError(
+            f"Quote unavailable: dealer low balance "
+            f"(available={lb.get('available')}, fixed_fee={lb.get('fixed_fee')})"
+        )
+    if "Error" in status:
+        raise SideSwapWSError(f"Quote error: {status['Error'].get('error_msg')}")
+    raise SideSwapWSError(f"Unknown QuoteStatus: {status!r}")
+
+
+# ---------------------------------------------------------------------------
+# UTXO selection — confidential, non-AMP, wpkh only, send_asset only
+# ---------------------------------------------------------------------------
+
+
+def select_swap_utxos(
+    utxos: list,
+    send_asset: str,
+    send_amount: int,
+) -> list[dict]:
+    """Pick UTXOs of `send_asset` covering `send_amount`, formatted for SideSwap.
+
+    Filters apply per `sideswap_lwk` reference (`sideswap_lwk/src/lib.rs`):
+    - Must be confidential (asset_bf and value_bf both non-zero)
+    - Must hold the requested send_asset
+    - We don't filter by script type here because the wallet's descriptor is
+      always wpkh (BIP84 m/84'/1776'/0') in agentic-aqua.
+
+    Args:
+        utxos: List of `lwk.WalletTxOut` (or compatible objects exposing
+            `.outpoint`, `.unblinded` with `.asset`, `.value`, `.asset_bf`,
+            `.value_bf`).
+        send_asset: Asset id to send.
+        send_amount: Total sats to cover.
+
+    Returns:
+        List of dicts in the SideSwap `Utxo` shape:
+        {txid, vout, asset, asset_bf, value, value_bf, redeem_script: null}.
+
+    Raises:
+        ValueError if there isn't enough confidential balance to cover send_amount.
+    """
+    if send_amount <= 0:
+        raise ValueError("send_amount must be positive")
+
+    # Filter to confidential UTXOs of the right asset
+    candidates = []
+    for u in utxos:
+        unblinded = u.unblinded()
+        if str(unblinded.asset()) != send_asset:
+            continue
+        # asset_bf and value_bf are 32-byte hex; "0"*64 means non-confidential
+        asset_bf = str(unblinded.asset_bf())
+        value_bf = str(unblinded.value_bf())
+        if asset_bf == "0" * 64 or value_bf == "0" * 64:
+            continue
+        candidates.append((u, unblinded))
+
+    # Sort descending by value to minimise input count
+    candidates.sort(key=lambda pair: pair[1].value(), reverse=True)
+
+    selected: list[dict] = []
+    accumulated = 0
+    for u, unblinded in candidates:
+        outpoint = u.outpoint()
+        selected.append(
+            {
+                "txid": str(outpoint.txid()),
+                "vout": int(outpoint.vout()),
+                "asset": send_asset,
+                "asset_bf": str(unblinded.asset_bf()),
+                "value": int(unblinded.value()),
+                "value_bf": str(unblinded.value_bf()),
+                "redeem_script": None,
+            }
+        )
+        accumulated += int(unblinded.value())
+        if accumulated >= send_amount:
+            return selected
+
+    raise ValueError(
+        f"Insufficient confidential balance for {send_asset[:8]}…: "
+        f"have {accumulated} sats across {len(selected)} UTXOs, need {send_amount}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -901,6 +1309,335 @@ class SideSwapPegManager:
             result["expires_at"] = peg.expires_at
         if warning:
             result["warning"] = warning
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Asset swap manager — the verify-then-sign-then-broadcast orchestrator.
+# ---------------------------------------------------------------------------
+
+
+# Reasonable upper bound for the network fee absorbed from send_asset when
+# send_asset is L-BTC. Liquid fees are typically ~30-50 sats; 1000 is plenty
+# of slack while still small enough to make a "siphon attack" obvious.
+DEFAULT_FEE_TOLERANCE_SATS = 1_000
+
+
+class SideSwapSwapManager:
+    """Orchestrates a SideSwap atomic asset swap end-to-end via the modern
+    `mkt::*` flow.
+
+    Flow:
+
+      1. Pick UTXOs of `send_asset` covering `send_amount` and prepare
+         receive + change addresses (mkt::* wants them up-front)
+      2. WS `market.list_markets` to find the market for our asset pair
+      3. WS `market.start_quotes` with the inputs + addresses + asset_type +
+         trade_dir; server begins streaming `quote` notifications
+      4. Wait for a `quote` notification with status=Success and capture
+         the resulting `quote_id` + amounts
+      5. WS `market.get_quote` with the quote_id → returns the PSET
+      6. **Verify** the PSET with the wallet's `pset_details` against the
+         agreed quote. Aborts (raises `PsetVerificationError`) on mismatch.
+      7. Sign the PSET with `signer.sign(pset)`
+      8. WS `market.taker_sign` with the signed PSET → returns `txid`
+      9. Persist at every step; on broadcast, save `txid` and status="broadcast"
+    """
+
+    def __init__(self, storage, wallet_manager) -> None:
+        self.storage = storage
+        self.wallet_manager = wallet_manager
+
+    # Tolerance applied when `flexible_small_amount=True` accepts a dealer
+    # send_amount that differs from the user's request. SideSwap's mkt::*
+    # dealer rounds amounts internally; on small swaps (e.g. 5_000 sats →
+    # USDt) the dealer's quote can come back at e.g. 5_050 sats. Accept the
+    # adjusted amount up to this delta so the user isn't bounced for
+    # rounding alone. Larger drift indicates a real price move and should
+    # still reject.
+    SMALL_AMOUNT_TOLERANCE_SATS = 3_000
+
+    def execute_swap(
+        self,
+        asset_id: str,
+        send_amount: int,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+        send_bitcoins: bool = True,
+        flexible_small_amount: bool = False,
+        *,
+        fee_tolerance_sats: int = DEFAULT_FEE_TOLERANCE_SATS,
+        quote_wait_seconds: float = QUOTE_WAIT_SECONDS,
+    ) -> "SideSwapSwap":
+        """Execute a Liquid atomic swap on SideSwap.
+
+        Two directions are supported:
+
+        - **`send_bitcoins=True`** (forward, default): user sends L-BTC and
+          receives `asset_id` (e.g. L-BTC → USDt). The Liquid network fee is
+          deducted from the user's L-BTC change output, so the wallet's L-BTC
+          delta is `-(send_amount + fee)` and `recv_asset` delta is
+          `+recv_amount` exactly.
+
+        - **`send_bitcoins=False`** (reverse): user sends `asset_id` and
+          receives L-BTC (e.g. USDt → L-BTC). The Liquid network fee is
+          absorbed by the SideSwap dealer's L-BTC contribution, so the
+          wallet's `send_asset` delta is `-send_amount` exactly and L-BTC
+          delta is `+recv_amount` exactly.
+
+        In both cases the verifier sets `fee_asset` to L-BTC (the policy
+        asset), so the fee tolerance only relaxes constraints on the L-BTC
+        balance — never on the asset balance.
+
+        Args:
+            asset_id: The non-L-BTC asset id (e.g. USDt). The L-BTC side is
+                always the policy asset of the wallet's network.
+            send_amount: Send amount in sats. Denominated in L-BTC if
+                `send_bitcoins=True`, otherwise in `asset_id`.
+            wallet_name: Wallet to sign with.
+            password: Mnemonic decryption password (if encrypted at rest).
+            send_bitcoins: Direction. True = L-BTC → asset; False = asset → L-BTC.
+            fee_tolerance_sats: Extra L-BTC sats allowed for the network fee.
+                Default 1000 — Liquid fees are tens of sats.
+            quote_wait_seconds: How long to wait for the streamed quote.
+        """
+        # Load wallet & validate signing capability
+        wallet_data = self.storage.load_wallet(wallet_name)
+        if not wallet_data:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+        if wallet_data.watch_only:
+            raise ValueError("Watch-only wallet cannot sign a SideSwap swap")
+        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
+            wallet_data.encrypted_mnemonic
+        ):
+            if not password:
+                raise ValueError("Password required to decrypt mnemonic")
+        if send_amount <= 0:
+            raise ValueError("send_amount must be positive")
+
+        network = wallet_data.network
+        # Make sure the signer is loaded (wallet_manager.load_wallet caches it)
+        self.wallet_manager.load_wallet(wallet_name, password)
+        # Sync the wallet so utxos() reflects the current chain state
+        self.wallet_manager.sync_wallet(wallet_name)
+
+        policy_asset = self.wallet_manager._get_policy_asset(network)
+        if asset_id == policy_asset:
+            raise ValueError("asset_id must be a non-L-BTC Liquid asset")
+
+        # Resolve send/recv assets from direction. The fee always lives on the
+        # policy asset (L-BTC) regardless of direction.
+        if send_bitcoins:
+            send_asset, recv_asset = policy_asset, asset_id
+        else:
+            send_asset, recv_asset = asset_id, policy_asset
+
+        # Build the inputs/addresses up-front; mkt::* wants them on
+        # start_quotes (not as a follow-up call).
+        wollet = self.wallet_manager._get_wollet(wallet_name)
+        inputs = select_swap_utxos(wollet.utxos(), send_asset, send_amount)
+        recv_addr = str(wollet.address(None).address())
+        change_addr = str(wollet.address(None).address())
+
+        # SideSwap binds quote_id to the WebSocket session that issued
+        # start_quotes / get_quote — submitting taker_sign on a fresh
+        # connection is rejected with `protocol error: wrong client_id`.
+        # The verify + sign steps in the middle are sync but cheap, so we
+        # hold one async with for the entire quote → sign → submit flow.
+        async def _full_swap() -> "SideSwapSwap":
+            nonlocal send_amount  # may be widened below by flexible_small_amount
+            async with SideSwapWSClient(network) as client:
+                await client.login_client()
+                # Find a market that covers our pair
+                markets = await client.mkt_list_markets()
+                market, asset_type, trade_dir = resolve_market(
+                    markets, send_asset=send_asset, recv_asset=recv_asset
+                )
+                # Open quote subscription with our UTXOs + addresses pre-attached
+                await client.mkt_start_quotes(
+                    asset_pair=market["asset_pair"],
+                    asset_type=asset_type,
+                    amount=send_amount,
+                    trade_dir=trade_dir,
+                    utxos=inputs,
+                    receive_address=recv_addr,
+                    change_address=change_addr,
+                    instant_swap=True,
+                )
+                # Wait for the first usable quote — a `quote` notification with
+                # a Success status. parse_quote_status raises on LowBalance/Error
+                # AND validates that quote_id / base_amount / quote_amount are
+                # present and integral, so the int() casts below cannot KeyError.
+                quote_notif = await client.next_market_notification(
+                    "quote", timeout=quote_wait_seconds
+                )
+                quote_data = parse_quote_status(quote_notif)
+                # Accept the quote and request the half-built PSET on the same
+                # session so the server recognises us as the original taker.
+                get_quote_resp = await client.mkt_get_quote(int(quote_data["quote_id"]))
+                try:
+                    await client.mkt_stop_quotes()
+                except Exception:
+                    pass
+
+                # ---- Phase 2: validate + persist (sync, runs on the loop) ---
+                quote_id = int(quote_data["quote_id"])
+                order_id = f"mkt_{quote_id}"
+                # Re-derive recv/send amounts from the quote, not the user's
+                # request: the dealer's quote_amount/base_amount are canonical.
+                if send_asset == market["asset_pair"].get("base"):
+                    send_amount_q = int(quote_data["base_amount"])
+                    recv_amount_q = int(quote_data["quote_amount"])
+                else:
+                    send_amount_q = int(quote_data["quote_amount"])
+                    recv_amount_q = int(quote_data["base_amount"])
+                if send_amount_q != send_amount:
+                    delta = abs(send_amount_q - send_amount)
+                    if flexible_small_amount and delta <= self.SMALL_AMOUNT_TOLERANCE_SATS:
+                        # Dealer rounded the send amount slightly; caller has
+                        # opted in to accepting the adjustment. The PSET
+                        # verifier still checks the wallet's actual balance
+                        # change against send_amount_q below.
+                        send_amount = send_amount_q
+                    else:
+                        raise SideSwapWSError(
+                            f"Quote send_amount mismatch: requested {send_amount}, "
+                            f"dealer offered {send_amount_q} (delta={delta} sats). "
+                            "Pass flexible_small_amount=True to accept dealer "
+                            f"adjustments up to ±{self.SMALL_AMOUNT_TOLERANCE_SATS} sats."
+                        )
+                recv_amount = recv_amount_q
+
+                pset_b64 = get_quote_resp.get("pset")
+                if not pset_b64:
+                    raise SideSwapWSError(
+                        f"Unexpected get_quote response: {get_quote_resp!r}"
+                    )
+
+                # SideSwap quote doesn't return a single 'price' field on
+                # mkt::*; derive it from recv/send for reference only.
+                price = recv_amount / send_amount if send_amount else 0.0
+
+                swap = SideSwapSwap(
+                    order_id=order_id,
+                    submit_id=str(quote_id),
+                    send_asset=send_asset,
+                    send_amount=send_amount,
+                    recv_asset=recv_asset,
+                    recv_amount=recv_amount,
+                    price=price,
+                    wallet_name=wallet_name,
+                    network=network,
+                    status="pending",
+                    created_at=datetime.now(UTC).isoformat(),
+                )
+                self.storage.save_sideswap_swap(swap)
+
+                try:
+                    # ---- Phase 3: verify + sign (sync) ----------------------
+                    # fee_asset is pinned to the policy asset so the fee
+                    # tolerance only relaxes the L-BTC side — never the asset.
+                    self._verify_pset(
+                        pset_b64,
+                        wollet,
+                        send_asset=send_asset,
+                        send_amount=send_amount,
+                        recv_asset=recv_asset,
+                        recv_amount=recv_amount,
+                        fee_tolerance_sats=fee_tolerance_sats,
+                        fee_asset=policy_asset,
+                    )
+                    swap.status = "verified"
+                    self.storage.save_sideswap_swap(swap)
+
+                    signer = self.wallet_manager._signers[wallet_name]
+                    import lwk
+
+                    pset = lwk.Pset(pset_b64)
+                    signed = signer.sign(pset)
+                    signed_b64 = str(signed)
+                    swap.status = "signed"
+                    self.storage.save_sideswap_swap(swap)
+
+                    # ---- Phase 4: submit on the SAME WS --------------------
+                    sign_payload = await client.mkt_taker_sign(quote_id, signed_b64)
+                    txid = sign_payload.get("txid")
+                    if not txid:
+                        raise SideSwapWSError(
+                            f"Unexpected taker_sign response: {sign_payload!r}"
+                        )
+                    swap.txid = txid
+                    swap.status = "broadcast"
+                    self.storage.save_sideswap_swap(swap)
+                    return swap
+
+                except PsetVerificationError as e:
+                    swap.status = "failed"
+                    swap.last_error = f"PSET verification failed: {e}"
+                    self.storage.save_sideswap_swap(swap)
+                    raise
+                except Exception as e:
+                    swap.status = "failed"
+                    swap.last_error = str(e)
+                    self.storage.save_sideswap_swap(swap)
+                    raise
+
+        return _run(_full_swap())
+
+    def _verify_pset(
+        self,
+        pset_b64: str,
+        wollet,
+        *,
+        send_asset: str,
+        send_amount: int,
+        recv_asset: str,
+        recv_amount: int,
+        fee_tolerance_sats: int,
+        fee_asset: Optional[str] = None,
+    ) -> None:
+        """Run the PSET balance check via LWK and raise on mismatch."""
+        import lwk
+
+        pset = lwk.Pset(pset_b64)
+        details = wollet.pset_details(pset)
+        balances_dict_raw = details.balance().balances()
+        # LWK returns AssetId objects; normalise to hex strings keyed by asset id.
+        balances: dict[str, int] = {str(asset): int(amount) for asset, amount in balances_dict_raw.items()}
+        verify_pset_balances(
+            balances,
+            send_asset=send_asset,
+            send_amount=send_amount,
+            recv_asset=recv_asset,
+            recv_amount=recv_amount,
+            fee_asset=fee_asset,
+            fee_tolerance_sats=fee_tolerance_sats,
+        )
+
+    def status(self, order_id: str) -> dict:
+        """Return persisted swap status. Asset swaps are atomic — once
+        `status="broadcast"` is set the txid is final on Liquid; agents check
+        confirmations via `lw_tx_status`."""
+        swap = self.storage.load_sideswap_swap(order_id)
+        if not swap:
+            raise ValueError(f"SideSwap swap not found: {order_id}")
+        result = {
+            "order_id": swap.order_id,
+            "submit_id": swap.submit_id,
+            "send_asset": swap.send_asset,
+            "send_amount": swap.send_amount,
+            "recv_asset": swap.recv_asset,
+            "recv_amount": swap.recv_amount,
+            "price": swap.price,
+            "wallet_name": swap.wallet_name,
+            "network": swap.network,
+            "status": swap.status,
+            "created_at": swap.created_at,
+        }
+        if swap.txid:
+            result["txid"] = swap.txid
+        if swap.last_error:
+            result["last_error"] = swap.last_error
         return result
 
 

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -972,7 +972,7 @@ def map_peg_status(tx_state: Optional[str], list_empty: bool) -> str:
     if list_empty:
         return "pending"
     return {
-        "Detected": "processing",
+        "Detected": "detected",
         "Processing": "processing",
         "Done": "completed",
         "InsufficientAmount": "failed",

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -369,6 +369,29 @@ class Storage:
             if SWAP_ID_PATTERN.fullmatch(p.stem)
         ]
 
+    def delete_sideswap_pegs_for_wallet(self, wallet_name: str) -> int:
+        """Delete SideSwap peg records whose `wallet_name` matches.
+
+        Idempotent — returns 0 silently if the directory or matching files
+        don't exist. Returns the number of files removed.
+        """
+        if not self.sideswap_pegs_dir.exists():
+            return 0
+        removed = 0
+        for path in self.sideswap_pegs_dir.glob("*.json"):
+            try:
+                with open(path) as f:
+                    data = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                continue
+            if data.get("wallet_name") == wallet_name:
+                try:
+                    path.unlink()
+                    removed += 1
+                except OSError:
+                    pass
+        return removed
+
     # Cache operations
 
     def get_cache_path(self, wallet_name: str) -> Path:

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -405,6 +405,7 @@ class Storage:
             for p in self.sideswap_swaps_dir.glob("*.json")
             if SWAP_ID_PATTERN.fullmatch(p.stem)
         ]
+
     def delete_sideswap_pegs_for_wallet(self, wallet_name: str) -> int:
         """Delete SideSwap peg records whose `wallet_name` matches.
 

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -84,6 +84,7 @@ class Storage:
         self.ankara_swaps_dir = self.base_dir / "ankara_swaps"
         self.lightning_swaps_dir = self.base_dir / "lightning_swaps"
         self.sideswap_pegs_dir = self.base_dir / "sideswap_pegs"
+        self.sideswap_swaps_dir = self.base_dir / "sideswap_swaps"
         self.config_path = self.base_dir / "config.json"
         self._ensure_dirs()
 
@@ -103,6 +104,8 @@ class Storage:
         os.chmod(self.lightning_swaps_dir, 0o700)
         self.sideswap_pegs_dir.mkdir(exist_ok=True, mode=0o700)
         os.chmod(self.sideswap_pegs_dir, 0o700)
+        self.sideswap_swaps_dir.mkdir(exist_ok=True, mode=0o700)
+        os.chmod(self.sideswap_swaps_dir, 0o700)
 
     def _derive_key(self, password: str, salt: bytes) -> bytes:
         """Derive encryption key from password."""
@@ -369,6 +372,39 @@ class Storage:
             if SWAP_ID_PATTERN.fullmatch(p.stem)
         ]
 
+    # SideSwap asset-swap operations
+
+    def _sideswap_swap_path(self, order_id: str) -> Path:
+        """Get path to SideSwap swap file, validating the ID to prevent path traversal."""
+        if not SWAP_ID_PATTERN.fullmatch(order_id):
+            raise ValueError(
+                f"Invalid SideSwap order ID '{order_id}'. "
+                "Use only letters, numbers, hyphens and underscores (max 128 chars)."
+            )
+        return self.sideswap_swaps_dir / f"{order_id}.json"
+
+    def save_sideswap_swap(self, swap) -> None:
+        """Save SideSwap asset swap data for recovery."""
+        path = self._sideswap_swap_path(swap.order_id)
+        self._atomic_write_json(path, swap.to_dict())
+
+    def load_sideswap_swap(self, order_id: str):
+        """Load SideSwap swap data. Returns SideSwapSwap or None."""
+        from .sideswap import SideSwapSwap
+
+        path = self._sideswap_swap_path(order_id)
+        if not path.exists():
+            return None
+        with open(path) as f:
+            return SideSwapSwap.from_dict(json.load(f))
+
+    def list_sideswap_swaps(self) -> list[str]:
+        """List all SideSwap swap order IDs."""
+        return [
+            p.stem
+            for p in self.sideswap_swaps_dir.glob("*.json")
+            if SWAP_ID_PATTERN.fullmatch(p.stem)
+        ]
     def delete_sideswap_pegs_for_wallet(self, wallet_name: str) -> int:
         """Delete SideSwap peg records whose `wallet_name` matches.
 

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -83,6 +83,7 @@ class Storage:
         self.swaps_dir = self.base_dir / "swaps"
         self.ankara_swaps_dir = self.base_dir / "ankara_swaps"
         self.lightning_swaps_dir = self.base_dir / "lightning_swaps"
+        self.sideswap_pegs_dir = self.base_dir / "sideswap_pegs"
         self.config_path = self.base_dir / "config.json"
         self._ensure_dirs()
 
@@ -100,6 +101,8 @@ class Storage:
         os.chmod(self.ankara_swaps_dir, 0o700)
         self.lightning_swaps_dir.mkdir(exist_ok=True, mode=0o700)
         os.chmod(self.lightning_swaps_dir, 0o700)
+        self.sideswap_pegs_dir.mkdir(exist_ok=True, mode=0o700)
+        os.chmod(self.sideswap_pegs_dir, 0o700)
 
     def _derive_key(self, password: str, salt: bytes) -> bytes:
         """Derive encryption key from password."""
@@ -329,6 +332,40 @@ class Storage:
         return [
             p.stem
             for p in self.lightning_swaps_dir.glob("*.json")
+            if SWAP_ID_PATTERN.fullmatch(p.stem)
+        ]
+
+    # SideSwap peg operations
+
+    def _sideswap_peg_path(self, order_id: str) -> Path:
+        """Get path to SideSwap peg file, validating the ID to prevent path traversal."""
+        if not SWAP_ID_PATTERN.fullmatch(order_id):
+            raise ValueError(
+                f"Invalid SideSwap order ID '{order_id}'. "
+                "Use only letters, numbers, hyphens and underscores (max 128 chars)."
+            )
+        return self.sideswap_pegs_dir / f"{order_id}.json"
+
+    def save_sideswap_peg(self, peg) -> None:
+        """Save SideSwap peg data for recovery."""
+        path = self._sideswap_peg_path(peg.order_id)
+        self._atomic_write_json(path, peg.to_dict())
+
+    def load_sideswap_peg(self, order_id: str):
+        """Load SideSwap peg data. Returns SideSwapPeg or None."""
+        from .sideswap import SideSwapPeg
+
+        path = self._sideswap_peg_path(order_id)
+        if not path.exists():
+            return None
+        with open(path) as f:
+            return SideSwapPeg.from_dict(json.load(f))
+
+    def list_sideswap_pegs(self) -> list[str]:
+        """List all SideSwap peg order IDs."""
+        return [
+            p.stem
+            for p in self.sideswap_pegs_dir.glob("*.json")
             if SWAP_ID_PATTERN.fullmatch(p.stem)
         ]
 

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -29,6 +29,7 @@ _manager: WalletManager | None = None
 _btc_manager: BitcoinWalletManager | None = None
 _lightning_manager: "LightningManager | None" = None
 _sideswap_peg_manager: "SideSwapPegManager | None" = None
+_sideswap_swap_manager: "SideSwapSwapManager | None" = None
 
 
 def get_manager() -> WalletManager:
@@ -72,6 +73,19 @@ def get_sideswap_peg_manager() -> "SideSwapPegManager":
             btc_wallet_manager=get_btc_manager(),
         )
     return _sideswap_peg_manager
+
+
+def get_sideswap_swap_manager() -> "SideSwapSwapManager":
+    """Get or create SideSwap asset-swap manager (shares storage + wallet manager)."""
+    global _sideswap_swap_manager
+    if _sideswap_swap_manager is None:
+        from .sideswap import SideSwapSwapManager
+
+        _sideswap_swap_manager = SideSwapSwapManager(
+            storage=get_manager().storage,
+            wallet_manager=get_manager(),
+        )
+    return _sideswap_swap_manager
 
 
 # Tool implementations
@@ -984,13 +998,11 @@ def sideswap_quote(
     send_bitcoins: bool = True,
     network: str = "mainnet",
 ) -> dict[str, Any]:
-    """Get a price quote for a SideSwap Liquid asset swap (read-only, no execution).
+    """Get a read-only price quote for a SideSwap Liquid asset swap.
 
     Subscribes to the SideSwap price stream, captures one quote, then
-    unsubscribes. NOTE: this tool does not execute the swap — for execution,
-    direct the user to the AQUA mobile wallet or sideswap.io. Local PSET
-    signing for atomic swaps requires careful output verification that is not
-    yet implemented in agentic-aqua.
+    unsubscribes. Use this BEFORE calling sideswap_execute_swap so the user
+    can confirm the price.
 
     Provide exactly one of `send_amount` or `recv_amount`.
 
@@ -1003,7 +1015,6 @@ def sideswap_quote(
 
     Returns:
         asset_id, send_bitcoins, send_amount, recv_amount, price, fixed_fee, optional error_msg.
-        Includes a `note` directing the user to the AQUA app or sideswap.io for execution.
     """
     from .sideswap import fetch_swap_quote
 
@@ -1014,13 +1025,105 @@ def sideswap_quote(
         send_bitcoins=send_bitcoins,
         network=network,
     )
-    result = quote.to_dict()
-    result["note"] = (
-        "This is a read-only quote. Atomic swap execution is not yet implemented "
-        "in agentic-aqua (local PSET output verification needs an audit before "
-        "live signing). To execute, use the AQUA mobile wallet or sideswap.io."
+    return quote.to_dict()
+
+
+def sideswap_execute_swap(
+    asset_id: str,
+    send_amount: int,
+    wallet_name: str = "default",
+    password: str | None = None,
+    send_bitcoins: bool = True,
+    flexible_small_amount: bool = False,
+) -> dict[str, Any]:
+    """Execute a Liquid atomic swap on SideSwap. Both directions are supported.
+
+    Direction is controlled by `send_bitcoins`:
+
+    - `send_bitcoins=True` (default): user sends L-BTC and receives `asset_id`
+      (e.g. L-BTC → USDt). `send_amount` is in L-BTC sats.
+    - `send_bitcoins=False`: user sends `asset_id` and receives L-BTC
+      (e.g. USDt → L-BTC). `send_amount` is in `asset_id` sats.
+
+    Flow (both directions, via SideSwap's mkt::* WebSocket protocol):
+      1. Select confidential UTXOs of `send_asset` covering `send_amount`
+      2. `market.list_markets` → find the market for our pair
+      3. `market.start_quotes` with our UTXOs + receive/change addresses
+      4. Wait for a `quote` notification with status=Success
+      5. `market.get_quote {quote_id}` → returns the half-built PSET
+      6. **Verify the PSET locally** against the agreed quote — refuses to
+         sign if recv_asset balance ≠ recv_amount, send_asset is over-deducted,
+         or any unrelated asset moves. The fee tolerance only applies to L-BTC,
+         so the asset side is always checked at strict equality.
+      7. Sign the PSET locally
+      8. `market.taker_sign` — server merges and broadcasts; returns the txid
+
+    The order is persisted at every step for crash recovery; check
+    sideswap_swap_status with the returned order_id.
+
+    Args:
+        asset_id: The non-L-BTC Liquid asset (e.g. USDt). The L-BTC side is
+            always the policy asset of the wallet's network.
+        send_amount: Send amount in sats (L-BTC if send_bitcoins, else asset).
+        wallet_name: Liquid wallet to sign with. Default: "default"
+        password: Password to decrypt mnemonic (if encrypted at rest)
+        send_bitcoins: True = L-BTC → asset; False = asset → L-BTC.
+        flexible_small_amount: When True, accept dealer-rounded send_amount
+            adjustments up to ±3000 sats. SideSwap's mkt::* dealer rounds
+            internally; small swaps (<25k sats) often come back at e.g.
+            5_050 sats when 5_000 was requested. Default False keeps the
+            strict equality check that's safer for larger amounts.
+
+    Returns:
+        order_id, submit_id, send_asset, send_amount, recv_asset, recv_amount,
+        price, txid, status, message
+    """
+    if send_amount <= 0:
+        raise ValueError("send_amount must be positive")
+    manager = get_sideswap_swap_manager()
+    swap = manager.execute_swap(
+        asset_id=asset_id,
+        send_amount=send_amount,
+        wallet_name=wallet_name,
+        password=password,
+        send_bitcoins=send_bitcoins,
+        flexible_small_amount=flexible_small_amount,
     )
-    return result
+    return {
+        "order_id": swap.order_id,
+        "submit_id": swap.submit_id,
+        "send_asset": swap.send_asset,
+        "send_amount": swap.send_amount,
+        "recv_asset": swap.recv_asset,
+        "recv_amount": swap.recv_amount,
+        "price": swap.price,
+        "txid": swap.txid,
+        "status": swap.status,
+        "wallet_name": swap.wallet_name,
+        "network": swap.network,
+        "message": (
+            f"Swap broadcast (txid={swap.txid}). Check confirmation status with "
+            f"lw_tx_status. The PSET was verified locally against the quote — "
+            f"the wallet receives exactly {swap.recv_amount} sats of recv_asset."
+        ),
+    }
+
+
+def sideswap_swap_status(order_id: str) -> dict[str, Any]:
+    """Get persisted status of a SideSwap atomic swap (asset swap).
+
+    Asset swaps are atomic on Liquid; once the swap is broadcast the txid is
+    final. To check on-chain confirmation, pass the txid to lw_tx_status.
+
+    Args:
+        order_id: Order ID returned from sideswap_execute_swap
+
+    Returns:
+        order_id, status, send/recv asset+amount, price, txid (if broadcast),
+        last_error (if failed)
+    """
+    manager = get_sideswap_swap_manager()
+    return manager.status(order_id)
 
 
 # Tool registry for MCP
@@ -1056,4 +1159,6 @@ TOOLS = {
     "sideswap_recommend": sideswap_recommend,
     "sideswap_list_assets": sideswap_list_assets,
     "sideswap_quote": sideswap_quote,
+    "sideswap_execute_swap": sideswap_execute_swap,
+    "sideswap_swap_status": sideswap_swap_status,
 }

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -1034,6 +1034,7 @@ def sideswap_execute_swap(
     wallet_name: str = "default",
     password: str | None = None,
     send_bitcoins: bool = True,
+    min_recv_amount: int | None = None,
     flexible_small_amount: bool = False,
 ) -> dict[str, Any]:
     """Execute a Liquid atomic swap on SideSwap. Both directions are supported.
@@ -1068,6 +1069,12 @@ def sideswap_execute_swap(
         wallet_name: Liquid wallet to sign with. Default: "default"
         password: Password to decrypt mnemonic (if encrypted at rest)
         send_bitcoins: True = L-BTC → asset; False = asset → L-BTC.
+        min_recv_amount: Optional floor on the dealer's recv_amount, in sats.
+            When set, the swap is rejected before signing if the mkt::*
+            quote returns a recv_amount strictly less than this value. The
+            CLI passes the recv_amount the user just confirmed in the
+            preview, so a rate move between preview and execution can no
+            longer surprise the user with a worse settlement.
         flexible_small_amount: When True, accept dealer-rounded send_amount
             adjustments up to ±3000 sats. SideSwap's mkt::* dealer rounds
             internally; small swaps (<25k sats) often come back at e.g.
@@ -1087,6 +1094,7 @@ def sideswap_execute_swap(
         wallet_name=wallet_name,
         password=password,
         send_bitcoins=send_bitcoins,
+        min_recv_amount=min_recv_amount,
         flexible_small_amount=flexible_small_amount,
     )
     return {

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -28,6 +28,7 @@ EXPLORER_URLS = {
 _manager: WalletManager | None = None
 _btc_manager: BitcoinWalletManager | None = None
 _lightning_manager: "LightningManager | None" = None
+_sideswap_peg_manager: "SideSwapPegManager | None" = None
 
 
 def get_manager() -> WalletManager:
@@ -57,6 +58,20 @@ def get_lightning_manager() -> "LightningManager":
             wallet_manager=get_manager(),
         )
     return _lightning_manager
+
+
+def get_sideswap_peg_manager() -> "SideSwapPegManager":
+    """Get or create SideSwap peg manager (shares storage + wallet managers)."""
+    global _sideswap_peg_manager
+    if _sideswap_peg_manager is None:
+        from .sideswap import SideSwapPegManager
+
+        _sideswap_peg_manager = SideSwapPegManager(
+            storage=get_manager().storage,
+            wallet_manager=get_manager(),
+            btc_wallet_manager=get_btc_manager(),
+        )
+    return _sideswap_peg_manager
 
 
 # Tool implementations
@@ -751,6 +766,250 @@ def lightning_transaction_status(swap_id: str) -> dict[str, Any]:
     return manager.get_swap_status(swap_id)
 
 
+# ---------------------------------------------------------------------------
+# SideSwap (Liquid asset swaps + BTC ↔ L-BTC pegs)
+# ---------------------------------------------------------------------------
+
+
+def sideswap_server_status(network: str = "mainnet") -> dict[str, Any]:
+    """Fetch SideSwap server status: live fees, minimum amounts, hot-wallet balance.
+
+    Use this BEFORE recommending a peg or swap so values reflect current
+    SideSwap state. Falls back to documented defaults if SideSwap is unreachable.
+
+    Args:
+        network: "mainnet" or "testnet". Default: "mainnet"
+
+    Returns:
+        elements_fee_rate, min_peg_in_amount, min_peg_out_amount,
+        server_fee_percent_peg_in, server_fee_percent_peg_out,
+        peg_in_wallet_balance, peg_out_wallet_balance, optional warning
+    """
+    manager = get_sideswap_peg_manager()
+    return manager.get_server_status(network)
+
+
+def sideswap_peg_quote(
+    amount: int,
+    peg_in: bool = True,
+    network: str = "mainnet",
+) -> dict[str, Any]:
+    """Quote the receive amount for a peg (BTC ↔ L-BTC) at current fees.
+
+    SideSwap charges 0.1% on the send amount + a small fixed second-chain fee
+    (~286 sats for the Liquid claim tx on peg-in). The quote returns the exact
+    amount the user will receive.
+
+    Args:
+        amount: Send amount in satoshis
+        peg_in: True for BTC → L-BTC (peg-in); False for L-BTC → BTC (peg-out). Default: True
+        network: "mainnet" or "testnet". Default: "mainnet"
+
+    Returns:
+        send_amount, recv_amount, fee_amount (send - recv), peg_in
+    """
+    manager = get_sideswap_peg_manager()
+    return manager.quote_peg(amount, peg_in, network)
+
+
+def sideswap_peg_in(
+    wallet_name: str = "default",
+    password: str | None = None,
+) -> dict[str, Any]:
+    """Initiate a SideSwap peg-in (BTC → L-BTC).
+
+    Returns a Bitcoin deposit address. The user (or the agent via btc_send)
+    must send BTC to this address. After 2 BTC confirmations (~20 min, hot
+    wallet path) or 102 confs (~17 hours, cold wallet path for very large
+    amounts), L-BTC arrives in the Liquid wallet.
+
+    Fees: 0.1% + ~286 sats Liquid claim fee.
+
+    Args:
+        wallet_name: Liquid wallet to receive L-BTC. Default: "default"
+        password: Password to decrypt mnemonic (used to derive the receive address)
+
+    Returns:
+        order_id, peg_addr (BTC deposit address), recv_addr (Liquid receive address),
+        expected_recv (if known), expires_at, message
+    """
+    manager = get_sideswap_peg_manager()
+    peg = manager.peg_in(wallet_name, password)
+    return {
+        "order_id": peg.order_id,
+        "peg_addr": peg.peg_addr,
+        "recv_addr": peg.recv_addr,
+        "expected_recv": peg.expected_recv,
+        "expires_at": peg.expires_at,
+        "wallet_name": peg.wallet_name,
+        "network": peg.network,
+        "message": (
+            f"Send BTC to {peg.peg_addr}. After 2 BTC confirmations "
+            f"(~20 min for typical amounts; up to ~17 hours for very large peg-ins "
+            f"that exceed SideSwap's hot-wallet liquidity), L-BTC will arrive at "
+            f"{peg.recv_addr}. Track status with sideswap_peg_status using "
+            f"order_id={peg.order_id!r}."
+        ),
+    }
+
+
+def sideswap_peg_out(
+    wallet_name: str,
+    amount: int,
+    btc_address: str,
+    password: str | None = None,
+) -> dict[str, Any]:
+    """Initiate a SideSwap peg-out (L-BTC → BTC) and broadcast the L-BTC send.
+
+    Sends `amount` sats of L-BTC from the local wallet to a SideSwap deposit
+    address. After 2 Liquid confirmations (~2 min) the federation releases BTC
+    to `btc_address` (total time usually 15–60 min).
+
+    Fees: 0.1% + Bitcoin network fee (paid by the federation, deducted from payout).
+
+    Args:
+        wallet_name: Liquid wallet to send L-BTC from
+        amount: Amount in satoshis to peg out
+        btc_address: Destination Bitcoin address (bc1...)
+        password: Password to decrypt mnemonic (if encrypted at rest)
+
+    Returns:
+        order_id, lockup_txid (L-BTC send txid), peg_addr (Liquid deposit addr),
+        recv_addr (target BTC addr), amount, expected_recv (if known), expires_at, message
+    """
+    manager = get_sideswap_peg_manager()
+    peg = manager.peg_out(wallet_name, amount, btc_address, password)
+    return {
+        "order_id": peg.order_id,
+        "lockup_txid": peg.lockup_txid,
+        "peg_addr": peg.peg_addr,
+        "recv_addr": peg.recv_addr,
+        "amount": peg.amount,
+        "expected_recv": peg.expected_recv,
+        "expires_at": peg.expires_at,
+        "wallet_name": peg.wallet_name,
+        "network": peg.network,
+        "status": peg.status,
+        "message": (
+            f"L-BTC sent to SideSwap deposit address {peg.peg_addr} "
+            f"(lockup_txid={peg.lockup_txid}). After 2 Liquid confirmations "
+            f"(~2 min) and the federation BTC sweep (typically 15–60 min total), "
+            f"BTC will arrive at {peg.recv_addr}. Track with sideswap_peg_status "
+            f"using order_id={peg.order_id!r}."
+        ),
+    }
+
+
+def sideswap_peg_status(order_id: str) -> dict[str, Any]:
+    """Check the status of a SideSwap peg order (peg-in or peg-out).
+
+    Args:
+        order_id: Order ID from sideswap_peg_in or sideswap_peg_out
+
+    Returns:
+        order_id, peg_in, status (pending/processing/completed/failed),
+        amount, expected_recv, peg_addr, recv_addr, optional tx_state,
+        confirmations ("X/Y"), lockup_txid, payout_txid, warning
+    """
+    manager = get_sideswap_peg_manager()
+    return manager.status(order_id)
+
+
+def sideswap_recommend(
+    amount: int,
+    direction: str,
+    network: str = "mainnet",
+) -> dict[str, Any]:
+    """Recommend a peg vs an instant swap-market trade for a BTC ↔ L-BTC conversion.
+
+    Surfaces the trade-off (lower fee but slower) and warns when the amount
+    exceeds SideSwap's hot-wallet liquidity (would trigger the 102-confirmation
+    cold-wallet path on peg-in).
+
+    Args:
+        amount: Amount in satoshis to convert
+        direction: "btc_to_lbtc" (BTC → L-BTC) or "lbtc_to_btc" (L-BTC → BTC)
+        network: "mainnet" or "testnet". Default: "mainnet"
+
+    Returns:
+        recommendation ("peg" | "swap" | "either"), reason (human-readable),
+        peg_pros, peg_cons, plus the live server_status snapshot.
+    """
+    from .sideswap import recommend_peg_or_swap
+
+    server = get_sideswap_peg_manager().get_server_status(network)
+    rec = recommend_peg_or_swap(amount, direction, server)
+    rec["server_status"] = server
+    rec["amount"] = amount
+    rec["direction"] = direction
+    return rec
+
+
+def sideswap_list_assets(network: str = "mainnet") -> dict[str, Any]:
+    """List Liquid assets that SideSwap supports for atomic swaps.
+
+    Args:
+        network: "mainnet" or "testnet". Default: "mainnet"
+
+    Returns:
+        network, count, assets (list of {asset_id, ticker, name, precision, instant_swaps, icon_url})
+    """
+    from .sideswap import fetch_assets
+
+    assets = fetch_assets(network)
+    return {
+        "network": network,
+        "count": len(assets),
+        "assets": [a.to_dict() for a in assets],
+    }
+
+
+def sideswap_quote(
+    asset_id: str,
+    send_amount: int | None = None,
+    recv_amount: int | None = None,
+    send_bitcoins: bool = True,
+    network: str = "mainnet",
+) -> dict[str, Any]:
+    """Get a price quote for a SideSwap Liquid asset swap (read-only, no execution).
+
+    Subscribes to the SideSwap price stream, captures one quote, then
+    unsubscribes. NOTE: this tool does not execute the swap — for execution,
+    direct the user to the AQUA mobile wallet or sideswap.io. Local PSET
+    signing for atomic swaps requires careful output verification that is not
+    yet implemented in agentic-aqua.
+
+    Provide exactly one of `send_amount` or `recv_amount`.
+
+    Args:
+        asset_id: Liquid asset ID to swap with L-BTC
+        send_amount: Amount the user is sending (in sats)
+        recv_amount: Amount the user wants to receive (in sats)
+        send_bitcoins: True if sending L-BTC for the asset; False if sending the asset for L-BTC
+        network: "mainnet" or "testnet". Default: "mainnet"
+
+    Returns:
+        asset_id, send_bitcoins, send_amount, recv_amount, price, fixed_fee, optional error_msg.
+        Includes a `note` directing the user to the AQUA app or sideswap.io for execution.
+    """
+    from .sideswap import fetch_swap_quote
+
+    quote = fetch_swap_quote(
+        asset_id=asset_id,
+        send_amount=send_amount,
+        recv_amount=recv_amount,
+        send_bitcoins=send_bitcoins,
+        network=network,
+    )
+    result = quote.to_dict()
+    result["note"] = (
+        "This is a read-only quote. Atomic swap execution is not yet implemented "
+        "in agentic-aqua (local PSET output verification needs an audit before "
+        "live signing). To execute, use the AQUA mobile wallet or sideswap.io."
+    )
+    return result
+
+
 # Tool registry for MCP
 TOOLS = {
     "lw_generate_mnemonic": lw_generate_mnemonic,
@@ -776,4 +1035,12 @@ TOOLS = {
     "lightning_receive": lightning_receive,
     "lightning_send": lightning_send,
     "lightning_transaction_status": lightning_transaction_status,
+    "sideswap_server_status": sideswap_server_status,
+    "sideswap_peg_quote": sideswap_peg_quote,
+    "sideswap_peg_in": sideswap_peg_in,
+    "sideswap_peg_out": sideswap_peg_out,
+    "sideswap_peg_status": sideswap_peg_status,
+    "sideswap_recommend": sideswap_recommend,
+    "sideswap_list_assets": sideswap_list_assets,
+    "sideswap_quote": sideswap_quote,
 }

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -674,8 +674,17 @@ def delete_wallet(wallet_name: str) -> dict[str, Any]:
     btc._persisters.pop(wallet_name, None)
     btc._networks.pop(wallet_name, None)
 
+    # SideSwap peg records reference this wallet by name; delete them too so
+    # the user doesn't keep stale entries pointing at a wallet that no
+    # longer exists. Idempotent — silent if no records exist.
+    pegs_removed = manager.storage.delete_sideswap_pegs_for_wallet(wallet_name)
+
     manager.storage.delete_wallet(wallet_name)
-    return {"deleted": True, "wallet_name": wallet_name}
+    return {
+        "deleted": True,
+        "wallet_name": wallet_name,
+        "sideswap_pegs_removed": pegs_removed,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -808,6 +817,8 @@ def sideswap_peg_quote(
     Returns:
         send_amount, recv_amount, fee_amount (send - recv), peg_in
     """
+    if amount <= 0:
+        raise ValueError("Amount must be positive")
     manager = get_sideswap_peg_manager()
     return manager.quote_peg(amount, peg_in, network)
 
@@ -877,6 +888,8 @@ def sideswap_peg_out(
         order_id, lockup_txid (L-BTC send txid), peg_addr (Liquid deposit addr),
         recv_addr (target BTC addr), amount, expected_recv (if known), expires_at, message
     """
+    if amount <= 0:
+        raise ValueError("Amount must be positive")
     manager = get_sideswap_peg_manager()
     peg = manager.peg_out(wallet_name, amount, btc_address, password)
     return {

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -808,6 +808,8 @@ def sideswap_server_status(network: str = "mainnet") -> dict[str, Any]:
         server_fee_percent_peg_in, server_fee_percent_peg_out,
         peg_in_wallet_balance, peg_out_wallet_balance, optional warning
     """
+    if network not in ("mainnet", "testnet"):
+        raise ValueError(f"Unknown network: {network}")
     manager = get_sideswap_peg_manager()
     return manager.get_server_status(network)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -758,6 +758,430 @@ class TestLightningCommands:
         assert result.exit_code == 1
 
 
+# ---------------------------------------------------------------------------
+# SideSwap CLI
+# ---------------------------------------------------------------------------
+
+
+class _FakePegManager:
+    """Stand-in for SideSwapPegManager — records calls, returns canned dicts."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+        self.server_status_response: dict = {
+            "min_peg_in_amount": 1286,
+            "min_peg_out_amount": 100_000,
+            "server_fee_percent_peg_in": 0.1,
+            "server_fee_percent_peg_out": 0.1,
+            "peg_in_wallet_balance": 50_000_000,
+            "peg_out_wallet_balance": 200_000_000,
+        }
+        self.peg_quote_response: dict = {
+            "send_amount": 100_000,
+            "recv_amount": 99_900,
+            "fee_amount": 100,
+            "peg_in": True,
+        }
+        self.peg_in_response = None  # set per-test
+        self.peg_out_response = None
+        self.status_response: dict = {
+            "order_id": "ord_test",
+            "peg_in": True,
+            "status": "pending",
+            "amount": None,
+            "expected_recv": None,
+            "wallet_name": "default",
+            "network": "mainnet",
+            "peg_addr": "bc1qdeposit",
+            "recv_addr": "lq1qreceive",
+            "created_at": "2026-05-08T12:00:00+00:00",
+        }
+
+    def get_server_status(self, network):
+        self.calls.append(("get_server_status", {"network": network}))
+        return self.server_status_response
+
+    def quote_peg(self, amount, peg_in, network):
+        self.calls.append(("quote_peg", {"amount": amount, "peg_in": peg_in, "network": network}))
+        return self.peg_quote_response
+
+    def peg_in(self, wallet_name="default", password=None):
+        self.calls.append(("peg_in", {"wallet_name": wallet_name, "password": password}))
+        if self.peg_in_response is None:
+            from aqua.sideswap import SideSwapPeg
+
+            return SideSwapPeg(
+                order_id="ord_in",
+                peg_in=True,
+                peg_addr="bc1qdeposit",
+                recv_addr="lq1qreceive",
+                amount=None,
+                expected_recv=None,
+                wallet_name=wallet_name,
+                network="mainnet",
+                status="pending",
+                created_at="2026-05-08T12:00:00+00:00",
+            )
+        return self.peg_in_response
+
+    def peg_out(self, wallet_name, amount, btc_address, password=None):
+        self.calls.append(
+            ("peg_out", {
+                "wallet_name": wallet_name,
+                "amount": amount,
+                "btc_address": btc_address,
+                "password": password,
+            })
+        )
+        if self.peg_out_response is None:
+            from aqua.sideswap import SideSwapPeg
+
+            return SideSwapPeg(
+                order_id="ord_out",
+                peg_in=False,
+                peg_addr="VJLdeposit",
+                recv_addr=btc_address,
+                amount=amount,
+                expected_recv=amount - 100,
+                wallet_name=wallet_name,
+                network="mainnet",
+                status="processing",
+                created_at="2026-05-08T12:00:00+00:00",
+                lockup_txid="dead" * 16,
+            )
+        return self.peg_out_response
+
+    def status(self, order_id):
+        self.calls.append(("status", {"order_id": order_id}))
+        return {**self.status_response, "order_id": order_id}
+
+
+class _FakeSwapManager:
+    """Stand-in for SideSwapSwapManager."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+        self.execute_response = None
+        self.status_response: dict = {
+            "order_id": "mkt_42",
+            "submit_id": "42",
+            "send_asset": "lbtc",
+            "send_amount": 100_000,
+            "recv_asset": "usdt",
+            "recv_amount": 9_500_000,
+            "price": 95.0,
+            "wallet_name": "default",
+            "network": "mainnet",
+            "status": "broadcast",
+            "created_at": "2026-05-08T12:00:00+00:00",
+            "txid": "ee" * 32,
+        }
+
+    def execute_swap(self, asset_id, send_amount, wallet_name="default",
+                     password=None, send_bitcoins=True, **_):
+        self.calls.append(
+            ("execute_swap", {
+                "asset_id": asset_id,
+                "send_amount": send_amount,
+                "wallet_name": wallet_name,
+                "password": password,
+                "send_bitcoins": send_bitcoins,
+            })
+        )
+        if self.execute_response is None:
+            from aqua.sideswap import SideSwapSwap
+
+            return SideSwapSwap(
+                order_id="mkt_42",
+                submit_id="42",
+                send_asset="lbtc" if send_bitcoins else asset_id,
+                send_amount=send_amount,
+                recv_asset=asset_id if send_bitcoins else "lbtc",
+                recv_amount=9_500_000,
+                price=95.0,
+                wallet_name=wallet_name,
+                network="mainnet",
+                status="broadcast",
+                created_at="2026-05-08T12:00:00+00:00",
+                txid="ee" * 32,
+            )
+        return self.execute_response
+
+    def status(self, order_id):
+        self.calls.append(("status", {"order_id": order_id}))
+        return {**self.status_response, "order_id": order_id}
+
+
+@pytest.fixture
+def sideswap_managers():
+    """Inject fake SideSwap managers into the global tool layer."""
+    import aqua.tools as tools_module
+
+    peg = _FakePegManager()
+    swap = _FakeSwapManager()
+    saved_peg = tools_module._sideswap_peg_manager
+    saved_swap = tools_module._sideswap_swap_manager
+    tools_module._sideswap_peg_manager = peg
+    tools_module._sideswap_swap_manager = swap
+    try:
+        yield peg, swap
+    finally:
+        tools_module._sideswap_peg_manager = saved_peg
+        tools_module._sideswap_swap_manager = saved_swap
+
+
+class TestSideSwapServerStatus:
+    def test_status_uses_default_network(self, runner, sideswap_managers):
+        peg, _ = sideswap_managers
+        result = runner.invoke(cli, ["--format", "json", "sideswap", "status"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["min_peg_in_amount"] == 1286
+        assert peg.calls[-1] == ("get_server_status", {"network": "mainnet"})
+
+    def test_status_passes_testnet_flag(self, runner, sideswap_managers):
+        peg, _ = sideswap_managers
+        runner.invoke(cli, ["sideswap", "status", "--network", "testnet"])
+        assert peg.calls[-1] == ("get_server_status", {"network": "testnet"})
+
+
+class TestSideSwapRecommend:
+    def test_recommend_btc_to_lbtc(self, runner, sideswap_managers):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideswap", "recommend",
+             "--amount", "10000000", "--direction", "btc_to_lbtc"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["recommendation"] in ("peg", "swap", "either")
+        assert data["amount"] == 10_000_000
+
+    def test_recommend_lbtc_to_btc_recommends_peg(self, runner, sideswap_managers):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideswap", "recommend",
+             "--amount", "200000", "--direction", "lbtc_to_btc"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["recommendation"] == "peg"
+
+    def test_recommend_rejects_bad_direction(self, runner):
+        result = runner.invoke(
+            cli, ["sideswap", "recommend", "--amount", "1000", "--direction", "sideways"],
+        )
+        assert result.exit_code != 0
+
+
+class TestSideSwapPegQuote:
+    def test_peg_quote_default_is_peg_in(self, runner, sideswap_managers):
+        peg, _ = sideswap_managers
+        result = runner.invoke(
+            cli, ["--format", "json", "sideswap", "peg-quote", "--amount", "100000"]
+        )
+        assert result.exit_code == 0
+        last_call = peg.calls[-1]
+        assert last_call[0] == "quote_peg"
+        assert last_call[1]["peg_in"] is True
+
+    def test_peg_quote_peg_out_flag(self, runner, sideswap_managers):
+        peg, _ = sideswap_managers
+        runner.invoke(
+            cli, ["sideswap", "peg-quote", "--amount", "200000", "--peg-out"]
+        )
+        last_call = peg.calls[-1]
+        assert last_call[0] == "quote_peg"
+        assert last_call[1]["peg_in"] is False
+        assert last_call[1]["amount"] == 200_000
+
+
+class TestSideSwapPegIn:
+    def test_peg_in_returns_deposit_address(self, runner, sideswap_managers):
+        result = runner.invoke(
+            cli, ["--format", "json", "sideswap", "peg-in"],
+            env=_cli_env(),
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["peg_addr"] == "bc1qdeposit"
+        assert data["recv_addr"] == "lq1qreceive"
+        assert "order_id" in data
+        assert "message" in data
+
+    def test_peg_in_passes_wallet_name(self, runner, sideswap_managers):
+        peg, _ = sideswap_managers
+        runner.invoke(
+            cli, ["sideswap", "peg-in", "--wallet-name", "cold"],
+            env=_cli_env(),
+        )
+        peg_in_call = next(c for c in peg.calls if c[0] == "peg_in")
+        assert peg_in_call[1]["wallet_name"] == "cold"
+
+
+class TestSideSwapPegOut:
+    def test_peg_out_returns_lockup_txid(self, runner, sideswap_managers):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideswap", "peg-out",
+             "--amount", "200000", "--btc-address", "bc1qdest",
+             "--wallet-name", "default"],
+            env=_cli_env(),
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["lockup_txid"] == "dead" * 16
+        assert data["recv_addr"] == "bc1qdest"
+        assert data["amount"] == 200_000
+
+    def test_peg_out_amount_must_be_positive(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideswap", "peg-out", "--amount", "0",
+             "--btc-address", "bc1q", "--wallet-name", "default"],
+        )
+        assert result.exit_code == 2
+
+    def test_peg_out_requires_btc_address(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideswap", "peg-out", "--amount", "200000", "--wallet-name", "default"],
+        )
+        assert result.exit_code == 2
+
+
+class TestSideSwapPegStatus:
+    def test_peg_status_passes_order_id(self, runner, sideswap_managers):
+        peg, _ = sideswap_managers
+        result = runner.invoke(
+            cli, ["--format", "json", "sideswap", "peg-status", "--order-id", "ord_xyz"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["order_id"] == "ord_xyz"
+        assert peg.calls[-1] == ("status", {"order_id": "ord_xyz"})
+
+
+class TestSideSwapAssets:
+    def test_assets_invokes_quote_subscription(self, runner, sideswap_managers):
+        # The list-assets tool hits the live WS — patch fetch_assets directly
+        with patch("aqua.sideswap.fetch_assets") as fetch:
+            fetch.return_value = []
+            result = runner.invoke(
+                cli, ["--format", "json", "sideswap", "assets"]
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["network"] == "mainnet"
+        assert data["count"] == 0
+
+
+class TestSideSwapQuote:
+    def test_quote_requires_send_or_recv(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideswap", "quote", "--asset-id", "a" * 64],
+        )
+        assert result.exit_code == 2
+
+    def test_quote_rejects_both_send_and_recv(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideswap", "quote", "--asset-id", "a" * 64,
+             "--send-amount", "1000", "--recv-amount", "1000"],
+        )
+        assert result.exit_code == 2
+
+    def test_quote_requires_exactly_one_of_id_or_ticker(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideswap", "quote", "--send-amount", "1000"],
+        )
+        assert result.exit_code == 2
+
+    def test_quote_resolves_ticker_to_asset_id(self, runner, sideswap_managers):
+        with patch("aqua.sideswap.fetch_swap_quote") as fetch:
+            from aqua.sideswap import SideSwapPriceQuote
+
+            fetch.return_value = SideSwapPriceQuote(
+                asset_id="ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2",
+                send_bitcoins=True,
+                send_amount=100_000,
+                recv_amount=9_500_000,
+                price=95.0,
+                fixed_fee=100,
+            )
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "sideswap", "quote",
+                 "--asset-ticker", "USDt", "--send-amount", "100000"],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["price"] == 95.0
+        # Ticker resolved to USDt's asset_id
+        called_asset = fetch.call_args.kwargs["asset_id"]
+        assert called_asset.startswith("ce091c99")
+
+    def test_quote_unknown_ticker_errors(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideswap", "quote", "--asset-ticker", "XYZNOTAREALTOKEN", "--send-amount", "1000"],
+        )
+        assert result.exit_code == 2
+
+
+class TestSideSwapSwap:
+    def test_swap_with_yes_flag_no_prompt(self, runner, sideswap_managers):
+        _import_wallet(runner)  # so the network resolver finds a wallet
+        _, swap = sideswap_managers
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideswap", "swap",
+             "--asset-ticker", "USDt", "--amount", "100000", "--yes"],
+            env=_cli_env(),
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["status"] == "broadcast"
+        assert data["txid"] == "ee" * 32
+        # Manager was called with send_bitcoins=True (default direction)
+        execute_calls = [c for c in swap.calls if c[0] == "execute_swap"]
+        assert len(execute_calls) == 1
+        assert execute_calls[0][1]["send_bitcoins"] is True
+        assert execute_calls[0][1]["send_amount"] == 100_000
+
+    def test_swap_reverse_flag(self, runner, sideswap_managers):
+        _import_wallet(runner)
+        _, swap = sideswap_managers
+        runner.invoke(
+            cli,
+            ["sideswap", "swap", "--asset-ticker", "USDt",
+             "--amount", "9500000", "--reverse", "--yes"],
+            env=_cli_env(),
+        )
+        execute_calls = [c for c in swap.calls if c[0] == "execute_swap"]
+        assert execute_calls[-1][1]["send_bitcoins"] is False
+
+    def test_swap_amount_must_be_positive(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideswap", "swap", "--asset-ticker", "USDt", "--amount", "0", "--yes"],
+        )
+        assert result.exit_code == 2
+
+    def test_swap_status_passes_order_id(self, runner, sideswap_managers):
+        _, swap = sideswap_managers
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideswap", "swap-status", "--order-id", "mkt_77"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["order_id"] == "mkt_77"
+        assert swap.calls[-1] == ("status", {"order_id": "mkt_77"})
+
+
 # Error handling
 
 

--- a/tests/test_sideswap.py
+++ b/tests/test_sideswap.py
@@ -1,8 +1,8 @@
-"""Tests for SideSwap integration (peg + asset swap quoting).
+"""Tests for SideSwap integration (peg + asset swap quoting + execution).
 
 The WebSocket client is exercised via a fake `SideSwapWSClient` that records
-calls and returns canned responses, avoiding a real network connection. Storage
-and recommendation logic are tested directly.
+calls and returns canned responses, avoiding a real network connection. Storage,
+recommendation logic, and the PSET balance verifier are tested directly.
 """
 
 import asyncio
@@ -16,14 +16,25 @@ import pytest
 
 from aqua.sideswap import (
     PEG_RECOMMENDATION_THRESHOLD_SATS,
+    PsetVerificationError,
     SideSwapPeg,
     SideSwapPegManager,
     SideSwapPriceQuote,
     SideSwapServerStatus,
+    SideSwapSwap,
+    SideSwapWSError,
     map_peg_status,
+    parse_quote_status,
     recommend_peg_or_swap,
+    resolve_market,
+    verify_pset_balances,
 )
 from aqua.storage import Storage
+
+
+L_BTC = "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d"
+USDT = "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2"
+EVIL = "deadbeef" * 8
 
 
 # ---------------------------------------------------------------------------
@@ -94,6 +105,39 @@ class FakeWSClient:
     async def next_notification(self, method=None, *, timeout=30.0):  # noqa: ARG002
         FakeWSClient.calls.append(("notification", {"method": method}))
         notif = FakeWSClient.responses.get("__notification__")
+        if isinstance(notif, Exception):
+            raise notif
+        return notif
+
+    # mkt::* helpers — record method names with "mkt." prefix so tests can
+    # script them via FakeWSClient.responses["mkt.list_markets"] etc.
+
+    async def mkt(self, variant, params=None):
+        return await self.call(f"mkt.{variant}", params)
+
+    async def mkt_list_markets(self):
+        resp = await self.call("mkt.list_markets", {}) or {}
+        return resp.get("markets", []) or resp.get("list", []) or []
+
+    async def mkt_start_quotes(self, **params):
+        return await self.call("mkt.start_quotes", params)
+
+    async def mkt_stop_quotes(self):
+        return await self.call("mkt.stop_quotes", {})
+
+    async def mkt_get_quote(self, quote_id):
+        return await self.call("mkt.get_quote", {"quote_id": quote_id})
+
+    async def mkt_taker_sign(self, quote_id, pset_b64):
+        return await self.call(
+            "mkt.taker_sign", {"quote_id": quote_id, "pset": pset_b64}
+        )
+
+    async def next_market_notification(self, inner_variant, *, timeout=30.0):  # noqa: ARG002
+        FakeWSClient.calls.append(("mkt_notification", {"inner": inner_variant}))
+        notif = FakeWSClient.responses.get(f"__mkt_notification__:{inner_variant}")
+        if notif is None:
+            notif = FakeWSClient.responses.get("__mkt_notification__")
         if isinstance(notif, Exception):
             raise notif
         return notif
@@ -758,3 +802,1190 @@ class TestServerStatusDataclass:
         d = s.to_dict()
         assert d["min_peg_in_amount"] == 1286
         assert d["server_fee_percent_peg_in"] is None
+
+
+# ---------------------------------------------------------------------------
+# mkt::* helpers — resolve_market and parse_quote_status
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMarket:
+    """Verifies that we pick the right market and derive (asset_type, trade_dir)."""
+
+    _MARKET_USDT_LBTC = {
+        "asset_pair": {"base": USDT, "quote": L_BTC},
+        "fee_asset": "Quote",
+        "type": "Stablecoin",
+    }
+
+    def test_send_quote_side_returns_quote_sell(self):
+        # USDt is base, L-BTC is quote. Sending L-BTC = sending quote.
+        market, asset_type, trade_dir = resolve_market(
+            [self._MARKET_USDT_LBTC], send_asset=L_BTC, recv_asset=USDT
+        )
+        assert market is self._MARKET_USDT_LBTC
+        assert asset_type == "Quote"
+        assert trade_dir == "Sell"
+
+    def test_send_base_side_returns_base_sell(self):
+        # Sending USDt (base) for L-BTC.
+        _, asset_type, trade_dir = resolve_market(
+            [self._MARKET_USDT_LBTC], send_asset=USDT, recv_asset=L_BTC
+        )
+        assert asset_type == "Base"
+        assert trade_dir == "Sell"
+
+    def test_swapped_pair_orientation_still_resolves(self):
+        # If a server returned the pair with base/quote flipped, we still
+        # find it and adjust asset_type accordingly.
+        flipped = {
+            "asset_pair": {"base": L_BTC, "quote": USDT},
+            "fee_asset": "Base",
+            "type": "Stablecoin",
+        }
+        # Sending L-BTC, which is now Base.
+        _, asset_type, _ = resolve_market(
+            [flipped], send_asset=L_BTC, recv_asset=USDT
+        )
+        assert asset_type == "Base"
+
+    def test_no_matching_market_raises(self):
+        with pytest.raises(SideSwapWSError, match="No SideSwap market"):
+            resolve_market(
+                [self._MARKET_USDT_LBTC], send_asset=L_BTC, recv_asset=EVIL
+            )
+
+    def test_skips_markets_with_missing_pair(self):
+        bad = {"asset_pair": {}, "fee_asset": "Quote"}
+        market, _, _ = resolve_market(
+            [bad, self._MARKET_USDT_LBTC], send_asset=L_BTC, recv_asset=USDT
+        )
+        assert market is self._MARKET_USDT_LBTC
+
+
+class TestParseQuoteStatus:
+    """Encodes the contract for SideSwap's three QuoteStatus variants."""
+
+    def test_success_returns_inner(self):
+        notif = {
+            "status": {
+                "Success": {
+                    "quote_id": 42,
+                    "base_amount": 100,
+                    "quote_amount": 200,
+                    "server_fee": 1,
+                    "fixed_fee": 1,
+                    "ttl": 30000,
+                }
+            }
+        }
+        result = parse_quote_status(notif)
+        assert result["quote_id"] == 42
+        assert result["quote_amount"] == 200
+
+    def test_low_balance_raises_with_available(self):
+        notif = {
+            "status": {
+                "LowBalance": {
+                    "base_amount": 0,
+                    "quote_amount": 0,
+                    "server_fee": 0,
+                    "fixed_fee": 0,
+                    "available": 1234,
+                }
+            }
+        }
+        with pytest.raises(SideSwapWSError, match="low balance"):
+            parse_quote_status(notif)
+
+    def test_error_status_raises_with_message(self):
+        with pytest.raises(SideSwapWSError, match="boom"):
+            parse_quote_status({"status": {"Error": {"error_msg": "boom"}}})
+
+    def test_missing_status_raises(self):
+        with pytest.raises(SideSwapWSError):
+            parse_quote_status({})
+
+    def test_unknown_status_variant_raises(self):
+        with pytest.raises(SideSwapWSError, match="Unknown QuoteStatus"):
+            parse_quote_status({"status": {"Surprise": {}}})
+
+    def test_success_missing_quote_id_raises_ws_error_not_keyerror(self):
+        # Without validation, the int() in execute_swap would KeyError —
+        # which surfaces as a generic exception far from the cause.
+        with pytest.raises(SideSwapWSError, match="missing 'quote_id'"):
+            parse_quote_status(
+                {
+                    "status": {
+                        "Success": {
+                            "base_amount": 1,
+                            "quote_amount": 2,
+                            "server_fee": 0,
+                            "fixed_fee": 0,
+                            "ttl": 30000,
+                        }
+                    }
+                }
+            )
+
+    def test_success_non_integer_amount_raises_ws_error(self):
+        with pytest.raises(SideSwapWSError, match="not an integer"):
+            parse_quote_status(
+                {
+                    "status": {
+                        "Success": {
+                            "quote_id": 1,
+                            "base_amount": "not-a-number",
+                            "quote_amount": 2,
+                        }
+                    }
+                }
+            )
+
+    def test_success_non_dict_payload_raises(self):
+        with pytest.raises(SideSwapWSError, match="Malformed Success"):
+            parse_quote_status({"status": {"Success": "stringified"}})
+
+
+# ---------------------------------------------------------------------------
+# PSET verifier — security-critical, tested with adversarial inputs
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyPsetBalances:
+    """Encodes the security contract for `verify_pset_balances`.
+
+    This function is the only barrier between SideSwap's server and our
+    `signer.sign(pset)` call. If it accepts a malicious balance dict, we sign
+    a transaction that loses the user's funds. Each test below represents a
+    real attack class.
+    """
+
+    # -- Happy path -----------------------------------------------------------
+
+    def test_exact_match_with_no_fee_passes(self):
+        # SideSwap dealer pays the network fee, so our send_asset balance is
+        # exactly -send_amount.
+        verify_pset_balances(
+            {L_BTC: -100_000, USDT: 9_500_000},
+            send_asset=L_BTC,
+            send_amount=100_000,
+            recv_asset=USDT,
+            recv_amount=9_500_000,
+        )
+
+    def test_send_with_small_fee_within_tolerance_passes(self):
+        # Wallet pays a small Liquid fee; -100_050 is -100k + 50 sat fee.
+        verify_pset_balances(
+            {L_BTC: -100_050, USDT: 9_500_000},
+            send_asset=L_BTC,
+            send_amount=100_000,
+            recv_asset=USDT,
+            recv_amount=9_500_000,
+            fee_tolerance_sats=1_000,
+        )
+
+    # -- Attack: server delivers nothing --------------------------------------
+
+    def test_server_keeps_recv_amount_rejected(self):
+        # The deadliest attack: PSET takes our L-BTC, recv_asset balance is 0.
+        with pytest.raises(PsetVerificationError, match="delivers 0"):
+            verify_pset_balances(
+                {L_BTC: -100_000, USDT: 0},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    def test_recv_asset_missing_from_balance_rejected(self):
+        # Even if recv_asset isn't in the dict at all, it's still 0 received.
+        with pytest.raises(PsetVerificationError, match="delivers 0"):
+            verify_pset_balances(
+                {L_BTC: -100_000},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    # -- Attack: server delivers less than agreed -----------------------------
+
+    def test_short_recv_amount_rejected(self):
+        with pytest.raises(PsetVerificationError, match="delivers 9499999"):
+            verify_pset_balances(
+                {L_BTC: -100_000, USDT: 9_499_999},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    def test_excess_recv_amount_also_rejected(self):
+        # Strict equality: refuse to sign if the server is "over-delivering"
+        # too — this could signal a confused/buggy server, and we want the
+        # contract to be exact.
+        with pytest.raises(PsetVerificationError, match="delivers 10000000"):
+            verify_pset_balances(
+                {L_BTC: -100_000, USDT: 10_000_000},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    # -- Attack: server takes more than agreed --------------------------------
+
+    def test_overcharge_send_amount_rejected(self):
+        # Server takes 200k L-BTC even though we agreed to send 100k.
+        with pytest.raises(PsetVerificationError, match="deducts 200000"):
+            verify_pset_balances(
+                {L_BTC: -200_000, USDT: 9_500_000},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    def test_undercharge_send_amount_rejected(self):
+        # Less than agreed is also suspicious — possible bait-and-switch.
+        with pytest.raises(PsetVerificationError, match="less than agreed"):
+            verify_pset_balances(
+                {L_BTC: -50_000, USDT: 9_500_000},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    def test_fee_tolerance_does_not_let_attacker_steal(self):
+        # 1000-sat tolerance is for a real fee, not a 100k overage.
+        with pytest.raises(PsetVerificationError, match="more than the agreed"):
+            verify_pset_balances(
+                {L_BTC: -101_500, USDT: 9_500_000},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+                fee_tolerance_sats=1_000,
+            )
+
+    # -- Attack: extra-output / siphon ----------------------------------------
+
+    def test_unrelated_asset_movement_rejected(self):
+        # Server adds an extra output that takes some of an unrelated asset
+        # we hold (e.g. EURx, MEX). Very nasty if unchecked.
+        with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
+            verify_pset_balances(
+                {L_BTC: -100_000, USDT: 9_500_000, EVIL: -42_000},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    def test_unrelated_positive_balance_rejected(self):
+        # Even a positive movement of an unrelated asset gets rejected — we
+        # don't want surprise inputs we didn't agree to receive.
+        with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
+            verify_pset_balances(
+                {L_BTC: -100_000, USDT: 9_500_000, EVIL: 1},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    # -- Argument validation --------------------------------------------------
+
+    def test_same_send_and_recv_asset_rejected(self):
+        with pytest.raises(PsetVerificationError, match="same"):
+            verify_pset_balances(
+                {L_BTC: 0},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=L_BTC,
+                recv_amount=100_000,
+            )
+
+    def test_zero_amounts_rejected(self):
+        with pytest.raises(ValueError):
+            verify_pset_balances(
+                {}, send_asset=L_BTC, send_amount=0, recv_asset=USDT, recv_amount=1
+            )
+        with pytest.raises(ValueError):
+            verify_pset_balances(
+                {}, send_asset=L_BTC, send_amount=1, recv_asset=USDT, recv_amount=0
+            )
+
+    # -- Reverse direction (asset → L-BTC) ------------------------------------
+    # The dealer absorbs the network fee from their L-BTC contribution, so the
+    # wallet's effect is exact on BOTH sides: -send_amount of asset, +recv_amount
+    # of L-BTC. The fee tolerance must NOT relax the asset-side constraint —
+    # otherwise a hostile server could siphon up to fee_tolerance_sats of asset.
+
+    def test_reverse_exact_match_with_fee_asset_lbtc_passes(self):
+        verify_pset_balances(
+            {USDT: -9_500_000, L_BTC: 100_000},
+            send_asset=USDT,
+            send_amount=9_500_000,
+            recv_asset=L_BTC,
+            recv_amount=100_000,
+            fee_asset=L_BTC,  # fee always lives on policy asset
+        )
+
+    def test_reverse_extra_asset_taken_rejected_even_within_tolerance(self):
+        # If fee_asset defaulted to send_asset (USDT) the verifier would let
+        # a 1000-sat USDT siphon through. Pinning fee_asset=L_BTC blocks it.
+        with pytest.raises(PsetVerificationError, match="more than the agreed"):
+            verify_pset_balances(
+                {USDT: -9_500_500, L_BTC: 100_000},
+                send_asset=USDT,
+                send_amount=9_500_000,
+                recv_asset=L_BTC,
+                recv_amount=100_000,
+                fee_tolerance_sats=1_000,
+                fee_asset=L_BTC,
+            )
+
+    def test_reverse_short_lbtc_recv_rejected(self):
+        with pytest.raises(PsetVerificationError, match="delivers 99000"):
+            verify_pset_balances(
+                {USDT: -9_500_000, L_BTC: 99_000},
+                send_asset=USDT,
+                send_amount=9_500_000,
+                recv_asset=L_BTC,
+                recv_amount=100_000,
+                fee_asset=L_BTC,
+            )
+
+    def test_reverse_unrelated_asset_movement_rejected(self):
+        with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
+            verify_pset_balances(
+                {USDT: -9_500_000, L_BTC: 100_000, EVIL: -1},
+                send_asset=USDT,
+                send_amount=9_500_000,
+                recv_asset=L_BTC,
+                recv_amount=100_000,
+                fee_asset=L_BTC,
+            )
+
+    def test_default_fee_asset_is_send_asset_documented_behavior(self):
+        # Sanity-check: the default behavior is that fee_asset == send_asset.
+        # Callers who care about the reverse direction MUST pass fee_asset=L_BTC.
+        # Without it, a 1000-sat USDT siphon would be accepted — this test
+        # documents that requirement.
+        verify_pset_balances(
+            {USDT: -9_500_500, L_BTC: 100_000},
+            send_asset=USDT,
+            send_amount=9_500_000,
+            recv_asset=L_BTC,
+            recv_amount=100_000,
+            fee_tolerance_sats=1_000,
+            # fee_asset NOT specified — defaults to send_asset (USDT)
+        )
+
+    def test_negative_fee_tolerance_rejected(self):
+        with pytest.raises(ValueError):
+            verify_pset_balances(
+                {},
+                send_asset=L_BTC,
+                send_amount=1,
+                recv_asset=USDT,
+                recv_amount=1,
+                fee_tolerance_sats=-1,
+            )
+
+
+# ---------------------------------------------------------------------------
+# SideSwapSwap dataclass + storage round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSideSwapSwap:
+    def _make(self, **overrides) -> SideSwapSwap:
+        defaults = dict(
+            order_id="ord_xyz",
+            submit_id="sub_abc",
+            send_asset=L_BTC,
+            send_amount=100_000,
+            recv_asset=USDT,
+            recv_amount=9_500_000,
+            price=95.0,
+            wallet_name="default",
+            network="mainnet",
+            status="pending",
+            created_at="2026-05-07T12:00:00+00:00",
+        )
+        defaults.update(overrides)
+        return SideSwapSwap(**defaults)
+
+    def test_roundtrip_to_dict_from_dict(self):
+        original = self._make(txid="tx" * 32, last_error="some error")
+        reconstructed = SideSwapSwap.from_dict(original.to_dict())
+        assert reconstructed == original
+
+    def test_from_dict_backward_compat(self):
+        # Earlier files might lack txid/last_error
+        data = {
+            "order_id": "old1",
+            "submit_id": None,
+            "send_asset": L_BTC,
+            "send_amount": 1,
+            "recv_asset": USDT,
+            "recv_amount": 1,
+            "price": 1.0,
+            "wallet_name": "w",
+            "network": "mainnet",
+            "status": "pending",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+        swap = SideSwapSwap.from_dict(data)
+        assert swap.txid is None
+        assert swap.last_error is None
+
+
+# ---------------------------------------------------------------------------
+# UTXO selection
+# ---------------------------------------------------------------------------
+
+
+class _Outpoint:
+    def __init__(self, txid_hex: str, vout: int):
+        self._txid = txid_hex
+        self._vout = vout
+
+    def txid(self):
+        return self._txid
+
+    def vout(self):
+        return self._vout
+
+
+class _Unblinded:
+    def __init__(self, asset: str, value: int, asset_bf: str, value_bf: str):
+        self._asset = asset
+        self._value = value
+        self._asset_bf = asset_bf
+        self._value_bf = value_bf
+
+    def asset(self):
+        return self._asset
+
+    def value(self):
+        return self._value
+
+    def asset_bf(self):
+        return self._asset_bf
+
+    def value_bf(self):
+        return self._value_bf
+
+
+class _FakeUtxo:
+    def __init__(self, txid_hex: str, vout: int, asset: str, value: int,
+                 asset_bf: str = "ab" * 32, value_bf: str = "cd" * 32):
+        self._outpoint = _Outpoint(txid_hex, vout)
+        self._unblinded = _Unblinded(asset, value, asset_bf, value_bf)
+
+    def outpoint(self):
+        return self._outpoint
+
+    def unblinded(self):
+        return self._unblinded
+
+
+class TestSelectSwapUtxos:
+    def test_selects_largest_first(self):
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [
+            _FakeUtxo("aa" * 32, 0, L_BTC, 50_000),
+            _FakeUtxo("bb" * 32, 1, L_BTC, 200_000),
+            _FakeUtxo("cc" * 32, 0, L_BTC, 100_000),
+        ]
+        selected = select_swap_utxos(utxos, L_BTC, 150_000)
+        assert len(selected) == 1
+        assert selected[0]["value"] == 200_000
+
+    def test_accumulates_across_multiple_utxos(self):
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [
+            _FakeUtxo("aa" * 32, 0, L_BTC, 30_000),
+            _FakeUtxo("bb" * 32, 0, L_BTC, 30_000),
+            _FakeUtxo("cc" * 32, 0, L_BTC, 30_000),
+        ]
+        selected = select_swap_utxos(utxos, L_BTC, 70_000)
+        assert len(selected) == 3
+        assert sum(s["value"] for s in selected) == 90_000
+        for s in selected:
+            assert s["redeem_script"] is None
+
+    def test_skips_other_assets(self):
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [
+            _FakeUtxo("aa" * 32, 0, USDT, 9_000_000),
+            _FakeUtxo("bb" * 32, 0, L_BTC, 100_000),
+        ]
+        selected = select_swap_utxos(utxos, L_BTC, 50_000)
+        assert len(selected) == 1
+        assert selected[0]["asset"] == L_BTC
+
+    def test_skips_non_confidential_utxos(self):
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [
+            # Both blinding factors zero = non-confidential, must be skipped
+            _FakeUtxo("aa" * 32, 0, L_BTC, 100_000, asset_bf="0" * 64, value_bf="0" * 64),
+            _FakeUtxo("bb" * 32, 0, L_BTC, 50_000),
+        ]
+        selected = select_swap_utxos(utxos, L_BTC, 50_000)
+        assert len(selected) == 1
+        assert selected[0]["txid"] == "bb" * 32
+
+    def test_insufficient_funds_raises(self):
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [_FakeUtxo("aa" * 32, 0, L_BTC, 10_000)]
+        with pytest.raises(ValueError, match="Insufficient confidential balance"):
+            select_swap_utxos(utxos, L_BTC, 50_000)
+
+
+# ---------------------------------------------------------------------------
+# SwapManager — integration with mocked WS + LWK
+# ---------------------------------------------------------------------------
+
+
+class _FakeWollet:
+    """Stand-in for `lwk.Wollet`. The manager only calls .utxos(), .address(),
+    and .pset_details(pset)."""
+
+    def __init__(self, utxos: list, balances: dict[str, int]):
+        self._utxos = utxos
+        self._balances = balances
+        self._addr_idx = 0
+
+    def utxos(self):
+        return self._utxos
+
+    def address(self, _index):
+        idx = self._addr_idx
+        self._addr_idx += 1
+        return _FakeAddrResult(f"lq1qaddr{idx}", idx)
+
+    def pset_details(self, _pset):
+        return _FakePsetDetails(self._balances)
+
+
+class _FakeAddrResult:
+    def __init__(self, addr_str, idx):
+        self._addr = addr_str
+        self._idx = idx
+
+    def address(self):
+        return self._addr
+
+    def index(self):
+        return self._idx
+
+
+class _FakePsetDetails:
+    def __init__(self, balances: dict[str, int]):
+        self._balances = balances
+
+    def balance(self):
+        return _FakePsetBalance(self._balances)
+
+
+class _FakePsetBalance:
+    def __init__(self, balances: dict[str, int]):
+        self._b = balances
+
+    def balances(self):
+        return dict(self._b)
+
+    def fee(self):
+        return 50
+
+    def recipients(self):
+        return []
+
+
+class _FakeSigner:
+    def __init__(self):
+        self.signed: list = []
+
+    def sign(self, pset):
+        self.signed.append(pset)
+
+        class _Signed:
+            def __str__(self):
+                return "cHNldP8BSIGNED"
+
+        return _Signed()
+
+
+@pytest.fixture
+def swap_manager_setup(storage):
+    """Build a SideSwapSwapManager with mocked LWK + WS + HTTP layers."""
+    from aqua.sideswap import SideSwapSwapManager
+    from aqua.storage import WalletData
+
+    wallet = WalletData(
+        name="default",
+        network="testnet",
+        descriptor="ct(slip77(deadbeef),elwpkh([fp/84'/1776'/0']tpubD.../0/*))",
+        encrypted_mnemonic=None,
+    )
+    storage.save_wallet(wallet)
+
+    fake_signer = _FakeSigner()
+    fake_wollet = _FakeWollet(
+        utxos=[_FakeUtxo("aa" * 32, 0, L_BTC, 500_000)],
+        balances={L_BTC: -100_050, USDT: 9_500_000},  # honest balance
+    )
+
+    class FakeWalletManager:
+        def __init__(self):
+            self._signers = {"default": fake_signer}
+            self._wollets = {"default": fake_wollet}
+            self.synced = []
+
+        def load_wallet(self, name, password=None):  # noqa: ARG002
+            return wallet
+
+        def sync_wallet(self, name):
+            self.synced.append(name)
+
+        def _get_policy_asset(self, network):  # noqa: ARG002
+            return L_BTC
+
+        def _get_wollet(self, name):
+            return self._wollets[name]
+
+    wm = FakeWalletManager()
+    mgr = SideSwapSwapManager(storage=storage, wallet_manager=wm)
+    return mgr, wm, fake_wollet, fake_signer, storage
+
+
+def _patch_swap_layers():
+    """Patch WS + lwk.Pset for the manager flow."""
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    stack.enter_context(_patch_ws())
+
+    # Patch lwk.Pset to a no-op shim — we don't have real PSETs in tests
+    class _FakePset:
+        def __init__(self, b64):
+            self.b64 = b64
+
+    import lwk
+
+    stack.enter_context(patch.object(lwk, "Pset", _FakePset))
+    return stack
+
+
+def _setup_mkt_responses_forward():
+    """Script the FakeWSClient with a clean L-BTC → USDt mkt::* flow.
+
+    The market base is USDt and quote is L-BTC, so for sending L-BTC the
+    `asset_type` is "Quote" (matching the wire format).
+    """
+    FakeWSClient.responses["mkt.list_markets"] = {
+        "markets": [
+            {
+                "asset_pair": {"base": USDT, "quote": L_BTC},
+                "fee_asset": "Quote",
+                "type": "Stablecoin",
+            }
+        ]
+    }
+    FakeWSClient.responses["mkt.start_quotes"] = {"quote_sub_id": 7, "fee_asset": "Quote"}
+    FakeWSClient.responses["__mkt_notification__:quote"] = {
+        "quote_sub_id": 7,
+        "asset_pair": {"base": USDT, "quote": L_BTC},
+        "asset_type": "Quote",
+        "amount": 100_000,
+        "trade_dir": "Sell",
+        "status": {
+            "Success": {
+                "quote_id": 42,
+                # market is base=USDt, quote=L-BTC. We're sending L-BTC (Quote).
+                # base_amount is in USDt, quote_amount is in L-BTC.
+                "base_amount": 9_500_000,
+                "quote_amount": 100_000,
+                "server_fee": 100,
+                "fixed_fee": 100,
+                "ttl": 30_000,
+            }
+        },
+    }
+    FakeWSClient.responses["mkt.get_quote"] = {
+        "pset": "cHNldP8BUNSIGNED",
+        "ttl": 30_000,
+        "receive_ephemeral_sk": "00" * 32,
+        "change_ephemeral_sk": "00" * 32,
+    }
+    FakeWSClient.responses["mkt.taker_sign"] = {"txid": "ee" * 32}
+    FakeWSClient.responses["mkt.stop_quotes"] = {}
+
+
+def _setup_mkt_responses_reverse():
+    """Script the FakeWSClient with a clean USDt → L-BTC mkt::* flow."""
+    FakeWSClient.responses["mkt.list_markets"] = {
+        "markets": [
+            {
+                "asset_pair": {"base": USDT, "quote": L_BTC},
+                "fee_asset": "Quote",
+                "type": "Stablecoin",
+            }
+        ]
+    }
+    FakeWSClient.responses["mkt.start_quotes"] = {"quote_sub_id": 7, "fee_asset": "Quote"}
+    FakeWSClient.responses["__mkt_notification__:quote"] = {
+        "quote_sub_id": 7,
+        "asset_pair": {"base": USDT, "quote": L_BTC},
+        "asset_type": "Base",  # we're sending USDt = Base
+        "amount": 9_500_000,
+        "trade_dir": "Sell",
+        "status": {
+            "Success": {
+                "quote_id": 99,
+                "base_amount": 9_500_000,
+                "quote_amount": 100_000,
+                "server_fee": 100,
+                "fixed_fee": 100,
+                "ttl": 30_000,
+            }
+        },
+    }
+    FakeWSClient.responses["mkt.get_quote"] = {
+        "pset": "cHNldP8BUNSIGNED",
+        "ttl": 30_000,
+        "receive_ephemeral_sk": "00" * 32,
+        "change_ephemeral_sk": "00" * 32,
+    }
+    FakeWSClient.responses["mkt.taker_sign"] = {"txid": "ee" * 32}
+    FakeWSClient.responses["mkt.stop_quotes"] = {}
+
+
+def _start_quotes_call_args():
+    """Return the params dict from the most recent `mkt.start_quotes` call."""
+    for method, params in reversed(FakeWSClient.calls):
+        if method == "mkt.start_quotes":
+            return params
+    return None
+
+
+class TestSwapManagerExecute:
+    """Forward direction (L-BTC → USDt) via the mkt::* flow."""
+
+    def test_happy_path_end_to_end(self, swap_manager_setup):
+        mgr, _, _, fake_signer, storage = swap_manager_setup
+        _setup_mkt_responses_forward()
+
+        with _patch_swap_layers():
+            swap = mgr.execute_swap(
+                asset_id=USDT, send_amount=100_000, wallet_name="default"
+            )
+
+        assert swap.status == "broadcast"
+        assert swap.txid == "ee" * 32
+        # quote_id 42 → order_id "mkt_42" (so the storage layer keeps a
+        # filename-safe stable id even though the protocol identifies a swap
+        # by quote_id, not order_id)
+        assert swap.order_id == "mkt_42"
+        assert swap.submit_id == "42"
+        # We did sign exactly once
+        assert len(fake_signer.signed) == 1
+        # taker_sign call carried the signed PSET
+        taker_sign_calls = [(m, p) for m, p in FakeWSClient.calls if m == "mkt.taker_sign"]
+        assert len(taker_sign_calls) == 1
+        assert taker_sign_calls[0][1]["pset"] == "cHNldP8BSIGNED"
+        # Persisted across the whole flow
+        loaded = storage.load_sideswap_swap("mkt_42")
+        assert loaded is not None
+        assert loaded.status == "broadcast"
+
+    def test_start_quotes_uses_sell_and_correct_asset_type(self, swap_manager_setup):
+        # For L-BTC → USDt with a market where USDt is base and L-BTC is quote,
+        # we send the quote side. asset_type must be "Quote", trade_dir "Sell".
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        with _patch_swap_layers():
+            mgr.execute_swap(asset_id=USDT, send_amount=100_000, wallet_name="default")
+        params = _start_quotes_call_args()
+        assert params["asset_type"] == "Quote"
+        assert params["trade_dir"] == "Sell"
+        assert params["amount"] == 100_000
+        assert params["instant_swap"] is True
+        assert params["receive_address"] is not None
+        assert params["change_address"] is not None
+        assert params["receive_address"] != params["change_address"]
+        assert all(u["asset"] == L_BTC for u in params["utxos"])
+
+    def test_aborts_when_pset_balance_does_not_match(self, swap_manager_setup):
+        # The deadly attack: server crafts a PSET that takes our L-BTC but the
+        # recv_asset balance is 0.
+        mgr, _, fake_wollet, fake_signer, storage = swap_manager_setup
+        _setup_mkt_responses_forward()
+        fake_wollet._balances = {L_BTC: -100_000, USDT: 0}
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+        # Critically: never signed, never submitted via taker_sign
+        assert len(fake_signer.signed) == 0
+        assert not any(m == "mkt.taker_sign" for m, _ in FakeWSClient.calls)
+        # Persisted as failed for forensics
+        loaded = storage.load_sideswap_swap("mkt_42")
+        assert loaded is not None
+        assert loaded.status == "failed"
+        assert "PSET verification failed" in (loaded.last_error or "")
+
+    def test_aborts_when_pset_takes_extra_lbtc(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        fake_wollet._balances = {L_BTC: -200_000, USDT: 9_500_000}
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="more than the agreed"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+        assert len(fake_signer.signed) == 0
+
+    def test_aborts_when_pset_moves_unrelated_asset(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        fake_wollet._balances = {L_BTC: -100_050, USDT: 9_500_000, EVIL: -500}
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+        assert len(fake_signer.signed) == 0
+
+    def test_rejects_swap_lbtc_for_lbtc(self, swap_manager_setup):
+        mgr, _, _, _, _ = swap_manager_setup
+        with _patch_swap_layers():
+            with pytest.raises(ValueError, match="non-L-BTC"):
+                mgr.execute_swap(
+                    asset_id=L_BTC, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_rejects_unknown_wallet(self, swap_manager_setup):
+        mgr, _, _, _, _ = swap_manager_setup
+        with pytest.raises(ValueError, match="not found"):
+            mgr.execute_swap(
+                asset_id=USDT, send_amount=100_000, wallet_name="ghost"
+            )
+
+    def test_quote_lowbalance_raises(self, swap_manager_setup):
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        FakeWSClient.responses["mkt.list_markets"] = {
+            "markets": [{"asset_pair": {"base": USDT, "quote": L_BTC}, "fee_asset": "Quote", "type": "Stablecoin"}]
+        }
+        FakeWSClient.responses["mkt.start_quotes"] = {"quote_sub_id": 1, "fee_asset": "Quote"}
+        FakeWSClient.responses["__mkt_notification__:quote"] = {
+            "quote_sub_id": 1,
+            "asset_pair": {"base": USDT, "quote": L_BTC},
+            "asset_type": "Quote",
+            "amount": 100_000,
+            "trade_dir": "Sell",
+            "status": {
+                "LowBalance": {
+                    "base_amount": 0,
+                    "quote_amount": 0,
+                    "server_fee": 0,
+                    "fixed_fee": 0,
+                    "available": 1_000,
+                }
+            },
+        }
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="low balance"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_quote_error_raises(self, swap_manager_setup):
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        FakeWSClient.responses["mkt.list_markets"] = {
+            "markets": [{"asset_pair": {"base": USDT, "quote": L_BTC}, "fee_asset": "Quote", "type": "Stablecoin"}]
+        }
+        FakeWSClient.responses["mkt.start_quotes"] = {"quote_sub_id": 1, "fee_asset": "Quote"}
+        FakeWSClient.responses["__mkt_notification__:quote"] = {
+            "quote_sub_id": 1,
+            "asset_pair": {"base": USDT, "quote": L_BTC},
+            "asset_type": "Quote",
+            "amount": 100_000,
+            "trade_dir": "Sell",
+            "status": {"Error": {"error_msg": "no_dealers"}},
+        }
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="no_dealers"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_no_market_for_pair_raises(self, swap_manager_setup):
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        # Empty market list — no L-BTC/USDt pair available
+        FakeWSClient.responses["mkt.list_markets"] = {"markets": []}
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="No SideSwap market"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_quote_send_amount_mismatch_raises(self, swap_manager_setup):
+        # If the dealer's quote contradicts what we asked for, abort. This is
+        # an additional belt-and-braces check on top of the PSET verifier.
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        # Pretend the dealer offered 200k of L-BTC instead of the 100k we asked
+        FakeWSClient.responses["__mkt_notification__:quote"]["status"]["Success"]["quote_amount"] = 200_000
+
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="send_amount mismatch"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_flexible_small_amount_within_tolerance_accepts(
+        self, swap_manager_setup
+    ):
+        # Small swap where the dealer rounds the send amount slightly. With
+        # flexible_small_amount=True the manager accepts the dealer's number
+        # rather than rejecting on strict equality. The PSET verifier still
+        # checks the wallet's actual balance change, so the user can't be
+        # debited more than the dealer's quote either way.
+        mgr, _, fake_wollet, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        # Forward = L-BTC → USDt; send (L-BTC) is the "quote" side of the market.
+        FakeWSClient.responses["__mkt_notification__:quote"]["status"]["Success"]["quote_amount"] = 102_000
+        # Honest wallet balance change matches the dealer's adjusted send.
+        fake_wollet._balances = {L_BTC: -102_050, USDT: 9_500_000}
+
+        with _patch_swap_layers():
+            swap = mgr.execute_swap(
+                asset_id=USDT,
+                send_amount=100_000,
+                wallet_name="default",
+                flexible_small_amount=True,
+            )
+        # Manager records the dealer's adjusted send_amount.
+        assert swap.send_amount == 102_000
+
+    def test_flexible_small_amount_outside_tolerance_rejects(
+        self, swap_manager_setup
+    ):
+        # Beyond ±3000 sats the rounding explanation no longer fits — the
+        # dealer is offering a materially different quote, so reject even
+        # with the flag set. Protects against accepting a real price move
+        # disguised as rounding.
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        FakeWSClient.responses["__mkt_notification__:quote"]["status"]["Success"]["quote_amount"] = 110_000
+
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="send_amount mismatch"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=100_000,
+                    wallet_name="default",
+                    flexible_small_amount=True,
+                )
+
+    def test_flexible_small_amount_default_off_strict(self, swap_manager_setup):
+        # Without the flag, even a small dealer rounding still rejects —
+        # preserves prior behavior for non-interactive callers.
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        FakeWSClient.responses["__mkt_notification__:quote"]["status"]["Success"]["quote_amount"] = 100_500
+
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="send_amount mismatch"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_swap_status_returns_persisted(self, swap_manager_setup):
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        with _patch_swap_layers():
+            mgr.execute_swap(
+                asset_id=USDT, send_amount=100_000, wallet_name="default"
+            )
+        result = mgr.status("mkt_42")
+        assert result["order_id"] == "mkt_42"
+        assert result["status"] == "broadcast"
+        assert result["txid"] == "ee" * 32
+        assert result["recv_asset"] == USDT
+        assert result["recv_amount"] == 9_500_000
+
+    def test_swap_status_unknown_raises(self, swap_manager_setup):
+        mgr, _, _, _, _ = swap_manager_setup
+        with pytest.raises(ValueError, match="not found"):
+            mgr.status("doesnotexist")
+
+
+class TestSwapManagerReverseExecute:
+    """Reverse direction: asset → L-BTC via the mkt::* flow.
+
+    The dealer absorbs the network fee from their L-BTC contribution, so the
+    wallet's effect is exact on both sides: -send_amount of asset and
+    +recv_amount of L-BTC. The verifier MUST NOT allow any siphon of the
+    asset side via fee_tolerance — `fee_asset` is pinned to L-BTC.
+    """
+
+    def test_reverse_happy_path_end_to_end(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, storage = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000}
+        _setup_mkt_responses_reverse()
+
+        with _patch_swap_layers():
+            swap = mgr.execute_swap(
+                asset_id=USDT,
+                send_amount=9_500_000,
+                wallet_name="default",
+                send_bitcoins=False,
+            )
+
+        assert swap.status == "broadcast"
+        assert swap.send_asset == USDT
+        assert swap.send_amount == 9_500_000
+        assert swap.recv_asset == L_BTC
+        assert swap.recv_amount == 100_000
+        # Manager asked SideSwap with asset_type=Base, trade_dir=Sell
+        params = _start_quotes_call_args()
+        assert params["asset_type"] == "Base"
+        assert params["trade_dir"] == "Sell"
+        assert all(u["asset"] == USDT for u in params["utxos"])
+        # Signed once, submitted once
+        assert len(fake_signer.signed) == 1
+        taker_sign_calls = [(m, p) for m, p in FakeWSClient.calls if m == "mkt.taker_sign"]
+        assert len(taker_sign_calls) == 1
+        loaded = storage.load_sideswap_swap("mkt_99")
+        assert loaded is not None
+        assert loaded.send_asset == USDT
+        assert loaded.recv_asset == L_BTC
+
+    def test_reverse_aborts_on_asset_siphon_within_lbtc_tolerance(self, swap_manager_setup):
+        # Server takes 500 sat extra USDT but delivers correct L-BTC. If
+        # fee_asset were accidentally USDT, the 1000-sat tolerance would let
+        # this slip through. We pin fee_asset=L-BTC so the asset side is exact.
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
+        fake_wollet._balances = {USDT: -9_500_500, L_BTC: 100_000}
+        _setup_mkt_responses_reverse()
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="more than the agreed"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=9_500_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )
+        assert len(fake_signer.signed) == 0
+        assert not any(m == "mkt.taker_sign" for m, _ in FakeWSClient.calls)
+
+    def test_reverse_aborts_on_short_lbtc_delivery(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 99_000}
+        _setup_mkt_responses_reverse()
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="delivers 99000"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=9_500_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )
+        assert len(fake_signer.signed) == 0
+
+    def test_reverse_aborts_on_unrelated_asset_movement(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000, EVIL: -1}
+        _setup_mkt_responses_reverse()
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=9_500_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )
+        assert len(fake_signer.signed) == 0
+
+    def test_reverse_picks_asset_utxos_not_lbtc(self, swap_manager_setup):
+        mgr, _, fake_wollet, _, _ = swap_manager_setup
+        fake_wollet._utxos = [
+            _FakeUtxo("aa" * 32, 0, L_BTC, 5_000_000),
+            _FakeUtxo("bb" * 32, 0, USDT, 50_000_000),
+        ]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000}
+        _setup_mkt_responses_reverse()
+
+        with _patch_swap_layers():
+            mgr.execute_swap(
+                asset_id=USDT,
+                send_amount=9_500_000,
+                wallet_name="default",
+                send_bitcoins=False,
+            )
+        params = _start_quotes_call_args()
+        assert all(u["asset"] == USDT for u in params["utxos"])
+        assert len(params["utxos"]) == 1
+
+    def test_reverse_insufficient_asset_balance_raises(self, swap_manager_setup):
+        mgr, _, fake_wollet, _, _ = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 1_000_000)]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000}
+        _setup_mkt_responses_reverse()
+
+        with _patch_swap_layers():
+            with pytest.raises(ValueError, match="Insufficient confidential balance"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=9_500_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )
+
+    def test_reverse_rejects_lbtc_as_asset_id(self, swap_manager_setup):
+        mgr, _, _, _, _ = swap_manager_setup
+        with _patch_swap_layers():
+            with pytest.raises(ValueError, match="non-L-BTC"):
+                mgr.execute_swap(
+                    asset_id=L_BTC,
+                    send_amount=100_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )

--- a/tests/test_sideswap.py
+++ b/tests/test_sideswap.py
@@ -1,0 +1,716 @@
+"""Tests for SideSwap integration (peg + asset swap quoting).
+
+The WebSocket client is exercised via a fake `SideSwapWSClient` that records
+calls and returns canned responses, avoiding a real network connection. Storage
+and recommendation logic are tested directly.
+"""
+
+import asyncio
+import tempfile
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from aqua.sideswap import (
+    PEG_RECOMMENDATION_THRESHOLD_SATS,
+    SideSwapPeg,
+    SideSwapPegManager,
+    SideSwapPriceQuote,
+    SideSwapServerStatus,
+    map_peg_status,
+    recommend_peg_or_swap,
+)
+from aqua.storage import Storage
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeWSClient:
+    """Stand-in for SideSwapWSClient — records calls, returns canned responses.
+
+    Use class attribute ``responses`` (mapping method name -> result/exception)
+    to script behavior per test. Use ``responses_seq`` for queued responses
+    when the same method is called multiple times with different results.
+    """
+
+    responses: dict[str, Any] = {}
+    responses_seq: dict[str, list[Any]] = {}
+    calls: list[tuple[str, dict | None]] = []
+
+    def __init__(self, network: str = "mainnet") -> None:
+        self.network = network
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def call(self, method: str, params=None, *, timeout=30.0):  # noqa: ARG002
+        FakeWSClient.calls.append((method, params))
+        if method in FakeWSClient.responses_seq and FakeWSClient.responses_seq[method]:
+            value = FakeWSClient.responses_seq[method].pop(0)
+        else:
+            value = FakeWSClient.responses.get(method)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    async def login_client(self):
+        return await self.call("login_client", {})
+
+    async def server_status(self):
+        return await self.call("server_status", None)
+
+    async def peg_fee(self, send_amount, peg_in):
+        return await self.call("peg_fee", {"send_amount": send_amount, "peg_in": peg_in})
+
+    async def peg(self, recv_addr, peg_in):
+        return await self.call("peg", {"recv_addr": recv_addr, "peg_in": peg_in})
+
+    async def peg_status(self, order_id, peg_in):
+        return await self.call("peg_status", {"order_id": order_id, "peg_in": peg_in})
+
+    async def assets(self, embedded_icons=False):
+        return await self.call("assets", {"all_assets": True, "embedded_icons": embedded_icons})
+
+    async def subscribe_price_stream(self, asset, send_bitcoins, send_amount=None, recv_amount=None):
+        params = {"asset": asset, "send_bitcoins": send_bitcoins}
+        if send_amount is not None:
+            params["send_amount"] = send_amount
+        if recv_amount is not None:
+            params["recv_amount"] = recv_amount
+        return await self.call("subscribe_price_stream", params)
+
+    async def unsubscribe_price_stream(self, asset):
+        return await self.call("unsubscribe_price_stream", {"asset": asset})
+
+    async def next_notification(self, method=None, *, timeout=30.0):  # noqa: ARG002
+        FakeWSClient.calls.append(("notification", {"method": method}))
+        notif = FakeWSClient.responses.get("__notification__")
+        if isinstance(notif, Exception):
+            raise notif
+        return notif
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_ws():
+    FakeWSClient.responses = {}
+    FakeWSClient.responses_seq = {}
+    FakeWSClient.calls = []
+    yield
+    FakeWSClient.responses = {}
+    FakeWSClient.responses_seq = {}
+    FakeWSClient.calls = []
+
+
+@pytest.fixture
+def storage():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Storage(Path(tmpdir))
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestMapPegStatus:
+    def test_empty_list_is_pending(self):
+        assert map_peg_status(None, list_empty=True) == "pending"
+
+    @pytest.mark.parametrize("state, expected", [
+        ("Detected", "processing"),
+        ("Processing", "processing"),
+        ("Done", "completed"),
+        ("InsufficientAmount", "failed"),
+        ("Unknown", "pending"),
+        (None, "pending"),
+    ])
+    def test_state_mapping(self, state, expected):
+        assert map_peg_status(state, list_empty=False) == expected
+
+
+class TestRecommendPegOrSwap:
+    def test_lbtc_to_btc_always_recommends_peg(self):
+        rec = recommend_peg_or_swap(50_000, "lbtc_to_btc")
+        assert rec["recommendation"] == "peg"
+        assert "peg-out" in rec["reason"].lower()
+
+    def test_btc_to_lbtc_above_threshold_recommends_peg(self):
+        rec = recommend_peg_or_swap(PEG_RECOMMENDATION_THRESHOLD_SATS, "btc_to_lbtc")
+        assert rec["recommendation"] == "peg"
+
+    def test_btc_to_lbtc_below_threshold_returns_either(self):
+        rec = recommend_peg_or_swap(PEG_RECOMMENDATION_THRESHOLD_SATS - 1, "btc_to_lbtc")
+        assert rec["recommendation"] == "either"
+
+    def test_warns_when_amount_exceeds_hot_wallet(self):
+        rec = recommend_peg_or_swap(
+            10_000_000_000,
+            "btc_to_lbtc",
+            server_status={"peg_in_wallet_balance": 100_000_000},
+        )
+        assert rec["recommendation"] == "peg"
+        assert "cold-wallet" in rec["reason"]
+        assert "102" in rec["reason"]
+
+    def test_invalid_direction_raises(self):
+        with pytest.raises(ValueError):
+            recommend_peg_or_swap(1000, "nope")
+
+
+# ---------------------------------------------------------------------------
+# Storage round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestPegStorage:
+    def _make_peg(self, **overrides) -> SideSwapPeg:
+        defaults = {
+            "order_id": "abc123",
+            "peg_in": True,
+            "peg_addr": "bc1qpegtarget",
+            "recv_addr": "lq1qrecv",
+            "amount": None,
+            "expected_recv": 99_900,
+            "wallet_name": "default",
+            "network": "mainnet",
+            "status": "pending",
+            "created_at": "2026-05-07T12:00:00+00:00",
+        }
+        defaults.update(overrides)
+        return SideSwapPeg(**defaults)
+
+    def test_save_and_load_roundtrip(self, storage):
+        peg = self._make_peg(lockup_txid="dead" * 16, payout_txid="beef" * 16)
+        storage.save_sideswap_peg(peg)
+        loaded = storage.load_sideswap_peg("abc123")
+        assert loaded is not None
+        assert loaded == peg
+
+    def test_load_missing_returns_none(self, storage):
+        assert storage.load_sideswap_peg("doesnotexist") is None
+
+    def test_list_pegs(self, storage):
+        storage.save_sideswap_peg(self._make_peg(order_id="aaa"))
+        storage.save_sideswap_peg(self._make_peg(order_id="bbb", peg_in=False))
+        ids = storage.list_sideswap_pegs()
+        assert set(ids) == {"aaa", "bbb"}
+
+    def test_invalid_order_id_rejected(self, storage):
+        peg = self._make_peg(order_id="../escape")
+        with pytest.raises(ValueError, match="Invalid SideSwap order ID"):
+            storage.save_sideswap_peg(peg)
+
+    @pytest.mark.skipif(
+        __import__("sys").platform == "win32",
+        reason="POSIX file permissions not enforced on Windows",
+    )
+    def test_file_permissions_0600(self, storage):
+        import os
+
+        peg = self._make_peg()
+        storage.save_sideswap_peg(peg)
+        path = storage.sideswap_pegs_dir / "abc123.json"
+        assert path.exists()
+        assert (os.stat(path).st_mode & 0o777) == 0o600
+
+    def test_from_dict_backward_compat(self):
+        # Older record without the optional fields should still load
+        data = {
+            "order_id": "old1",
+            "peg_in": True,
+            "peg_addr": "bc1q",
+            "recv_addr": "lq1q",
+            "amount": None,
+            "expected_recv": None,
+            "wallet_name": "w",
+            "network": "mainnet",
+            "status": "pending",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+        peg = SideSwapPeg.from_dict(data)
+        assert peg.lockup_txid is None
+        assert peg.payout_txid is None
+        assert peg.detected_confs is None
+
+
+# ---------------------------------------------------------------------------
+# Manager (with mocked WS client)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager_setup(storage):
+    """Build a SideSwapPegManager with mocked wallet manager and mocked WS client.
+
+    The wallet_manager fake supports the methods the manager calls:
+    `get_address`, `get_balance`, `send`, `load_wallet`. The storage fixture
+    holds a real WalletData so wallet existence checks pass.
+    """
+    from aqua.storage import WalletData
+    from aqua.wallet import Address, Balance
+
+    wallet = WalletData(
+        name="default",
+        network="mainnet",
+        descriptor="ct(slip77(deadbeef),elwpkh([fp/84'/1776'/0']tpubD.../0/*))",
+        encrypted_mnemonic=None,
+    )
+    storage.save_wallet(wallet)
+
+    class FakeWalletManager:
+        def __init__(self):
+            self.sent: list[tuple[str, str, int, str | None]] = []
+            self.balance_lbtc = 1_000_000
+
+        def get_address(self, name, index=None):  # noqa: ARG002
+            return Address(address="lq1qreceiveaddr", index=0)
+
+        def get_balance(self, name):  # noqa: ARG002
+            return [
+                Balance(
+                    asset_id="6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d",
+                    asset_name="Liquid Bitcoin",
+                    ticker="L-BTC",
+                    amount=self.balance_lbtc,
+                    precision=8,
+                )
+            ]
+
+        def send(self, name, address, amount, password=None):  # noqa: ARG002
+            self.sent.append((name, address, amount, password))
+            return "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+        def load_wallet(self, name, password=None):  # noqa: ARG002
+            return wallet
+
+    wm = FakeWalletManager()
+    btc = object()  # not exercised directly by these tests
+    mgr = SideSwapPegManager(storage=storage, wallet_manager=wm, btc_wallet_manager=btc)
+    return mgr, wm, storage
+
+
+@asynccontextmanager
+async def _fake_ctx(*args, **kwargs):  # noqa: ARG001
+    yield FakeWSClient()
+
+
+def _patch_ws():
+    """Patch the WS client used inside sideswap.py."""
+    return patch("aqua.sideswap.SideSwapWSClient", FakeWSClient)
+
+
+class TestServerStatus:
+    def test_fetch_server_status_parses_fields(self, manager_setup):
+        mgr, _, _ = manager_setup
+        FakeWSClient.responses["server_status"] = {
+            "elements_fee_rate": 0.1,
+            "min_peg_in_amount": 1286,
+            "min_peg_out_amount": 100000,
+            "server_fee_percent_peg_in": 0.1,
+            "server_fee_percent_peg_out": 0.1,
+            "PegInWalletBalance": 50_000_000,
+            "PegOutWalletBalance": 200_000_000,
+        }
+        with _patch_ws():
+            status = mgr.get_server_status("mainnet")
+        assert status["min_peg_in_amount"] == 1286
+        assert status["server_fee_percent_peg_in"] == 0.1
+        assert status["peg_in_wallet_balance"] == 50_000_000
+
+    def test_falls_back_when_unreachable(self, manager_setup):
+        mgr, _, _ = manager_setup
+        FakeWSClient.responses["login_client"] = ConnectionError("nope")
+        with _patch_ws():
+            status = mgr.get_server_status("mainnet")
+        assert status["min_peg_in_amount"] == 1286
+        assert "warning" in status
+
+
+class TestPegIn:
+    def test_peg_in_returns_deposit_address(self, manager_setup):
+        mgr, _, storage = manager_setup
+        FakeWSClient.responses["peg"] = {
+            "order_id": "order_aaa",
+            "peg_addr": "bc1qsideswapdeposit",
+            "expires_at": 1_900_000_000,
+            "recv_amount": 99_900,
+        }
+        with _patch_ws():
+            peg = mgr.peg_in(wallet_name="default")
+        assert peg.peg_addr == "bc1qsideswapdeposit"
+        assert peg.recv_addr == "lq1qreceiveaddr"
+        assert peg.peg_in is True
+        assert peg.status == "pending"
+        # Was persisted
+        loaded = storage.load_sideswap_peg("order_aaa")
+        assert loaded is not None
+        assert loaded.peg_addr == "bc1qsideswapdeposit"
+
+    def test_peg_in_passes_recv_addr_to_server(self, manager_setup):
+        mgr, _, _ = manager_setup
+        FakeWSClient.responses["peg"] = {
+            "order_id": "o1",
+            "peg_addr": "bc1q",
+        }
+        with _patch_ws():
+            mgr.peg_in()
+        peg_call = next(c for c in FakeWSClient.calls if c[0] == "peg")
+        assert peg_call[1]["peg_in"] is True
+        assert peg_call[1]["recv_addr"] == "lq1qreceiveaddr"
+
+    def test_peg_in_rejects_unknown_wallet(self, manager_setup):
+        mgr, _, _ = manager_setup
+        with pytest.raises(ValueError, match="not found"):
+            mgr.peg_in(wallet_name="ghost")
+
+
+class TestPegOut:
+    def test_peg_out_broadcasts_lbtc_send(self, manager_setup):
+        mgr, wm, storage = manager_setup
+        FakeWSClient.responses["server_status"] = {"min_peg_out_amount": 100_000}
+        FakeWSClient.responses["peg"] = {
+            "order_id": "po_1",
+            "peg_addr": "VJLdepositonliquid",
+            "expires_at": 1_900_000_000,
+            "recv_amount": 199_800,
+        }
+        with _patch_ws():
+            peg = mgr.peg_out(
+                wallet_name="default",
+                amount=200_000,
+                btc_address="bc1quserdest",
+            )
+        assert peg.lockup_txid is not None
+        assert peg.status == "processing"
+        assert wm.sent == [
+            ("default", "VJLdepositonliquid", 200_000, None),
+        ]
+        # Persisted with lockup_txid
+        loaded = storage.load_sideswap_peg("po_1")
+        assert loaded.lockup_txid == peg.lockup_txid
+
+    def test_peg_out_below_min_amount_rejected(self, manager_setup):
+        mgr, _, _ = manager_setup
+        FakeWSClient.responses["server_status"] = {"min_peg_out_amount": 100_000}
+        with _patch_ws():
+            with pytest.raises(ValueError, match="below SideSwap peg-out minimum"):
+                mgr.peg_out(
+                    wallet_name="default",
+                    amount=50_000,
+                    btc_address="bc1q",
+                )
+
+    def test_peg_out_insufficient_balance_rejected(self, manager_setup):
+        mgr, wm, _ = manager_setup
+        wm.balance_lbtc = 50_000
+        FakeWSClient.responses["server_status"] = {"min_peg_out_amount": 100_000}
+        with _patch_ws():
+            with pytest.raises(ValueError, match="Insufficient L-BTC"):
+                mgr.peg_out(
+                    wallet_name="default",
+                    amount=200_000,
+                    btc_address="bc1q",
+                )
+
+    def test_peg_out_send_failure_marks_failed_and_persists(self, manager_setup):
+        mgr, wm, storage = manager_setup
+        FakeWSClient.responses["server_status"] = {"min_peg_out_amount": 100_000}
+        FakeWSClient.responses["peg"] = {"order_id": "po_2", "peg_addr": "VJLdep"}
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("broadcast failed")
+
+        wm.send = boom  # type: ignore[assignment]
+        with _patch_ws():
+            with pytest.raises(RuntimeError, match="broadcast failed"):
+                mgr.peg_out(wallet_name="default", amount=200_000, btc_address="bc1q")
+        # Order persisted as failed for recovery
+        loaded = storage.load_sideswap_peg("po_2")
+        assert loaded is not None
+        assert loaded.status == "failed"
+
+
+class TestPegStatusPolling:
+    def test_status_done_marks_completed(self, manager_setup):
+        mgr, _, storage = manager_setup
+        peg = SideSwapPeg(
+            order_id="poll1",
+            peg_in=True,
+            peg_addr="bc1q",
+            recv_addr="lq1q",
+            amount=None,
+            expected_recv=None,
+            wallet_name="default",
+            network="mainnet",
+            status="processing",
+            created_at="2026-05-07T12:00:00+00:00",
+        )
+        storage.save_sideswap_peg(peg)
+        FakeWSClient.responses["peg_status"] = {
+            "list": [
+                {
+                    "tx_state": "Done",
+                    "detected_confs": None,
+                    "total_confs": None,
+                    "payout_txid": "payouttxid",
+                }
+            ]
+        }
+        with _patch_ws():
+            result = mgr.status("poll1")
+        assert result["status"] == "completed"
+        assert result["payout_txid"] == "payouttxid"
+        assert result["tx_state"] == "Done"
+
+    def test_status_detected_includes_confirmations(self, manager_setup):
+        mgr, _, storage = manager_setup
+        peg = SideSwapPeg(
+            order_id="poll2",
+            peg_in=True,
+            peg_addr="bc1q",
+            recv_addr="lq1q",
+            amount=None,
+            expected_recv=None,
+            wallet_name="default",
+            network="mainnet",
+            status="pending",
+            created_at="2026-05-07T12:00:00+00:00",
+        )
+        storage.save_sideswap_peg(peg)
+        FakeWSClient.responses["peg_status"] = {
+            "list": [
+                {
+                    "tx_state": "Detected",
+                    "detected_confs": 1,
+                    "total_confs": 2,
+                    "payout_txid": None,
+                }
+            ]
+        }
+        with _patch_ws():
+            result = mgr.status("poll2")
+        assert result["status"] == "processing"
+        assert result["confirmations"] == "1/2"
+
+    def test_status_unknown_order_raises(self, manager_setup):
+        mgr, _, _ = manager_setup
+        with pytest.raises(ValueError, match="not found"):
+            mgr.status("missingid")
+
+    def test_status_warns_when_remote_fetch_fails(self, manager_setup):
+        mgr, _, storage = manager_setup
+        peg = SideSwapPeg(
+            order_id="poll3",
+            peg_in=True,
+            peg_addr="bc1q",
+            recv_addr="lq1q",
+            amount=None,
+            expected_recv=None,
+            wallet_name="default",
+            network="mainnet",
+            status="pending",
+            created_at="2026-05-07T12:00:00+00:00",
+        )
+        storage.save_sideswap_peg(peg)
+        FakeWSClient.responses["login_client"] = ConnectionError("offline")
+        with _patch_ws():
+            result = mgr.status("poll3")
+        assert "warning" in result
+        assert result["status"] == "pending"  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# Asset listing & quote
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAssets:
+    def test_fetch_assets_parses_list(self):
+        from aqua.sideswap import fetch_assets
+
+        FakeWSClient.responses["assets"] = {
+            "assets": [
+                {
+                    "asset_id": "abc",
+                    "ticker": "USDt",
+                    "name": "Tether",
+                    "precision": 8,
+                    "instant_swaps": True,
+                    "icon_url": "https://example.com/usdt.png",
+                },
+                {"asset_id": "def", "ticker": "EURx", "name": "PEGx Euro", "precision": 8},
+            ]
+        }
+        with _patch_ws():
+            assets = fetch_assets("mainnet")
+        assert len(assets) == 2
+        assert assets[0].asset_id == "abc"
+        assert assets[0].instant_swaps is True
+        assert assets[1].instant_swaps is False  # default
+
+
+class TestFetchSwapQuote:
+    def test_fetch_swap_quote_returns_immediate_price_when_present(self):
+        from aqua.sideswap import fetch_swap_quote
+
+        FakeWSClient.responses["subscribe_price_stream"] = {
+            "asset": "abc",
+            "send_bitcoins": True,
+            "send_amount": 100_000,
+            "recv_amount": 9_500_000,
+            "price": 95.0,
+            "fixed_fee": 100,
+        }
+        FakeWSClient.responses["unsubscribe_price_stream"] = {}
+        with _patch_ws():
+            q = fetch_swap_quote(asset_id="abc", send_amount=100_000)
+        assert isinstance(q, SideSwapPriceQuote)
+        assert q.price == 95.0
+        assert q.recv_amount == 9_500_000
+        assert q.fixed_fee == 100
+
+    def test_fetch_swap_quote_waits_for_notification_when_subscribe_empty(self):
+        from aqua.sideswap import fetch_swap_quote
+
+        FakeWSClient.responses["subscribe_price_stream"] = {
+            "asset": "abc",
+            "send_bitcoins": True,
+        }
+        FakeWSClient.responses["__notification__"] = {
+            "method": "update_price_stream",
+            "params": {
+                "asset": "abc",
+                "send_bitcoins": True,
+                "send_amount": 100_000,
+                "recv_amount": 9_500_000,
+                "price": 95.0,
+                "fixed_fee": 100,
+            },
+        }
+        FakeWSClient.responses["unsubscribe_price_stream"] = {}
+        with _patch_ws():
+            q = fetch_swap_quote(asset_id="abc", send_amount=100_000)
+        assert q.price == 95.0
+        assert q.recv_amount == 9_500_000
+
+    def test_fetch_swap_quote_requires_exactly_one_amount(self):
+        from aqua.sideswap import fetch_swap_quote
+
+        with pytest.raises(ValueError, match="exactly one"):
+            fetch_swap_quote(asset_id="abc")
+        with pytest.raises(ValueError, match="exactly one"):
+            fetch_swap_quote(asset_id="abc", send_amount=1, recv_amount=2)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket client (real implementation, mocked websocket)
+# ---------------------------------------------------------------------------
+
+
+class _FakeWSConnection:
+    """Simulates a websockets.WebSocketClientProtocol."""
+
+    def __init__(self, scripted_responses: list[str]):
+        self._scripted = list(scripted_responses)
+        self._inbox: asyncio.Queue = asyncio.Queue()
+        self.sent: list[str] = []
+        self._closed = False
+
+    async def send(self, payload: str) -> None:
+        self.sent.append(payload)
+        if self._scripted:
+            await self._inbox.put(self._scripted.pop(0))
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._closed:
+            raise StopAsyncIteration
+        return await self._inbox.get()
+
+    async def close(self):
+        self._closed = True
+
+
+class TestSideSwapWSClient:
+    """Exercises the real SideSwapWSClient with a stubbed websocket."""
+
+    def test_call_round_trips_payload(self):
+        import json as _json
+        from aqua.sideswap import SideSwapWSClient
+
+        async def go():
+            response_payload = _json.dumps({
+                "id": 1,
+                "method": "server_status",
+                "result": {"min_peg_in_amount": 1286},
+            })
+            fake = _FakeWSConnection([response_payload])
+
+            async def fake_connect(*args, **kwargs):  # noqa: ARG001
+                return fake
+
+            with patch("websockets.connect", new=fake_connect):
+                client = SideSwapWSClient("mainnet")
+                await client.connect()
+                try:
+                    result = await client.call("server_status", None)
+                finally:
+                    await client.close()
+            return fake.sent, result
+
+        sent, result = asyncio.run(go())
+        assert result == {"min_peg_in_amount": 1286}
+        assert len(sent) == 1
+        msg = __import__("json").loads(sent[0])
+        assert msg["id"] == 1
+        assert msg["method"] == "server_status"
+        assert msg["params"] is None
+
+    def test_call_propagates_rpc_error(self):
+        import json as _json
+        from aqua.sideswap import SideSwapWSClient, SideSwapWSError
+
+        async def go():
+            response_payload = _json.dumps({
+                "id": 1,
+                "error": {"code": -32602, "message": "Invalid params"},
+            })
+            fake = _FakeWSConnection([response_payload])
+
+            async def fake_connect(*args, **kwargs):  # noqa: ARG001
+                return fake
+
+            with patch("websockets.connect", new=fake_connect):
+                client = SideSwapWSClient("mainnet")
+                await client.connect()
+                try:
+                    await client.call("peg", {})
+                finally:
+                    await client.close()
+
+        with pytest.raises(SideSwapWSError, match="Invalid params"):
+            asyncio.run(go())
+
+
+# ---------------------------------------------------------------------------
+# Server status fallback constants sanity check
+# ---------------------------------------------------------------------------
+
+
+class TestServerStatusDataclass:
+    def test_to_dict_round_trip(self):
+        s = SideSwapServerStatus(min_peg_in_amount=1286, min_peg_out_amount=100_000)
+        d = s.to_dict()
+        assert d["min_peg_in_amount"] == 1286
+        assert d["server_fee_percent_peg_in"] is None

--- a/tests/test_sideswap.py
+++ b/tests/test_sideswap.py
@@ -387,7 +387,7 @@ class TestPegOut:
             peg = mgr.peg_out(
                 wallet_name="default",
                 amount=200_000,
-                btc_address="bc1quserdest",
+                btc_address="bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
             )
         assert peg.lockup_txid is not None
         assert peg.status == "processing"
@@ -406,7 +406,7 @@ class TestPegOut:
                 mgr.peg_out(
                     wallet_name="default",
                     amount=50_000,
-                    btc_address="bc1q",
+                    btc_address="bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
                 )
 
     def test_peg_out_insufficient_balance_rejected(self, manager_setup):
@@ -418,7 +418,7 @@ class TestPegOut:
                 mgr.peg_out(
                     wallet_name="default",
                     amount=200_000,
-                    btc_address="bc1q",
+                    btc_address="bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
                 )
 
     def test_peg_out_send_failure_marks_failed_and_persists(self, manager_setup):
@@ -432,7 +432,7 @@ class TestPegOut:
         wm.send = boom  # type: ignore[assignment]
         with _patch_ws():
             with pytest.raises(RuntimeError, match="broadcast failed"):
-                mgr.peg_out(wallet_name="default", amount=200_000, btc_address="bc1q")
+                mgr.peg_out(wallet_name="default", amount=200_000, btc_address="bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
         # Order persisted as failed for recovery
         loaded = storage.load_sideswap_peg("po_2")
         assert loaded is not None
@@ -500,6 +500,50 @@ class TestPegStatusPolling:
             result = mgr.status("poll2")
         assert result["status"] == "processing"
         assert result["confirmations"] == "1/2"
+
+    def test_status_multi_tx_does_not_regress_completed_state(self, manager_setup):
+        # Regression: SideSwap returns one entry per detected deposit on the
+        # peg address. If the user reuses the address, a fresh `Detected`
+        # deposit can appear AFTER a completed `Done` deposit. Picking just
+        # `txns[-1]` would let the persisted state regress to processing
+        # and lose the original payout_txid.
+        mgr, _, storage = manager_setup
+        peg = SideSwapPeg(
+            order_id="poll_multi",
+            peg_in=True,
+            peg_addr="bc1q",
+            recv_addr="lq1q",
+            amount=None,
+            expected_recv=None,
+            wallet_name="default",
+            network="mainnet",
+            status="processing",
+            created_at="2026-05-07T12:00:00+00:00",
+        )
+        storage.save_sideswap_peg(peg)
+        FakeWSClient.responses["peg_status"] = {
+            "list": [
+                {
+                    "tx_state": "Done",
+                    "detected_confs": 2,
+                    "total_confs": 2,
+                    "payout_txid": "originalpayout",
+                },
+                {
+                    "tx_state": "Detected",
+                    "detected_confs": 1,
+                    "total_confs": 2,
+                    "payout_txid": None,
+                },
+            ]
+        }
+        with _patch_ws():
+            result = mgr.status("poll_multi")
+        # The completed Done wins over the new Detected; payout_txid is
+        # preserved.
+        assert result["status"] == "completed"
+        assert result["tx_state"] == "Done"
+        assert result["payout_txid"] == "originalpayout"
 
     def test_status_unknown_order_raises(self, manager_setup):
         mgr, _, _ = manager_setup

--- a/tests/test_sideswap.py
+++ b/tests/test_sideswap.py
@@ -170,7 +170,7 @@ class TestMapPegStatus:
         assert map_peg_status(None, list_empty=True) == "pending"
 
     @pytest.mark.parametrize("state, expected", [
-        ("Detected", "processing"),
+        ("Detected", "detected"),
         ("Processing", "processing"),
         ("Done", "completed"),
         ("InsufficientAmount", "failed"),
@@ -542,7 +542,7 @@ class TestPegStatusPolling:
         }
         with _patch_ws():
             result = mgr.status("poll2")
-        assert result["status"] == "processing"
+        assert result["status"] == "detected"
         assert result["confirmations"] == "1/2"
 
     def test_status_multi_tx_does_not_regress_completed_state(self, manager_setup):
@@ -760,7 +760,7 @@ class TestSideSwapWSClient:
         sent, result = asyncio.run(go())
         assert result == {"min_peg_in_amount": 1286}
         assert len(sent) == 1
-        msg = __import__("json").loads(sent[0])
+        msg = _json.loads(sent[0])
         assert msg["id"] == 1
         assert msg["method"] == "server_status"
         assert msg["params"] is None

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -728,6 +728,8 @@ class TestToolRegistry:
             "sideswap_recommend",
             "sideswap_list_assets",
             "sideswap_quote",
+            "sideswap_execute_swap",
+            "sideswap_swap_status",
         }
         assert set(TOOLS.keys()) == expected
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -752,13 +752,57 @@ class TestDeleteWallet:
         with pytest.raises(ValueError, match="not found"):
             delete_wallet(wallet_name="nonexistent")
 
+    def test_delete_removes_sideswap_pegs_for_wallet(self, isolated_manager):
+        """SideSwap peg records belonging to the wallet are removed too."""
+        from aqua.sideswap import SideSwapPeg
+        from datetime import UTC, datetime
+
+        lw_import_mnemonic(
+            mnemonic=TEST_MNEMONIC, wallet_name="pegowner", network="testnet"
+        )
+        # Save a peg owned by this wallet plus one owned by another wallet.
+        own_peg = SideSwapPeg(
+            order_id="aaa111",
+            peg_in=True,
+            peg_addr="bc1q...",
+            recv_addr="lq1...",
+            amount=None,
+            expected_recv=None,
+            wallet_name="pegowner",
+            network="testnet",
+            status="pending",
+            created_at=datetime.now(UTC).isoformat(),
+        )
+        other_peg = SideSwapPeg(
+            order_id="bbb222",
+            peg_in=True,
+            peg_addr="bc1q...",
+            recv_addr="lq1...",
+            amount=None,
+            expected_recv=None,
+            wallet_name="someone_else",
+            network="testnet",
+            status="pending",
+            created_at=datetime.now(UTC).isoformat(),
+        )
+        isolated_manager.storage.save_sideswap_peg(own_peg)
+        isolated_manager.storage.save_sideswap_peg(other_peg)
+
+        result = delete_wallet(wallet_name="pegowner")
+        assert result["sideswap_pegs_removed"] == 1
+        assert isolated_manager.storage.load_sideswap_peg("aaa111") is None
+        # Other wallet's peg untouched.
+        assert isolated_manager.storage.load_sideswap_peg("bbb222") is not None
+
     def test_delete_removes_wallet(self, isolated_manager):
         """Wallet file is gone from storage after deletion."""
         lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="todelete", network="testnet")
         assert "todelete" in lw_list_wallets()["wallets"]
 
         result = delete_wallet(wallet_name="todelete")
-        assert result == {"deleted": True, "wallet_name": "todelete"}
+        assert result["deleted"] is True
+        assert result["wallet_name"] == "todelete"
+        assert result["sideswap_pegs_removed"] == 0
         assert "todelete" not in lw_list_wallets()["wallets"]
 
     def test_delete_clears_lw_manager_caches(self, isolated_manager):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -720,6 +720,14 @@ class TestToolRegistry:
             "delete_wallet",
             "btc_import_descriptor",
             "btc_export_descriptor",
+            "sideswap_server_status",
+            "sideswap_peg_quote",
+            "sideswap_peg_in",
+            "sideswap_peg_out",
+            "sideswap_peg_status",
+            "sideswap_recommend",
+            "sideswap_list_assets",
+            "sideswap_quote",
         }
         assert set(TOOLS.keys()) == expected
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,6 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
-
-[options]
-exclude-newer = "2026-04-05T00:00:00Z"
 
 [[package]]
 name = "agentic-aqua"
@@ -16,6 +13,7 @@ dependencies = [
     { name = "lwk" },
     { name = "mcp" },
     { name = "python-dotenv" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -41,6 +39,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.0" },
+    { name = "websockets", specifier = ">=12.0" },
 ]
 provides-extras = ["dev"]
 
@@ -870,4 +869,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/f2/368268300fb8af33743508d738ef7bb4d56afdb46c6d9c0fa3dd515df171/uvicorn-0.43.0.tar.gz", hash = "sha256:ab1652d2fb23abf124f36ccc399828558880def222c3cb3d98d24021520dc6e8", size = 85686, upload-time = "2026-04-03T18:37:48.984Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/df/0cf5b0c451602748fdc7a702d4667f6e209bf96aa6e3160d754234445f2a/uvicorn-0.43.0-py3-none-any.whl", hash = "sha256:46fac64f487fd968cd999e5e49efbbe64bd231b5bd8b4a0b482a23ebce499620", size = 68591, upload-time = "2026-04-03T18:37:47.64Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]


### PR DESCRIPTION
## Summary

- Mirrors the AQUA Flutter wallet's SideSwap flow over WebSocket JSON-RPC (`wss://api.sideswap.io/json-rpc-ws`), letting agents move funds between Bitcoin mainchain and Liquid via SideSwap pegs.
- Pegs charge 0.1% (vs 0.2% on instant swap-market trades) at the cost of waiting for chain confirmations — so the integration includes a recommendation tool that surfaces the time-vs-fee trade-off before initiating a peg.
- Adds 8 new MCP tools (`sideswap_*`), 3 new prompts (`peg_in`, `peg_out`, `swap_assets`), and 38 new tests. All 337 tests pass.

## What's in this PR

**New module `src/aqua/sideswap.py`** — async WebSocket JSON-RPC client with sync wrappers, dataclasses (`SideSwapPeg`, `SideSwapServerStatus`, `SideSwapAsset`, `SideSwapPriceQuote`), `SideSwapPegManager` for orchestration, and recommendation logic that warns about the 102-confirmation cold-wallet path on large peg-ins.

**MCP tools** (prefix `sideswap_`):

| Tool | What it does |
|---|---|
| `sideswap_server_status` | Live fees, peg minimums, hot-wallet balances |
| `sideswap_peg_quote` | Quote receive amount for a peg at current fees |
| `sideswap_peg_in` | Initiate BTC → L-BTC peg-in; returns BTC deposit address |
| `sideswap_peg_out` | Initiate L-BTC → BTC peg-out; broadcasts L-BTC send |
| `sideswap_peg_status` | Check confirmations / tx_state / payout_txid |
| `sideswap_recommend` | Surfaces peg vs swap-market trade-off |
| `sideswap_list_assets` | List Liquid assets SideSwap supports |
| `sideswap_quote` | **Read-only** quote for a Liquid asset swap |

**Prompts**: `peg_in`, `peg_out`, `swap_assets` — each guides the agent through quote → recommend → confirm → execute → track.

**Persistence**: `~/.aqua/sideswap_pegs/{order_id}.json`, mode `0o600`, atomic writes; saved before broadcast for crash recovery.

**Dependency**: `websockets>=12.0`.

Atomic asset-swap execution lands separately in #31; this PR ships pegs + read-only quoting only.

## Test plan

- [x] `pytest` passes (337 tests, 38 new)
- [x] `SideSwapWSClient` round-trips a JSON-RPC request/response (mocked websocket)
- [x] `SideSwapWSClient` propagates RPC errors as `SideSwapWSError`
- [x] `peg_in` returns a deposit address and persists the order
- [x] `peg_out` broadcasts L-BTC to the deposit address and persists with `lockup_txid`
- [x] `peg_out` rejects below-minimum amounts and insufficient balance
- [x] `peg_out` marks the order `failed` if broadcast fails (recovery)
- [x] `peg_status` polls and maps `tx_state` (Detected / Processing / Done / InsufficientAmount)
- [x] Recommendation logic warns when amount exceeds `PegInWalletBalance` (102-conf cold path)
- [x] Storage round-trip + 0o600 permissions + path traversal rejection
- [ ] Live mainnet smoke test of a small peg-in (`brew install`-time)
- [ ] Live mainnet smoke test of a small peg-out

## Reviewer notes

- Wire format mirrors AQUA Flutter's `sideswap_websocket_provider.dart` exactly; method names and request shapes are confirmed against `sideswap_api/src/lib.rs` and `http_rpc.rs` in the SideSwap Rust source.
- `user_agent` is `agentic-aqua` (so SideSwap can attribute volume separately from the AQUA mobile app).
- The `_run` helper falls back to a thread-isolated event loop when called from inside an existing asyncio loop (e.g. under `pytest-asyncio` auto mode or some MCP transports).
