### PR TITLE
Support asset \xe2\x86\x92 L-BTC direction in sideswap_execute_swap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified 
 | `sideswap_recommend` | Recommend peg vs swap-market for a BTC ↔ L-BTC conversion. Surfaces time-vs-fee trade-off and warns if amount exceeds hot-wallet liquidity. | `amount` (sats), `direction`: btc_to_lbtc/lbtc_to_btc, `network`: optional |
 | `sideswap_list_assets` | List Liquid assets supported by SideSwap (USDt, EURx, MEX, DePix, etc.). | `network`: optional |
 | `sideswap_quote` | Read-only price quote for a Liquid asset swap (e.g. L-BTC ↔ USDt). Use BEFORE `sideswap_execute_swap` to confirm price with user. | `asset_id`, `send_amount` (sats) OR `recv_amount` (sats), `send_bitcoins`: optional, `network`: optional |
-| `sideswap_execute_swap` | Execute an atomic swap of L-BTC for an asset. PSET is verified locally against the agreed quote before signing — refuses to sign if balance does not match exactly. **L-BTC → asset only**; reverse direction not supported (use AQUA mobile). | `asset_id`, `send_amount` (sats), `wallet_name`: optional, `password`: optional |
+| `sideswap_execute_swap` | Execute an atomic Liquid swap. Both directions supported via `send_bitcoins`: True = L-BTC → asset; False = asset → L-BTC. PSET verified locally against the agreed quote before signing; fee tolerance pinned to L-BTC so the asset side is always strict equality. | `asset_id`, `send_amount` (sats), `send_bitcoins`: optional (default true), `wallet_name`: optional, `password`: optional |
 | `sideswap_swap_status` | Get persisted status of an atomic swap. Pass the txid to `lw_tx_status` for on-chain confirmation. | `order_id`: string |
 
 > ⚠️ **Pegs vs swaps**: pegs charge 0.1% (vs 0.2% for instant swap-market trades) but require waiting for confirmations. Always call `sideswap_recommend` for amounts ≥ 0.01 BTC and surface the trade-off (and any 102-confirmation cold-wallet warning) before initiating a peg-in.
@@ -345,16 +345,21 @@ SideSwap (`sideswap.io`) provides BTC ↔ L-BTC pegs and Liquid asset swaps via 
 - Peg-in: 2 BTC confs (~20 min) hot-wallet path; 102 BTC confs (~17 hours) if amount exceeds `PegInWalletBalance`
 - Peg-out: 2 Liquid confs + federation BTC sweep (typically 15–60 min total)
 
-**Asset swap execution** (`sideswap_execute_swap`) supports the legacy `start_swap_web` + HTTP `swap_start`/`swap_sign` flow with **local PSET verification before signing**. Direction is currently L-BTC → asset only.
+**Asset swap execution** (`sideswap_execute_swap`) supports the legacy `start_swap_web` + HTTP `swap_start`/`swap_sign` flow in **both directions**:
+
+- **L-BTC → asset** (`send_bitcoins=True`): user's L-BTC change pays the network fee. Wallet net effect: `L-BTC: -(send_amount + fee)`, `asset: +recv_amount`.
+- **asset → L-BTC** (`send_bitcoins=False`): SideSwap dealer absorbs the network fee from their L-BTC contribution. Wallet net effect: `asset: -send_amount` (exact), `L-BTC: +recv_amount` (exact).
 
 **Verification rules** (`verify_pset_balances` in `src/aqua/sideswap.py`):
 1. Wallet must gain *exactly* `recv_amount` of `recv_asset`.
-2. Wallet must lose at most `send_amount + fee_tolerance_sats` (default 1000) of `send_asset`.
+2. Wallet must lose at most `send_amount + fee_tolerance_sats` (default 1000) of `send_asset` *if* `send_asset == fee_asset`; otherwise strict equality.
 3. No other asset may have a non-zero balance change.
+
+The manager always passes `fee_asset = policy_asset` (L-BTC) regardless of direction, so the fee tolerance only relaxes constraints on the L-BTC side — never on a non-L-BTC asset, which would otherwise be a siphon vector on the reverse path.
 
 If any rule fails, `PsetVerificationError` is raised and signing is aborted — the order is persisted as `failed` for forensics. The order is also persisted at every flow step (`pending` → `verified` → `signed` → `broadcast`) for crash recovery.
 
-UTXO selection (`select_swap_utxos`): confidential (asset_bf and value_bf both non-zero), holding the requested send_asset, sorted descending by value, accumulated to cover `send_amount`. wpkh-only (matching the wallet's BIP84 m/84'/1776'/0' descriptor).
+UTXO selection (`select_swap_utxos`): confidential (asset_bf and value_bf both non-zero), holding the requested send_asset, sorted descending by value, accumulated to cover `send_amount`. wpkh-only (matching the wallet's BIP84 m/84'/1776'/0' descriptor). No separate L-BTC fee inputs are required on either direction (mirroring AQUA Flutter's `swap_provider.dart`).
 
 ## Bitcoin Implementation Details
 

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -653,25 +653,32 @@ TOOL_SCHEMAS = {
     },
     "sideswap_execute_swap": {
         "description": (
-            "Execute a Liquid atomic swap of L-BTC for an asset on SideSwap. "
-            "Currently L-BTC → asset only (e.g. L-BTC → USDt). The PSET "
-            "returned by SideSwap is verified locally against the agreed "
-            "quote BEFORE signing — the swap is aborted if the wallet's net "
-            "balance change does not exactly match (refusing to sign protects "
-            "against a hostile server). Order is persisted at every step for "
-            "crash recovery. ALWAYS call sideswap_quote first and confirm the "
-            "price with the user before invoking this tool."
+            "Execute a Liquid atomic swap on SideSwap. Both directions are "
+            "supported via send_bitcoins: True = L-BTC → asset (default), "
+            "False = asset → L-BTC. The PSET returned by SideSwap is verified "
+            "locally against the agreed quote BEFORE signing — the swap is "
+            "aborted if the wallet's net balance change does not exactly match "
+            "(refusing to sign protects against a hostile server). The fee "
+            "tolerance is pinned to L-BTC, so on the asset → L-BTC direction "
+            "the asset side is checked at strict equality. Order is persisted "
+            "at every step for crash recovery. ALWAYS call sideswap_quote "
+            "first and confirm the price with the user before invoking this tool."
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
                 "asset_id": {
                     "type": "string",
-                    "description": "Liquid asset ID to receive (e.g. USDt)",
+                    "description": "Non-L-BTC Liquid asset (e.g. USDt). The L-BTC side is always the policy asset.",
                 },
                 "send_amount": {
                     "type": "integer",
-                    "description": "L-BTC sats to send",
+                    "description": "Send amount in sats (L-BTC if send_bitcoins, else asset)",
+                },
+                "send_bitcoins": {
+                    "type": "boolean",
+                    "description": "True = send L-BTC to receive asset; False = send asset to receive L-BTC",
+                    "default": True,
                 },
                 "wallet_name": {
                     "type": "string",
@@ -782,12 +789,12 @@ SIDESWAP (BTC ↔ L-BTC pegs and Liquid asset swaps):
 - For VERY LARGE peg-ins that exceed SideSwap's hot-wallet balance, expect the
   cold-wallet path: 102 BTC confirmations (~17 hours). Always check
   sideswap_server_status first and warn the user when this applies.
-- For Liquid asset swaps (e.g. L-BTC → USDt), sideswap_quote returns a quote
-  and sideswap_execute_swap performs the swap. The PSET returned by SideSwap
-  is verified LOCALLY against the agreed quote before signing — refusing to
-  sign if the recv balance does not match exactly. Currently only L-BTC →
-  asset is supported; for asset → L-BTC, direct the user to the AQUA mobile
-  wallet or sideswap.io.
+- For Liquid asset swaps (e.g. L-BTC ↔ USDt), sideswap_quote returns a quote
+  and sideswap_execute_swap performs the swap. Both directions are supported
+  via the send_bitcoins flag. The PSET returned by SideSwap is verified
+  LOCALLY against the agreed quote before signing — refusing to sign if the
+  recv balance does not match exactly. The fee tolerance is pinned to L-BTC,
+  so the non-L-BTC asset side is always checked at strict equality.
 
 WHEN TO RECOMMEND A PEG:
 - "I want to move my BTC to Liquid" → if amount ≥ 0.01 BTC, recommend peg-in.
@@ -1329,23 +1336,27 @@ Please:
                         role="user",
                         content=TextContent(
                             type="text",
-                            text="""I want to swap Liquid assets (e.g. L-BTC → USDt) via SideSwap.
+                            text="""I want to swap Liquid assets (e.g. L-BTC ↔ USDt) via SideSwap.
 
 Please:
 1. Call sideswap_list_assets to show what's tradeable on SideSwap right now
-2. Ask me what I want to swap. Currently agentic-aqua supports L-BTC → asset
-   only; for asset → L-BTC tell me to use the AQUA mobile wallet
-3. Ask me for the send_amount in L-BTC sats (or in BTC and convert)
-4. Show me my current L-BTC balance (lw_balance) so I have context
-5. Call sideswap_quote with send_bitcoins=true to get a price quote
+2. Ask me what I want to swap and which direction:
+   - L-BTC → asset (send_bitcoins=true): I send L-BTC, receive an asset
+   - asset → L-BTC (send_bitcoins=false): I send an asset, receive L-BTC
+3. Ask me for the send_amount in the corresponding sats (L-BTC sats if
+   sending L-BTC; asset sats otherwise). For L-BTC, accept input in BTC
+   and convert.
+4. Show me my current balance for the send asset (lw_balance) so I have context
+5. Call sideswap_quote with the right send_bitcoins flag to get a price quote
 6. Show me a summary clearly:
-   - Send: X L-BTC sats
-   - Receive: Y sats of [asset]
+   - Send: X sats of [send asset]
+   - Receive: Y sats of [recv asset]
    - Price + fixed_fee
    - Net effective rate
 7. Ask for explicit confirmation
 8. If wallet is password-encrypted, ask me for the password
-9. Call sideswap_execute_swap with the same asset_id and send_amount.
+9. Call sideswap_execute_swap with the same asset_id, send_amount, and
+   send_bitcoins flag.
    The tool will: capture a fresh quote (price may have moved by a few
    percent), call start_swap_web, request the PSET, VERIFY it locally
    against the quote, sign it, and submit. If the verification fails the

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -37,10 +37,18 @@ send_asset loses no more than send_amount + fee_tolerance, no other assets
 move). The server is trusted-but-verify; without this check, a hostile or
 buggy server could craft a PSET that takes our funds and pays us nothing.
 
-Execution (`SideSwapSwapManager.execute_swap`) currently supports only the
-L-BTC → asset direction (`send_bitcoins=True`). The reverse direction needs
-careful fee handling and is excluded; users should use the AQUA mobile app
-or sideswap.io for asset → L-BTC swaps until that's implemented and audited.
+Execution (`SideSwapSwapManager.execute_swap`) supports both directions:
+
+  - `send_bitcoins=True`: L-BTC → asset (e.g. L-BTC → USDt). The Liquid network
+    fee comes out of the user's L-BTC change output, so the wallet's L-BTC
+    delta is `-(send_amount + fee)`.
+  - `send_bitcoins=False`: asset → L-BTC (e.g. USDt → L-BTC). The dealer
+    absorbs the network fee from their L-BTC contribution, so the wallet's
+    asset delta is `-send_amount` and L-BTC delta is `+recv_amount` exactly.
+
+The verifier's `fee_asset` parameter is always pinned to the policy asset so
+the fee tolerance only relaxes constraints on the L-BTC side — never on a
+non-L-BTC asset, which would otherwise be a siphon vector on the reverse path.
 """
 
 from __future__ import annotations
@@ -1179,23 +1187,41 @@ class SideSwapSwapManager:
         send_amount: int,
         wallet_name: str = "default",
         password: Optional[str] = None,
+        send_bitcoins: bool = True,
         *,
         fee_tolerance_sats: int = DEFAULT_FEE_TOLERANCE_SATS,
         quote_wait_seconds: float = QUOTE_WAIT_SECONDS,
     ) -> "SideSwapSwap":
-        """Execute a swap of L-BTC for `asset_id` (i.e. `send_bitcoins=True`).
+        """Execute a Liquid atomic swap on SideSwap.
 
-        Only L-BTC → asset is supported in this version. The reverse direction
-        (asset → L-BTC) needs more thought re: fee handling and is intentionally
-        excluded; the user should be directed to the AQUA mobile app for that.
+        Two directions are supported:
+
+        - **`send_bitcoins=True`** (forward, default): user sends L-BTC and
+          receives `asset_id` (e.g. L-BTC → USDt). The Liquid network fee is
+          deducted from the user's L-BTC change output, so the wallet's L-BTC
+          delta is `-(send_amount + fee)` and `recv_asset` delta is
+          `+recv_amount` exactly.
+
+        - **`send_bitcoins=False`** (reverse): user sends `asset_id` and
+          receives L-BTC (e.g. USDt → L-BTC). The Liquid network fee is
+          absorbed by the SideSwap dealer's L-BTC contribution, so the
+          wallet's `send_asset` delta is `-send_amount` exactly and L-BTC
+          delta is `+recv_amount` exactly.
+
+        In both cases the verifier sets `fee_asset` to L-BTC (the policy
+        asset), so the fee tolerance only relaxes constraints on the L-BTC
+        balance — never on the asset balance.
 
         Args:
-            asset_id: Liquid asset id to receive (e.g. USDt).
-            send_amount: L-BTC sats to send.
+            asset_id: The non-L-BTC asset id (e.g. USDt). The L-BTC side is
+                always the policy asset of the wallet's network.
+            send_amount: Send amount in sats. Denominated in L-BTC if
+                `send_bitcoins=True`, otherwise in `asset_id`.
             wallet_name: Wallet to sign with.
             password: Mnemonic decryption password (if encrypted at rest).
-            fee_tolerance_sats: Extra L-BTC sats we'll allow for the network
-                fee. Default 1000 — Liquid fees are tens of sats.
+            send_bitcoins: Direction. True = L-BTC → asset; False = asset → L-BTC.
+            fee_tolerance_sats: Extra L-BTC sats allowed for the network fee.
+                Default 1000 — Liquid fees are tens of sats.
             quote_wait_seconds: How long to wait for the streamed quote.
         """
         # Load wallet & validate signing capability
@@ -1218,9 +1244,16 @@ class SideSwapSwapManager:
         # Sync the wallet so utxos() reflects the current chain state
         self.wallet_manager.sync_wallet(wallet_name)
 
-        send_asset = self.wallet_manager._get_policy_asset(network)
-        if asset_id == send_asset:
-            raise ValueError("Cannot swap L-BTC for L-BTC")
+        policy_asset = self.wallet_manager._get_policy_asset(network)
+        if asset_id == policy_asset:
+            raise ValueError("asset_id must be a non-L-BTC Liquid asset")
+
+        # Resolve send/recv assets from direction. The fee always lives on the
+        # policy asset (L-BTC) regardless of direction.
+        if send_bitcoins:
+            send_asset, recv_asset = policy_asset, asset_id
+        else:
+            send_asset, recv_asset = asset_id, policy_asset
 
         async def _quote_and_start() -> tuple[dict, dict]:
             async with SideSwapWSClient(network) as client:
@@ -1228,7 +1261,7 @@ class SideSwapSwapManager:
                 # Get the streamed price quote
                 initial = await client.subscribe_price_stream(
                     asset=asset_id,
-                    send_bitcoins=True,
+                    send_bitcoins=send_bitcoins,
                     send_amount=send_amount,
                 )
                 quote = initial or {}
@@ -1247,7 +1280,7 @@ class SideSwapSwapManager:
                 start_resp = await client.start_swap_web(
                     asset=asset_id,
                     price=float(quote["price"]),
-                    send_bitcoins=True,
+                    send_bitcoins=send_bitcoins,
                     send_amount=int(quote["send_amount"]),
                     recv_amount=int(quote["recv_amount"]),
                 )
@@ -1271,7 +1304,7 @@ class SideSwapSwapManager:
             submit_id=None,
             send_asset=send_asset,
             send_amount=send_amount,
-            recv_asset=asset_id,
+            recv_asset=recv_asset,
             recv_amount=recv_amount,
             price=float(quote["price"]),
             wallet_name=wallet_name,
@@ -1282,7 +1315,11 @@ class SideSwapSwapManager:
         self.storage.save_sideswap_swap(swap)
 
         try:
-            # Build the inputs/addresses for swap_start
+            # Build the inputs/addresses for swap_start. AQUA Flutter selects
+            # only UTXOs of `send_asset` (no separate L-BTC fee inputs); the
+            # SideSwap dealer absorbs the network fee on the reverse direction
+            # and routes it through the user's L-BTC change on the forward
+            # direction. See `lib/features/sideswap/providers/swap_provider.dart`.
             wollet = self.wallet_manager._get_wollet(wallet_name)
             inputs = select_swap_utxos(wollet.utxos(), send_asset, send_amount)
             recv_addr = str(wollet.address(None).address())
@@ -1296,7 +1333,7 @@ class SideSwapSwapManager:
                 change_addr=change_addr,
                 send_asset=send_asset,
                 send_amount=send_amount,
-                recv_asset=asset_id,
+                recv_asset=recv_asset,
                 recv_amount=recv_amount,
             )
             submit_id = start_payload.get("submit_id")
@@ -1308,15 +1345,18 @@ class SideSwapSwapManager:
             swap.submit_id = submit_id
             self.storage.save_sideswap_swap(swap)
 
-            # Verify before signing — security-critical
+            # Verify before signing — security-critical. fee_asset is always
+            # the policy asset (L-BTC); when send_asset != L-BTC the fee
+            # tolerance does NOT relax the constraint on the asset side.
             self._verify_pset(
                 pset_b64,
                 wollet,
                 send_asset=send_asset,
                 send_amount=send_amount,
-                recv_asset=asset_id,
+                recv_asset=recv_asset,
                 recv_amount=recv_amount,
                 fee_tolerance_sats=fee_tolerance_sats,
+                fee_asset=policy_asset,
             )
             swap.status = "verified"
             self.storage.save_sideswap_swap(swap)
@@ -1364,6 +1404,7 @@ class SideSwapSwapManager:
         recv_asset: str,
         recv_amount: int,
         fee_tolerance_sats: int,
+        fee_asset: Optional[str] = None,
     ) -> None:
         """Run the PSET balance check via LWK and raise on mismatch."""
         import lwk
@@ -1379,6 +1420,7 @@ class SideSwapSwapManager:
             send_amount=send_amount,
             recv_asset=recv_asset,
             recv_amount=recv_amount,
+            fee_asset=fee_asset,
             fee_tolerance_sats=fee_tolerance_sats,
         )
 

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -1020,22 +1020,26 @@ def sideswap_execute_swap(
     send_amount: int,
     wallet_name: str = "default",
     password: str | None = None,
+    send_bitcoins: bool = True,
 ) -> dict[str, Any]:
-    """Execute a Liquid atomic swap of L-BTC for an asset on SideSwap.
+    """Execute a Liquid atomic swap on SideSwap. Both directions are supported.
 
-    Currently L-BTC → asset only (e.g. L-BTC → USDt). The reverse direction
-    is not yet supported in agentic-aqua and will raise an error from the
-    server; for asset → L-BTC, direct the user to the AQUA mobile wallet
-    or sideswap.io.
+    Direction is controlled by `send_bitcoins`:
 
-    Flow:
+    - `send_bitcoins=True` (default): user sends L-BTC and receives `asset_id`
+      (e.g. L-BTC → USDt). `send_amount` is in L-BTC sats.
+    - `send_bitcoins=False`: user sends `asset_id` and receives L-BTC
+      (e.g. USDt → L-BTC). `send_amount` is in `asset_id` sats.
+
+    Flow (both directions):
       1. Subscribe to a price stream and capture a quote at the current price
       2. Submit start_swap_web with the captured price; receive an upload_url
-      3. Select confidential UTXOs of L-BTC covering send_amount
+      3. Select confidential UTXOs of `send_asset` covering `send_amount`
       4. POST swap_start to receive the half-built PSET
       5. **Verify the PSET locally** against the agreed quote — refuses to
-         sign if recv_asset balance ≠ recv_amount, or send_asset is over-deducted,
-         or any unrelated asset moves
+         sign if recv_asset balance ≠ recv_amount, send_asset is over-deducted,
+         or any unrelated asset moves. The fee tolerance only applies to L-BTC,
+         so the asset side is always checked at strict equality.
       6. Sign the PSET locally
       7. POST swap_sign — server merges and broadcasts; returns the txid
 
@@ -1043,10 +1047,12 @@ def sideswap_execute_swap(
     sideswap_swap_status with the returned order_id.
 
     Args:
-        asset_id: Liquid asset ID to receive (e.g. USDt)
-        send_amount: L-BTC sats to send
+        asset_id: The non-L-BTC Liquid asset (e.g. USDt). The L-BTC side is
+            always the policy asset of the wallet's network.
+        send_amount: Send amount in sats (L-BTC if send_bitcoins, else asset).
         wallet_name: Liquid wallet to sign with. Default: "default"
         password: Password to decrypt mnemonic (if encrypted at rest)
+        send_bitcoins: True = L-BTC → asset; False = asset → L-BTC.
 
     Returns:
         order_id, submit_id, send_asset, send_amount, recv_asset, recv_amount,
@@ -1060,6 +1066,7 @@ def sideswap_execute_swap(
         send_amount=send_amount,
         wallet_name=wallet_name,
         password=password,
+        send_bitcoins=send_bitcoins,
     )
     return {
         "order_id": swap.order_id,
@@ -1076,7 +1083,7 @@ def sideswap_execute_swap(
         "message": (
             f"Swap broadcast (txid={swap.txid}). Check confirmation status with "
             f"lw_tx_status. The PSET was verified locally against the quote — "
-            f"the wallet will receive exactly {swap.recv_amount} sats of recv_asset."
+            f"the wallet receives exactly {swap.recv_amount} sats of recv_asset."
         ),
     }
 

--- a/tests/test_sideswap.py
+++ b/tests/test_sideswap.py
@@ -907,6 +907,73 @@ class TestVerifyPsetBalances:
                 {}, send_asset=L_BTC, send_amount=1, recv_asset=USDT, recv_amount=0
             )
 
+    # -- Reverse direction (asset → L-BTC) ------------------------------------
+    # The dealer absorbs the network fee from their L-BTC contribution, so the
+    # wallet's effect is exact on BOTH sides: -send_amount of asset, +recv_amount
+    # of L-BTC. The fee tolerance must NOT relax the asset-side constraint —
+    # otherwise a hostile server could siphon up to fee_tolerance_sats of asset.
+
+    def test_reverse_exact_match_with_fee_asset_lbtc_passes(self):
+        verify_pset_balances(
+            {USDT: -9_500_000, L_BTC: 100_000},
+            send_asset=USDT,
+            send_amount=9_500_000,
+            recv_asset=L_BTC,
+            recv_amount=100_000,
+            fee_asset=L_BTC,  # fee always lives on policy asset
+        )
+
+    def test_reverse_extra_asset_taken_rejected_even_within_tolerance(self):
+        # If fee_asset defaulted to send_asset (USDT) the verifier would let
+        # a 1000-sat USDT siphon through. Pinning fee_asset=L_BTC blocks it.
+        with pytest.raises(PsetVerificationError, match="more than the agreed"):
+            verify_pset_balances(
+                {USDT: -9_500_500, L_BTC: 100_000},
+                send_asset=USDT,
+                send_amount=9_500_000,
+                recv_asset=L_BTC,
+                recv_amount=100_000,
+                fee_tolerance_sats=1_000,
+                fee_asset=L_BTC,
+            )
+
+    def test_reverse_short_lbtc_recv_rejected(self):
+        with pytest.raises(PsetVerificationError, match="delivers 99000"):
+            verify_pset_balances(
+                {USDT: -9_500_000, L_BTC: 99_000},
+                send_asset=USDT,
+                send_amount=9_500_000,
+                recv_asset=L_BTC,
+                recv_amount=100_000,
+                fee_asset=L_BTC,
+            )
+
+    def test_reverse_unrelated_asset_movement_rejected(self):
+        with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
+            verify_pset_balances(
+                {USDT: -9_500_000, L_BTC: 100_000, EVIL: -1},
+                send_asset=USDT,
+                send_amount=9_500_000,
+                recv_asset=L_BTC,
+                recv_amount=100_000,
+                fee_asset=L_BTC,
+            )
+
+    def test_default_fee_asset_is_send_asset_documented_behavior(self):
+        # Sanity-check: the default behavior is that fee_asset == send_asset.
+        # Callers who care about the reverse direction MUST pass fee_asset=L_BTC.
+        # Without it, a 1000-sat USDT siphon would be accepted — this test
+        # documents that requirement.
+        verify_pset_balances(
+            {USDT: -9_500_500, L_BTC: 100_000},
+            send_asset=USDT,
+            send_amount=9_500_000,
+            recv_asset=L_BTC,
+            recv_amount=100_000,
+            fee_tolerance_sats=1_000,
+            # fee_asset NOT specified — defaults to send_asset (USDT)
+        )
+
     def test_negative_fee_tolerance_rejected(self):
         with pytest.raises(ValueError):
             verify_pset_balances(
@@ -1449,7 +1516,7 @@ class TestSwapManagerExecute:
     def test_rejects_swap_lbtc_for_lbtc(self, swap_manager_setup):
         mgr, _, _, _, _ = swap_manager_setup
         with _patch_swap_layers():
-            with pytest.raises(ValueError, match="Cannot swap L-BTC for L-BTC"):
+            with pytest.raises(ValueError, match="non-L-BTC"):
                 mgr.execute_swap(
                     asset_id=L_BTC, send_amount=100_000, wallet_name="default"
                 )
@@ -1494,3 +1561,168 @@ class TestSwapManagerExecute:
         mgr, _, _, _, _ = swap_manager_setup
         with pytest.raises(ValueError, match="not found"):
             mgr.status("doesnotexist")
+
+
+class TestSwapManagerReverseExecute:
+    """Reverse direction: asset → L-BTC.
+
+    The dealer absorbs the network fee from their L-BTC contribution, so the
+    wallet's effect is exact on both sides: -send_amount of asset and
+    +recv_amount of L-BTC. Crucially, the verifier must NOT allow any siphon
+    of the asset side via fee_tolerance — `fee_asset` is pinned to L-BTC.
+    """
+
+    def _ws_responses_reverse_quote(self):
+        FakeWSClient.responses["subscribe_price_stream"] = {
+            "asset": USDT,
+            "send_bitcoins": False,
+            "send_amount": 9_500_000,
+            "recv_amount": 100_000,
+            "price": 95.0,
+            "fixed_fee": 100,
+        }
+        FakeWSClient.responses["start_swap_web"] = {
+            "order_id": "ord_reverse",
+            "send_asset": USDT,
+            "send_amount": 9_500_000,
+            "recv_asset": L_BTC,
+            "recv_amount": 100_000,
+            "upload_url": "https://api-testnet.sideswap.io/upload/foo",
+        }
+        FakeWSClient.responses["unsubscribe_price_stream"] = {}
+
+    def test_reverse_happy_path_end_to_end(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, storage = swap_manager_setup
+        # Wallet now holds USDt UTXOs and pset_details reflects the reverse
+        # direction's exact balance (no fee on either side; dealer absorbs)
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000}
+        self._ws_responses_reverse_quote()
+
+        with _patch_swap_layers():
+            swap = mgr.execute_swap(
+                asset_id=USDT,
+                send_amount=9_500_000,
+                wallet_name="default",
+                send_bitcoins=False,
+            )
+
+        assert swap.status == "broadcast"
+        assert swap.send_asset == USDT
+        assert swap.send_amount == 9_500_000
+        assert swap.recv_asset == L_BTC
+        assert swap.recv_amount == 100_000
+        # Must have signed and submitted
+        assert len(fake_signer.signed) == 1
+        assert _FakeHTTPClient.last_swap_sign_call is not None
+        # Manager should have asked SideSwap with send_bitcoins=False
+        ws_calls = {m: p for m, p in FakeWSClient.calls}
+        assert ws_calls["subscribe_price_stream"]["send_bitcoins"] is False
+        assert ws_calls["start_swap_web"]["send_bitcoins"] is False
+        # Persisted
+        loaded = storage.load_sideswap_swap("ord_reverse")
+        assert loaded is not None
+        assert loaded.send_asset == USDT
+        assert loaded.recv_asset == L_BTC
+
+    def test_reverse_aborts_on_asset_siphon_within_lbtc_tolerance(self, swap_manager_setup):
+        # The hostile case: server crafts a PSET that takes 9_500_500 USDT
+        # (500 sat siphon) but delivers the agreed L-BTC. If fee_asset were
+        # accidentally USDT, the 1000-sat tolerance would let this through.
+        # We ensure fee_asset is pinned to L-BTC, so the asset side is exact.
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
+        fake_wollet._balances = {USDT: -9_500_500, L_BTC: 100_000}  # siphon 500 USDT
+        self._ws_responses_reverse_quote()
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="more than the agreed"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=9_500_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )
+        # And critically: did NOT sign, did NOT submit
+        assert len(fake_signer.signed) == 0
+        assert _FakeHTTPClient.last_swap_sign_call is None
+
+    def test_reverse_aborts_on_short_lbtc_delivery(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
+        # Server delivers 99k L-BTC instead of 100k
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 99_000}
+        self._ws_responses_reverse_quote()
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="delivers 99000"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=9_500_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )
+        assert len(fake_signer.signed) == 0
+
+    def test_reverse_aborts_on_unrelated_asset_movement(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000, EVIL: -1}
+        self._ws_responses_reverse_quote()
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=9_500_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )
+        assert len(fake_signer.signed) == 0
+
+    def test_reverse_picks_asset_utxos_not_lbtc(self, swap_manager_setup):
+        mgr, _, fake_wollet, _, _ = swap_manager_setup
+        # Wallet has both USDt and L-BTC; manager must select USDT only.
+        fake_wollet._utxos = [
+            _FakeUtxo("aa" * 32, 0, L_BTC, 5_000_000),
+            _FakeUtxo("bb" * 32, 0, USDT, 50_000_000),
+        ]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000}
+        self._ws_responses_reverse_quote()
+
+        with _patch_swap_layers():
+            mgr.execute_swap(
+                asset_id=USDT,
+                send_amount=9_500_000,
+                wallet_name="default",
+                send_bitcoins=False,
+            )
+        sent_inputs = _FakeHTTPClient.last_swap_start_call["inputs"]
+        assert all(u["asset"] == USDT for u in sent_inputs)
+        assert len(sent_inputs) == 1
+
+    def test_reverse_insufficient_asset_balance_raises(self, swap_manager_setup):
+        mgr, _, fake_wollet, _, _ = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 1_000_000)]  # only 1M USDT
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000}
+        self._ws_responses_reverse_quote()
+
+        with _patch_swap_layers():
+            with pytest.raises(ValueError, match="Insufficient confidential balance"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=9_500_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )
+
+    def test_reverse_rejects_lbtc_as_asset_id(self, swap_manager_setup):
+        mgr, _, _, _, _ = swap_manager_setup
+        with _patch_swap_layers():
+            with pytest.raises(ValueError, match="non-L-BTC"):
+                mgr.execute_swap(
+                    asset_id=L_BTC,
+                    send_amount=100_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )


### PR DESCRIPTION
> **Stacked on top of #28** (which is itself stacked on #27). Once #28 lands on `main`, GitHub will auto-rebase this PR's base.

## Summary

- Generalises `sideswap_execute_swap` to handle the reverse direction (asset \xe2\x86\x92 L-BTC, e.g. USDt \xe2\x86\x92 L-BTC) via a new `send_bitcoins: bool` parameter.
- Closes a security gap that the previous PR's verifier had only by accident: pins `fee_asset` to the policy asset (L-BTC) so the 1000-sat fee tolerance never relaxes constraints on a non-L-BTC asset.
- Adds 12 new tests, including 5 verifier tests for the reverse direction's fee semantics and 7 manager-level integration tests covering both honest and malicious-PSET cases.

## Why this needs its own audit

The forward direction has the user paying the network fee out of their L-BTC change, so we allow ~1000 sats of L-BTC slack on the send side. **In the reverse direction the asset side must be exact** — the dealer absorbs the network fee from their L-BTC contribution, and any \"slack\" on the user's USDt would be a direct theft vector. If `fee_asset` were left at its default (`send_asset`), the verifier would happily accept up to 1000 sats of USDt being siphoned per swap. This PR pins `fee_asset = policy_asset` regardless of direction, eliminating that.

## Fee model (verified against AQUA Flutter + sideswap_lwk)

| Direction | User inputs | Network fee paid by | Wallet net effect |
|---|---|---|---|
| L-BTC \xe2\x86\x92 asset | L-BTC UTXOs >= send_amount | User's L-BTC change | L-BTC `-(send + fee)`, asset `+recv` |
| asset \xe2\x86\x92 L-BTC | asset UTXOs >= send_amount | Dealer's L-BTC change | asset `-send` exact, L-BTC `+recv` exact |

In both cases UTXO selection only picks UTXOs of `send_asset` (no separate L-BTC fee inputs), matching `swap_provider.dart` `executeTransaction()` in aquawallet/aqua-wallet.

## What changed

- `SideSwapSwapManager.execute_swap`: new `send_bitcoins: bool = True` parameter; resolves `send_asset`/`recv_asset` based on direction; subscribes to the price stream and starts the order with the right `send_bitcoins` flag; passes `fee_asset = policy_asset` to the verifier.
- `_verify_pset`: now accepts and forwards `fee_asset`.
- `sideswap_execute_swap` MCP tool: new `send_bitcoins` parameter (defaults to `true` so existing callers keep working).
- Tool schema and `swap_assets` prompt: updated to surface both directions.

## Test plan

- [x] Verifier: exact match passes with `fee_asset=L_BTC`
- [x] Verifier: 500-sat USDT siphon rejected when `fee_asset=L_BTC` (the attack vector)
- [x] Verifier: short L-BTC delivery rejected
- [x] Verifier: unrelated-asset siphon rejected
- [x] Verifier: documented test that the default `fee_asset=send_asset` would let the asset siphon through (so future callers know to pass `fee_asset=policy_asset` explicitly)
- [x] Manager: happy path executes asset \xe2\x86\x92 L-BTC end-to-end
- [x] Manager: ALL three malicious-PSET cases for the reverse direction never sign and never POST swap_sign
- [x] Manager: UTXO selector correctly picks USDT inputs even when L-BTC UTXOs are also present
- [x] Manager: insufficient asset balance raises ValueError
- [x] Manager: rejects `asset_id == policy_asset`
- [ ] **Manual testnet smoke test** (asset \xe2\x86\x92 L-BTC) \xe2\x80\x94 required before merging

## Manual testnet smoke test (REQUIRED)

The forward direction's smoke test from #28 still applies. For this PR additionally:

1. Get some testnet USDt (or any non-L-BTC testnet asset) into the wallet
2. Call `sideswap_quote(asset_id=\"<testnet asset>\", send_amount=1000000, send_bitcoins=false, network=\"testnet\")` and verify a price comes back
3. Call `sideswap_execute_swap(asset_id=\"<testnet asset>\", send_amount=1000000, send_bitcoins=false, password=\"...\")`
4. Confirm:
   - Order persists through `pending` \xe2\x86\x92 `verified` \xe2\x86\x92 `signed` \xe2\x86\x92 `broadcast`
   - Wallet's USDt balance decreases by *exactly* `send_amount` (no extra)
   - Wallet's L-BTC balance increases by *exactly* the quoted `recv_amount` (no fee deducted on the user side)
   - The on-chain tx fee is paid by the dealer's L-BTC change output

## Reviewer notes

- The `test_default_fee_asset_is_send_asset_documented_behavior` test is intentionally not a failure case \xe2\x80\x94 it documents the default behaviour. If we ever decide the default should change, that test will fail loudly and force the conversation. Until then it serves as a tripwire.
- `send_bitcoins` is the same flag SideSwap uses on the wire (per AQUA Flutter's `sideswap.dart` const), so we're not introducing a new vocabulary.
- The legacy `start_swap_web` flow is the only flow this code path touches; the new `mkt::*` API is still a separate possible follow-up.

\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)