### PR TITLE
Migrate sideswap_execute_swap to the modern mkt::* flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,7 @@ SideSwap (`sideswap.io`) provides BTC ↔ L-BTC pegs and Liquid asset swaps via 
 - `server_status` — fees, mins, hot-wallet balances
 - `peg_fee`, `peg`, `peg_status` — peg flow
 - `assets`, `subscribe_price_stream`, `unsubscribe_price_stream` — asset swap quoting
+- `market.list_markets`, `market.start_quotes`, `market.get_quote`, `market.taker_sign` — atomic asset swap execution (the modern `mkt::*` flow). Wire format wraps the inner variant in a single-key object: `{"id": N, "method": "market", "params": {"<variant_in_snake_case>": {...}}}`. `AssetType` and `TradeDir` are PascalCase on the wire (`"Base"|"Quote"`, `"Buy"|"Sell"`).
 
 **Fees**:
 - Pegs: 0.1% on send amount + small second-chain fee (~286 sats Liquid claim on peg-in)
@@ -345,10 +346,22 @@ SideSwap (`sideswap.io`) provides BTC ↔ L-BTC pegs and Liquid asset swaps via 
 - Peg-in: 2 BTC confs (~20 min) hot-wallet path; 102 BTC confs (~17 hours) if amount exceeds `PegInWalletBalance`
 - Peg-out: 2 Liquid confs + federation BTC sweep (typically 15–60 min total)
 
-**Asset swap execution** (`sideswap_execute_swap`) supports the legacy `start_swap_web` + HTTP `swap_start`/`swap_sign` flow in **both directions**:
+**Asset swap execution** (`sideswap_execute_swap`) uses SideSwap's modern `mkt::*` flow over WebSocket only (no HTTP dance) and supports **both directions**:
 
 - **L-BTC → asset** (`send_bitcoins=True`): user's L-BTC change pays the network fee. Wallet net effect: `L-BTC: -(send_amount + fee)`, `asset: +recv_amount`.
 - **asset → L-BTC** (`send_bitcoins=False`): SideSwap dealer absorbs the network fee from their L-BTC contribution. Wallet net effect: `asset: -send_amount` (exact), `L-BTC: +recv_amount` (exact).
+
+**mkt::* flow steps**:
+1. `market.list_markets` — fetch available pairs and find one matching ours
+2. Resolve `(asset_type, trade_dir)` via `resolve_market` — always `Sell` with the asset_type matching the side we're sending
+3. `market.start_quotes` with our UTXOs + receive/change addresses + `instant_swap=true`
+4. Wait for a `quote` notification with `status=Success`; `parse_quote_status` raises on `LowBalance` / `Error`
+5. `market.get_quote {quote_id}` → returns the half-built PSET
+6. **Verify** with `wollet.pset_details(pset)` against the agreed quote — refuses to sign on mismatch
+7. `signer.sign(pset)` locally
+8. `market.taker_sign {quote_id, pset}` → server merges & broadcasts; returns the txid
+
+The legacy `start_swap_web` + HTTP `swap_start`/`swap_sign` path is no longer the live execution path. `SideSwapHTTPClient` and `start_swap_web` are kept in the module for compatibility / debugging only.
 
 **Verification rules** (`verify_pset_balances` in `src/aqua/sideswap.py`):
 1. Wallet must gain *exactly* `recv_amount` of `recv_asset`.

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -22,13 +22,15 @@ Methods used here:
 - `assets`                 — list supported assets for swap quoting
 - `subscribe_price_stream` / `unsubscribe_price_stream`
                            — get a price quote for a Liquid asset swap
+- `market.list_markets`    — find the market for an asset pair (mkt::* flow)
+- `market.start_quotes`    — open a quote stream with our UTXOs + addresses
+- `market.get_quote`       — receive the half-built PSET to sign
+- `market.taker_sign`      — submit the locally-signed PSET; server broadcasts
+
+Legacy methods retained for compatibility / debugging only:
+
 - `start_swap_web`         — convert a quote into an order with `upload_url`
-                             for the HTTP `swap_start` / `swap_sign` calls
-
-Plus HTTP (POST to `upload_url` returned by `start_swap_web`):
-
-- `swap_start`             — server returns the half-built PSET to sign
-- `swap_sign`              — submit the locally-signed PSET; server broadcasts
+- HTTP `swap_start` / `swap_sign` to that `upload_url`
 
 PSET verification (security-critical): before signing, we call
 `wollet.pset_details(pset).balance.balances()` and confirm the wallet's net
@@ -521,8 +523,11 @@ class SideSwapWSClient:
         send_amount: int,
         recv_amount: int,
     ) -> dict:
-        """Convert an accepted price quote into an order. Returns an `upload_url`
-        that the HTTP `swap_start` / `swap_sign` calls go to."""
+        """[Legacy] Convert an accepted price quote into an order. Returns an
+        `upload_url` that the HTTP `swap_start` / `swap_sign` calls go to.
+
+        Kept for compatibility/debugging; the live `execute_swap` orchestrator
+        uses the mkt::* flow below."""
         return await self.call(
             "start_swap_web",
             {
@@ -533,6 +538,95 @@ class SideSwapWSClient:
                 "recv_amount": recv_amount,
             },
         )
+
+    # -- mkt::* (modern) ------------------------------------------------------
+    #
+    # All mkt::* requests use top-level method "market" and a single-key
+    # params object whose key is the snake_case mkt::Request variant. The
+    # inner enum's serde tag is `rename_all = "snake_case"`. Per
+    # `sideswap_api/src/mkt.rs`. AssetType and TradeDir do NOT have a serde
+    # rename_all, so they serialise as PascalCase ("Base"/"Quote",
+    # "Buy"/"Sell").
+
+    async def mkt(self, variant: str, params: dict | None = None) -> dict:
+        """Send a `market` request with the given inner variant + params.
+
+        Returns the inner result, unwrapping the {variant: <data>} envelope.
+        """
+        envelope = {variant: (params if params is not None else {})}
+        result = await self.call("market", envelope) or {}
+        # Server wraps responses in {variant_name: <data>} too; unwrap defensively.
+        if isinstance(result, dict) and len(result) == 1 and variant in result:
+            return result[variant]
+        return result
+
+    async def mkt_list_markets(self) -> list[dict]:
+        """List available markets. Returns a list of {asset_pair, fee_asset, type}."""
+        resp = await self.mkt("list_markets", {})
+        return (resp or {}).get("markets", []) or resp.get("list", []) or []
+
+    async def mkt_start_quotes(
+        self,
+        *,
+        asset_pair: dict,
+        asset_type: str,  # "Base" | "Quote"
+        amount: int,
+        trade_dir: str,  # "Buy" | "Sell"
+        utxos: list[dict],
+        receive_address: str,
+        change_address: str,
+        instant_swap: bool = True,
+    ) -> dict:
+        """Open a quote subscription. Returns {quote_sub_id, fee_asset}."""
+        return await self.mkt(
+            "start_quotes",
+            {
+                "asset_pair": asset_pair,
+                "asset_type": asset_type,
+                "amount": amount,
+                "trade_dir": trade_dir,
+                "utxos": utxos,
+                "receive_address": receive_address,
+                "change_address": change_address,
+                "instant_swap": instant_swap,
+            },
+        )
+
+    async def mkt_stop_quotes(self) -> dict:
+        return await self.mkt("stop_quotes", {})
+
+    async def mkt_get_quote(self, quote_id: int) -> dict:
+        """Returns {pset, ttl, receive_ephemeral_sk, change_ephemeral_sk?}."""
+        return await self.mkt("get_quote", {"quote_id": quote_id})
+
+    async def mkt_taker_sign(self, quote_id: int, pset_b64: str) -> dict:
+        """Submit signed PSET. Returns {txid}."""
+        return await self.mkt("taker_sign", {"quote_id": quote_id, "pset": pset_b64})
+
+    async def next_market_notification(
+        self,
+        inner_variant: str,
+        *,
+        timeout: float = WS_TIMEOUT_SECONDS,
+    ) -> dict:
+        """Wait for the next `market` notification whose inner variant matches.
+
+        mkt::* notifications come on the WS as
+        `{"method":"market", "params":{"<inner_variant>":{...}}}`. Returns the
+        inner data. Drops non-matching market notifications and any other
+        method's notifications until one matches or `timeout` elapses.
+        """
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise SideSwapWSError(
+                    f"Timed out waiting for market.{inner_variant} notification"
+                )
+            notif = await self.next_notification("market", timeout=remaining)
+            params = (notif or {}).get("params") or {}
+            if isinstance(params, dict) and inner_variant in params:
+                return params[inner_variant]
 
 
 # ---------------------------------------------------------------------------
@@ -623,6 +717,84 @@ class SideSwapHTTPClient:
                 "pset": signed_pset_b64,
             },
         )
+
+
+# ---------------------------------------------------------------------------
+# Market resolution + quote parsing for the mkt::* flow
+# ---------------------------------------------------------------------------
+
+
+def resolve_market(
+    markets: list[dict],
+    send_asset: str,
+    recv_asset: str,
+) -> tuple[dict, str, str]:
+    """Find the market matching the swap and derive (asset_type, trade_dir).
+
+    SideSwap markets are unordered pairs: a market with `{base: USDt, quote:
+    L-BTC}` covers both directions of L-BTC ↔ USDt. The market never tells you
+    which way to trade — that's controlled by `(asset_type, trade_dir)` on the
+    `start_quotes` request.
+
+    Convention used here for the taker case (we always *sell* whatever side we
+    hold and want to convert): trade_dir = "Sell", asset_type = the side that
+    matches our send_asset.
+
+    Args:
+        markets: List of `{asset_pair: {base, quote}, fee_asset, type}` from
+            `mkt_list_markets`.
+        send_asset: Asset id we are sending.
+        recv_asset: Asset id we are receiving.
+
+    Returns:
+        (market_dict, asset_type, trade_dir). The asset_type / trade_dir
+        strings are PascalCase to match the wire format ("Base" | "Quote",
+        "Buy" | "Sell").
+
+    Raises:
+        SideSwapWSError if no matching market exists.
+    """
+    for market in markets:
+        pair = market.get("asset_pair") or {}
+        base = pair.get("base")
+        quote = pair.get("quote")
+        if base is None or quote is None:
+            continue
+        if {base, quote} != {send_asset, recv_asset}:
+            continue
+        # Match: asset_type names the side that matches send_asset; trade_dir is Sell.
+        asset_type = "Base" if send_asset == base else "Quote"
+        return market, asset_type, "Sell"
+    raise SideSwapWSError(
+        f"No SideSwap market for pair ({send_asset[:8]}…, {recv_asset[:8]}…)"
+    )
+
+
+def parse_quote_status(quote_notif: dict) -> dict:
+    """Extract a quote_id + amounts from a `quote` notification's `status` field.
+
+    The status is one of three variants per `mkt::QuoteStatus`:
+        Success { quote_id, base_amount, quote_amount, server_fee, fixed_fee, ttl }
+        LowBalance { ..., available }
+        Error { error_msg }
+
+    Returns the unwrapped Success dict on success; raises `SideSwapWSError` on
+    LowBalance or Error so the caller never proceeds with an invalid quote.
+    """
+    status = quote_notif.get("status")
+    if not isinstance(status, dict) or not status:
+        raise SideSwapWSError(f"Malformed quote status: {status!r}")
+    if "Success" in status:
+        return status["Success"]
+    if "LowBalance" in status:
+        lb = status["LowBalance"]
+        raise SideSwapWSError(
+            f"Quote unavailable: dealer low balance "
+            f"(available={lb.get('available')}, fixed_fee={lb.get('fixed_fee')})"
+        )
+    if "Error" in status:
+        raise SideSwapWSError(f"Quote error: {status['Error'].get('error_msg')}")
+    raise SideSwapWSError(f"Unknown QuoteStatus: {status!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -1162,19 +1334,28 @@ DEFAULT_FEE_TOLERANCE_SATS = 1_000
 
 
 class SideSwapSwapManager:
-    """Orchestrates a SideSwap atomic asset swap end-to-end.
+    """Orchestrates a SideSwap atomic asset swap end-to-end via the modern
+    `mkt::*` flow.
 
-    Flow (legacy `start_swap_web` + HTTP `swap_start`/`swap_sign`):
+    Flow:
 
-      1. Subscribe to a price stream and capture a quote (price + amounts)
-      2. Send `start_swap_web` with the captured price → returns `upload_url`
-      3. Select confidential UTXOs of `send_asset` covering `send_amount`
-      4. POST `swap_start` with inputs + recv_addr + change_addr → returns PSET
-      5. **Verify** the PSET with the wallet's `pset_details` against the quote.
-         Aborts (raises `PsetVerificationError`) if the PSET doesn't match.
-      6. Sign the PSET with `signer.sign(pset)`
-      7. POST `swap_sign` with the signed PSET → returns `txid`
-      8. Persist throughout; on broadcast, save `txid` and status="broadcast"
+      1. Pick UTXOs of `send_asset` covering `send_amount` and prepare
+         receive + change addresses (mkt::* wants them up-front)
+      2. WS `market.list_markets` to find the market for our asset pair
+      3. WS `market.start_quotes` with the inputs + addresses + asset_type +
+         trade_dir; server begins streaming `quote` notifications
+      4. Wait for a `quote` notification with status=Success and capture
+         the resulting `quote_id` + amounts
+      5. WS `market.get_quote` with the quote_id → returns the PSET
+      6. **Verify** the PSET with the wallet's `pset_details` against the
+         agreed quote. Aborts (raises `PsetVerificationError`) on mismatch.
+      7. Sign the PSET with `signer.sign(pset)`
+      8. WS `market.taker_sign` with the signed PSET → returns `txid`
+      9. Persist at every step; on broadcast, save `txid` and status="broadcast"
+
+    The legacy `start_swap_web` + HTTP `swap_start`/`swap_sign` path is no
+    longer used by this orchestrator; its WS method and HTTP client are kept
+    in this module for compatibility / debugging only.
     """
 
     def __init__(self, storage, wallet_manager) -> None:
@@ -1255,58 +1436,93 @@ class SideSwapSwapManager:
         else:
             send_asset, recv_asset = asset_id, policy_asset
 
-        async def _quote_and_start() -> tuple[dict, dict]:
+        # Build the inputs/addresses up-front; mkt::* wants them on
+        # start_quotes (not as a follow-up call).
+        wollet = self.wallet_manager._get_wollet(wallet_name)
+        inputs = select_swap_utxos(wollet.utxos(), send_asset, send_amount)
+        recv_addr = str(wollet.address(None).address())
+        change_addr = str(wollet.address(None).address())
+
+        async def _quote_to_pset() -> tuple[dict, dict, dict]:
+            """Open WS, run the mkt::* dance, return (market, quote, get_quote_resp)."""
             async with SideSwapWSClient(network) as client:
                 await client.login_client()
-                # Get the streamed price quote
-                initial = await client.subscribe_price_stream(
-                    asset=asset_id,
-                    send_bitcoins=send_bitcoins,
-                    send_amount=send_amount,
+                # Find a market that covers our pair
+                markets = await client.mkt_list_markets()
+                market, asset_type, trade_dir = resolve_market(
+                    markets, send_asset=send_asset, recv_asset=recv_asset
                 )
-                quote = initial or {}
-                if not quote.get("price"):
-                    notif = await client.next_notification(
-                        "update_price_stream", timeout=quote_wait_seconds
-                    )
-                    quote = (notif or {}).get("params") or {}
-                if not quote.get("price"):
-                    raise SideSwapWSError(
-                        "SideSwap did not return a usable price quote"
-                    )
-                if quote.get("error_msg"):
-                    raise SideSwapWSError(f"SideSwap quote error: {quote['error_msg']}")
-                # Accept the price and start the order
-                start_resp = await client.start_swap_web(
-                    asset=asset_id,
-                    price=float(quote["price"]),
-                    send_bitcoins=send_bitcoins,
-                    send_amount=int(quote["send_amount"]),
-                    recv_amount=int(quote["recv_amount"]),
+                # Open quote subscription with our UTXOs + addresses pre-attached
+                await client.mkt_start_quotes(
+                    asset_pair=market["asset_pair"],
+                    asset_type=asset_type,
+                    amount=send_amount,
+                    trade_dir=trade_dir,
+                    utxos=inputs,
+                    receive_address=recv_addr,
+                    change_address=change_addr,
+                    instant_swap=True,
                 )
+                # Wait for the first usable quote — a `quote` notification with
+                # a Success status. parse_quote_status raises on LowBalance/Error.
+                quote_notif = await client.next_market_notification(
+                    "quote", timeout=quote_wait_seconds
+                )
+                quote = parse_quote_status(quote_notif)
+                # Accept the quote and request the half-built PSET
+                get_quote_resp = await client.mkt_get_quote(int(quote["quote_id"]))
+                # Best-effort cleanup
                 try:
-                    await client.unsubscribe_price_stream(asset_id)
+                    await client.mkt_stop_quotes()
                 except Exception:
                     pass
-                return quote, start_resp
+                return market, quote, get_quote_resp
 
-        quote, start_resp = _run(_quote_and_start())
+        market, quote_data, get_quote_resp = _run(_quote_to_pset())
 
-        order_id = start_resp.get("order_id")
-        upload_url = start_resp.get("upload_url")
-        recv_amount = int(start_resp.get("recv_amount") or quote.get("recv_amount"))
-        if not order_id or not upload_url:
-            raise SideSwapWSError(f"Unexpected start_swap_web response: {start_resp!r}")
+        # Decide a stable order_id we control for persistence. SideSwap mkt::*
+        # gives us a `quote_id` (numeric) per quote; the `order_id` field is
+        # only used for marker resting orders. We persist the quote_id as a
+        # string in our `order_id` slot so the rest of the manager (status
+        # lookup, storage path) keeps the same shape.
+        quote_id = int(quote_data["quote_id"])
+        order_id = f"mkt_{quote_id}"
+        recv_amount = int(quote_data["quote_amount"]) if asset_id == market["asset_pair"]["base"] else int(quote_data["base_amount"])
+        # Re-derive recv/send amounts from the quote, not the user's request:
+        # the dealer's quote_amount/base_amount are the canonical numbers.
+        if send_asset == market["asset_pair"].get("base"):
+            send_amount_q = int(quote_data["base_amount"])
+            recv_amount_q = int(quote_data["quote_amount"])
+        else:
+            send_amount_q = int(quote_data["quote_amount"])
+            recv_amount_q = int(quote_data["base_amount"])
+        if send_amount_q != send_amount:
+            raise SideSwapWSError(
+                f"Quote send_amount mismatch: requested {send_amount}, dealer offered {send_amount_q}"
+            )
+        recv_amount = recv_amount_q
 
-        # Persist the in-progress swap before any HTTP work
+        pset_b64 = get_quote_resp.get("pset")
+        if not pset_b64:
+            raise SideSwapWSError(f"Unexpected get_quote response: {get_quote_resp!r}")
+
+        # Persist the in-progress swap before signing.
+        # `submit_id` is reused to hold the quote_id so existing storage stays
+        # backward-compatible with the legacy flow.
+        price = float(quote_data.get("server_fee", 0)) and 0.0  # placeholder; filled below
+        # SideSwap quote doesn't return a single 'price' field on mkt::*; derive
+        # it from amounts. price = quote_amount / base_amount — but client may
+        # interpret either side, so we just store recv/send ratio for reference.
+        price = recv_amount / send_amount if send_amount else 0.0
+
         swap = SideSwapSwap(
             order_id=order_id,
-            submit_id=None,
+            submit_id=str(quote_id),
             send_asset=send_asset,
             send_amount=send_amount,
             recv_asset=recv_asset,
             recv_amount=recv_amount,
-            price=float(quote["price"]),
+            price=price,
             wallet_name=wallet_name,
             network=network,
             status="pending",
@@ -1315,39 +1531,9 @@ class SideSwapSwapManager:
         self.storage.save_sideswap_swap(swap)
 
         try:
-            # Build the inputs/addresses for swap_start. AQUA Flutter selects
-            # only UTXOs of `send_asset` (no separate L-BTC fee inputs); the
-            # SideSwap dealer absorbs the network fee on the reverse direction
-            # and routes it through the user's L-BTC change on the forward
-            # direction. See `lib/features/sideswap/providers/swap_provider.dart`.
-            wollet = self.wallet_manager._get_wollet(wallet_name)
-            inputs = select_swap_utxos(wollet.utxos(), send_asset, send_amount)
-            recv_addr = str(wollet.address(None).address())
-            change_addr = str(wollet.address(None).address())
-
-            http = SideSwapHTTPClient(upload_url)
-            start_payload = http.swap_start(
-                order_id=order_id,
-                inputs=inputs,
-                recv_addr=recv_addr,
-                change_addr=change_addr,
-                send_asset=send_asset,
-                send_amount=send_amount,
-                recv_asset=recv_asset,
-                recv_amount=recv_amount,
-            )
-            submit_id = start_payload.get("submit_id")
-            pset_b64 = start_payload.get("pset")
-            if not submit_id or not pset_b64:
-                raise SideSwapWSError(
-                    f"Unexpected swap_start response: {start_payload!r}"
-                )
-            swap.submit_id = submit_id
-            self.storage.save_sideswap_swap(swap)
-
-            # Verify before signing — security-critical. fee_asset is always
-            # the policy asset (L-BTC); when send_asset != L-BTC the fee
-            # tolerance does NOT relax the constraint on the asset side.
+            # Verify before signing — security-critical. fee_asset is pinned
+            # to the policy asset; on the reverse direction this prevents a
+            # 1000-sat siphon of the asset via the fee tolerance loophole.
             self._verify_pset(
                 pset_b64,
                 wollet,
@@ -1371,13 +1557,16 @@ class SideSwapSwapManager:
             swap.status = "signed"
             self.storage.save_sideswap_swap(swap)
 
-            # Submit signed PSET; server merges & broadcasts
-            sign_payload = http.swap_sign(
-                order_id=order_id, submit_id=submit_id, signed_pset_b64=signed_b64
-            )
+            # Submit signed PSET via mkt::taker_sign; server merges & broadcasts
+            async def _submit() -> dict:
+                async with SideSwapWSClient(network) as client:
+                    await client.login_client()
+                    return await client.mkt_taker_sign(quote_id, signed_b64)
+
+            sign_payload = _run(_submit())
             txid = sign_payload.get("txid")
             if not txid:
-                raise SideSwapWSError(f"Unexpected swap_sign response: {sign_payload!r}")
+                raise SideSwapWSError(f"Unexpected taker_sign response: {sign_payload!r}")
             swap.txid = txid
             swap.status = "broadcast"
             self.storage.save_sideswap_swap(swap)

--- a/tests/test_sideswap.py
+++ b/tests/test_sideswap.py
@@ -22,8 +22,11 @@ from aqua.sideswap import (
     SideSwapPriceQuote,
     SideSwapServerStatus,
     SideSwapSwap,
+    SideSwapWSError,
     map_peg_status,
+    parse_quote_status,
     recommend_peg_or_swap,
+    resolve_market,
     verify_pset_balances,
 )
 from aqua.storage import Storage
@@ -114,6 +117,39 @@ class FakeWSClient:
     async def next_notification(self, method=None, *, timeout=30.0):  # noqa: ARG002
         FakeWSClient.calls.append(("notification", {"method": method}))
         notif = FakeWSClient.responses.get("__notification__")
+        if isinstance(notif, Exception):
+            raise notif
+        return notif
+
+    # mkt::* helpers — record method names with "mkt." prefix so tests can
+    # script them via FakeWSClient.responses["mkt.list_markets"] etc.
+
+    async def mkt(self, variant, params=None):
+        return await self.call(f"mkt.{variant}", params)
+
+    async def mkt_list_markets(self):
+        resp = await self.call("mkt.list_markets", {}) or {}
+        return resp.get("markets", []) or resp.get("list", []) or []
+
+    async def mkt_start_quotes(self, **params):
+        return await self.call("mkt.start_quotes", params)
+
+    async def mkt_stop_quotes(self):
+        return await self.call("mkt.stop_quotes", {})
+
+    async def mkt_get_quote(self, quote_id):
+        return await self.call("mkt.get_quote", {"quote_id": quote_id})
+
+    async def mkt_taker_sign(self, quote_id, pset_b64):
+        return await self.call(
+            "mkt.taker_sign", {"quote_id": quote_id, "pset": pset_b64}
+        )
+
+    async def next_market_notification(self, inner_variant, *, timeout=30.0):  # noqa: ARG002
+        FakeWSClient.calls.append(("mkt_notification", {"inner": inner_variant}))
+        notif = FakeWSClient.responses.get(f"__mkt_notification__:{inner_variant}")
+        if notif is None:
+            notif = FakeWSClient.responses.get("__mkt_notification__")
         if isinstance(notif, Exception):
             raise notif
         return notif
@@ -734,6 +770,113 @@ class TestServerStatusDataclass:
         d = s.to_dict()
         assert d["min_peg_in_amount"] == 1286
         assert d["server_fee_percent_peg_in"] is None
+
+
+# ---------------------------------------------------------------------------
+# mkt::* helpers — resolve_market and parse_quote_status
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMarket:
+    """Verifies that we pick the right market and derive (asset_type, trade_dir)."""
+
+    _MARKET_USDT_LBTC = {
+        "asset_pair": {"base": USDT, "quote": L_BTC},
+        "fee_asset": "Quote",
+        "type": "Stablecoin",
+    }
+
+    def test_send_quote_side_returns_quote_sell(self):
+        # USDt is base, L-BTC is quote. Sending L-BTC = sending quote.
+        market, asset_type, trade_dir = resolve_market(
+            [self._MARKET_USDT_LBTC], send_asset=L_BTC, recv_asset=USDT
+        )
+        assert market is self._MARKET_USDT_LBTC
+        assert asset_type == "Quote"
+        assert trade_dir == "Sell"
+
+    def test_send_base_side_returns_base_sell(self):
+        # Sending USDt (base) for L-BTC.
+        _, asset_type, trade_dir = resolve_market(
+            [self._MARKET_USDT_LBTC], send_asset=USDT, recv_asset=L_BTC
+        )
+        assert asset_type == "Base"
+        assert trade_dir == "Sell"
+
+    def test_swapped_pair_orientation_still_resolves(self):
+        # If a server returned the pair with base/quote flipped, we still
+        # find it and adjust asset_type accordingly.
+        flipped = {
+            "asset_pair": {"base": L_BTC, "quote": USDT},
+            "fee_asset": "Base",
+            "type": "Stablecoin",
+        }
+        # Sending L-BTC, which is now Base.
+        _, asset_type, _ = resolve_market(
+            [flipped], send_asset=L_BTC, recv_asset=USDT
+        )
+        assert asset_type == "Base"
+
+    def test_no_matching_market_raises(self):
+        with pytest.raises(SideSwapWSError, match="No SideSwap market"):
+            resolve_market(
+                [self._MARKET_USDT_LBTC], send_asset=L_BTC, recv_asset=EVIL
+            )
+
+    def test_skips_markets_with_missing_pair(self):
+        bad = {"asset_pair": {}, "fee_asset": "Quote"}
+        market, _, _ = resolve_market(
+            [bad, self._MARKET_USDT_LBTC], send_asset=L_BTC, recv_asset=USDT
+        )
+        assert market is self._MARKET_USDT_LBTC
+
+
+class TestParseQuoteStatus:
+    """Encodes the contract for SideSwap's three QuoteStatus variants."""
+
+    def test_success_returns_inner(self):
+        notif = {
+            "status": {
+                "Success": {
+                    "quote_id": 42,
+                    "base_amount": 100,
+                    "quote_amount": 200,
+                    "server_fee": 1,
+                    "fixed_fee": 1,
+                    "ttl": 30000,
+                }
+            }
+        }
+        result = parse_quote_status(notif)
+        assert result["quote_id"] == 42
+        assert result["quote_amount"] == 200
+
+    def test_low_balance_raises_with_available(self):
+        notif = {
+            "status": {
+                "LowBalance": {
+                    "base_amount": 0,
+                    "quote_amount": 0,
+                    "server_fee": 0,
+                    "fixed_fee": 0,
+                    "available": 1234,
+                }
+            }
+        }
+        with pytest.raises(SideSwapWSError, match="low balance"):
+            parse_quote_status(notif)
+
+    def test_error_status_raises_with_message(self):
+        with pytest.raises(SideSwapWSError, match="boom"):
+            parse_quote_status({"status": {"Error": {"error_msg": "boom"}}})
+
+    def test_missing_status_raises(self):
+        with pytest.raises(SideSwapWSError):
+            parse_quote_status({})
+
+    def test_unknown_status_variant_raises(self):
+        with pytest.raises(SideSwapWSError, match="Unknown QuoteStatus"):
+            parse_quote_status({"status": {"Surprise": {}}})
 
 
 # ---------------------------------------------------------------------------
@@ -1426,29 +1569,104 @@ def _patch_swap_layers():
     return stack
 
 
+def _setup_mkt_responses_forward():
+    """Script the FakeWSClient with a clean L-BTC → USDt mkt::* flow.
+
+    The market base is USDt and quote is L-BTC, so for sending L-BTC the
+    `asset_type` is "Quote" (matching the wire format).
+    """
+    FakeWSClient.responses["mkt.list_markets"] = {
+        "markets": [
+            {
+                "asset_pair": {"base": USDT, "quote": L_BTC},
+                "fee_asset": "Quote",
+                "type": "Stablecoin",
+            }
+        ]
+    }
+    FakeWSClient.responses["mkt.start_quotes"] = {"quote_sub_id": 7, "fee_asset": "Quote"}
+    FakeWSClient.responses["__mkt_notification__:quote"] = {
+        "quote_sub_id": 7,
+        "asset_pair": {"base": USDT, "quote": L_BTC},
+        "asset_type": "Quote",
+        "amount": 100_000,
+        "trade_dir": "Sell",
+        "status": {
+            "Success": {
+                "quote_id": 42,
+                # market is base=USDt, quote=L-BTC. We're sending L-BTC (Quote).
+                # base_amount is in USDt, quote_amount is in L-BTC.
+                "base_amount": 9_500_000,
+                "quote_amount": 100_000,
+                "server_fee": 100,
+                "fixed_fee": 100,
+                "ttl": 30_000,
+            }
+        },
+    }
+    FakeWSClient.responses["mkt.get_quote"] = {
+        "pset": "cHNldP8BUNSIGNED",
+        "ttl": 30_000,
+        "receive_ephemeral_sk": "00" * 32,
+        "change_ephemeral_sk": "00" * 32,
+    }
+    FakeWSClient.responses["mkt.taker_sign"] = {"txid": "ee" * 32}
+    FakeWSClient.responses["mkt.stop_quotes"] = {}
+
+
+def _setup_mkt_responses_reverse():
+    """Script the FakeWSClient with a clean USDt → L-BTC mkt::* flow."""
+    FakeWSClient.responses["mkt.list_markets"] = {
+        "markets": [
+            {
+                "asset_pair": {"base": USDT, "quote": L_BTC},
+                "fee_asset": "Quote",
+                "type": "Stablecoin",
+            }
+        ]
+    }
+    FakeWSClient.responses["mkt.start_quotes"] = {"quote_sub_id": 7, "fee_asset": "Quote"}
+    FakeWSClient.responses["__mkt_notification__:quote"] = {
+        "quote_sub_id": 7,
+        "asset_pair": {"base": USDT, "quote": L_BTC},
+        "asset_type": "Base",  # we're sending USDt = Base
+        "amount": 9_500_000,
+        "trade_dir": "Sell",
+        "status": {
+            "Success": {
+                "quote_id": 99,
+                "base_amount": 9_500_000,
+                "quote_amount": 100_000,
+                "server_fee": 100,
+                "fixed_fee": 100,
+                "ttl": 30_000,
+            }
+        },
+    }
+    FakeWSClient.responses["mkt.get_quote"] = {
+        "pset": "cHNldP8BUNSIGNED",
+        "ttl": 30_000,
+        "receive_ephemeral_sk": "00" * 32,
+        "change_ephemeral_sk": "00" * 32,
+    }
+    FakeWSClient.responses["mkt.taker_sign"] = {"txid": "ee" * 32}
+    FakeWSClient.responses["mkt.stop_quotes"] = {}
+
+
+def _start_quotes_call_args():
+    """Return the params dict from the most recent `mkt.start_quotes` call."""
+    for method, params in reversed(FakeWSClient.calls):
+        if method == "mkt.start_quotes":
+            return params
+    return None
+
+
 class TestSwapManagerExecute:
-    def _ws_responses_for_quote(self):
-        FakeWSClient.responses["subscribe_price_stream"] = {
-            "asset": USDT,
-            "send_bitcoins": True,
-            "send_amount": 100_000,
-            "recv_amount": 9_500_000,
-            "price": 95.0,
-            "fixed_fee": 100,
-        }
-        FakeWSClient.responses["start_swap_web"] = {
-            "order_id": "ord_happy",
-            "send_asset": L_BTC,
-            "send_amount": 100_000,
-            "recv_asset": USDT,
-            "recv_amount": 9_500_000,
-            "upload_url": "https://api-testnet.sideswap.io/upload/foo",
-        }
-        FakeWSClient.responses["unsubscribe_price_stream"] = {}
+    """Forward direction (L-BTC → USDt) via the mkt::* flow."""
 
     def test_happy_path_end_to_end(self, swap_manager_setup):
         mgr, _, _, fake_signer, storage = swap_manager_setup
-        self._ws_responses_for_quote()
+        _setup_mkt_responses_forward()
 
         with _patch_swap_layers():
             swap = mgr.execute_swap(
@@ -1457,21 +1675,45 @@ class TestSwapManagerExecute:
 
         assert swap.status == "broadcast"
         assert swap.txid == "ee" * 32
-        assert swap.order_id == "ord_happy"
+        # quote_id 42 → order_id "mkt_42" (so the storage layer keeps a
+        # filename-safe stable id even though the protocol identifies a swap
+        # by quote_id, not order_id)
+        assert swap.order_id == "mkt_42"
+        assert swap.submit_id == "42"
         # We did sign exactly once
         assert len(fake_signer.signed) == 1
-        # HTTP layer received the signed PSET
-        assert _FakeHTTPClient.last_swap_sign_call["signed_pset_b64"] == "cHNldP8BSIGNED"
+        # taker_sign call carried the signed PSET
+        taker_sign_calls = [(m, p) for m, p in FakeWSClient.calls if m == "mkt.taker_sign"]
+        assert len(taker_sign_calls) == 1
+        assert taker_sign_calls[0][1]["pset"] == "cHNldP8BSIGNED"
         # Persisted across the whole flow
-        loaded = storage.load_sideswap_swap("ord_happy")
+        loaded = storage.load_sideswap_swap("mkt_42")
         assert loaded is not None
         assert loaded.status == "broadcast"
 
+    def test_start_quotes_uses_sell_and_correct_asset_type(self, swap_manager_setup):
+        # For L-BTC → USDt with a market where USDt is base and L-BTC is quote,
+        # we send the quote side. asset_type must be "Quote", trade_dir "Sell".
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        with _patch_swap_layers():
+            mgr.execute_swap(asset_id=USDT, send_amount=100_000, wallet_name="default")
+        params = _start_quotes_call_args()
+        assert params["asset_type"] == "Quote"
+        assert params["trade_dir"] == "Sell"
+        assert params["amount"] == 100_000
+        assert params["instant_swap"] is True
+        assert params["receive_address"] is not None
+        assert params["change_address"] is not None
+        assert params["receive_address"] != params["change_address"]
+        assert all(u["asset"] == L_BTC for u in params["utxos"])
+
     def test_aborts_when_pset_balance_does_not_match(self, swap_manager_setup):
-        # Override the fake wollet to return a malicious balance (server stole funds)
+        # The deadly attack: server crafts a PSET that takes our L-BTC but the
+        # recv_asset balance is 0.
         mgr, _, fake_wollet, fake_signer, storage = swap_manager_setup
-        self._ws_responses_for_quote()
-        fake_wollet._balances = {L_BTC: -100_000, USDT: 0}  # we get nothing!
+        _setup_mkt_responses_forward()
+        fake_wollet._balances = {L_BTC: -100_000, USDT: 0}
 
         with _patch_swap_layers():
             with pytest.raises(PsetVerificationError):
@@ -1479,19 +1721,18 @@ class TestSwapManagerExecute:
                     asset_id=USDT, send_amount=100_000, wallet_name="default"
                 )
 
-        # Critically: we did NOT sign, and we did NOT submit
+        # Critically: never signed, never submitted via taker_sign
         assert len(fake_signer.signed) == 0
-        assert _FakeHTTPClient.last_swap_sign_call is None
-        # And the order is persisted as failed for forensics
-        loaded = storage.load_sideswap_swap("ord_happy")
+        assert not any(m == "mkt.taker_sign" for m, _ in FakeWSClient.calls)
+        # Persisted as failed for forensics
+        loaded = storage.load_sideswap_swap("mkt_42")
         assert loaded is not None
         assert loaded.status == "failed"
         assert "PSET verification failed" in (loaded.last_error or "")
 
     def test_aborts_when_pset_takes_extra_lbtc(self, swap_manager_setup):
         mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
-        self._ws_responses_for_quote()
-        # Server overcharges: takes 200k instead of 100k
+        _setup_mkt_responses_forward()
         fake_wollet._balances = {L_BTC: -200_000, USDT: 9_500_000}
 
         with _patch_swap_layers():
@@ -1503,7 +1744,7 @@ class TestSwapManagerExecute:
 
     def test_aborts_when_pset_moves_unrelated_asset(self, swap_manager_setup):
         mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
-        self._ws_responses_for_quote()
+        _setup_mkt_responses_forward()
         fake_wollet._balances = {L_BTC: -100_050, USDT: 9_500_000, EVIL: -500}
 
         with _patch_swap_layers():
@@ -1528,30 +1769,95 @@ class TestSwapManagerExecute:
                 asset_id=USDT, send_amount=100_000, wallet_name="ghost"
             )
 
-    def test_no_quote_returned(self, swap_manager_setup):
+    def test_quote_lowbalance_raises(self, swap_manager_setup):
         from aqua.sideswap import SideSwapWSError
 
         mgr, _, _, _, _ = swap_manager_setup
-        FakeWSClient.responses["subscribe_price_stream"] = {"asset": USDT, "send_bitcoins": True}
-        FakeWSClient.responses["__notification__"] = {
-            "method": "update_price_stream",
-            "params": {"error_msg": "no_liquidity"},
+        FakeWSClient.responses["mkt.list_markets"] = {
+            "markets": [{"asset_pair": {"base": USDT, "quote": L_BTC}, "fee_asset": "Quote", "type": "Stablecoin"}]
+        }
+        FakeWSClient.responses["mkt.start_quotes"] = {"quote_sub_id": 1, "fee_asset": "Quote"}
+        FakeWSClient.responses["__mkt_notification__:quote"] = {
+            "quote_sub_id": 1,
+            "asset_pair": {"base": USDT, "quote": L_BTC},
+            "asset_type": "Quote",
+            "amount": 100_000,
+            "trade_dir": "Sell",
+            "status": {
+                "LowBalance": {
+                    "base_amount": 0,
+                    "quote_amount": 0,
+                    "server_fee": 0,
+                    "fixed_fee": 0,
+                    "available": 1_000,
+                }
+            },
         }
         with _patch_swap_layers():
-            with pytest.raises(SideSwapWSError):
+            with pytest.raises(SideSwapWSError, match="low balance"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_quote_error_raises(self, swap_manager_setup):
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        FakeWSClient.responses["mkt.list_markets"] = {
+            "markets": [{"asset_pair": {"base": USDT, "quote": L_BTC}, "fee_asset": "Quote", "type": "Stablecoin"}]
+        }
+        FakeWSClient.responses["mkt.start_quotes"] = {"quote_sub_id": 1, "fee_asset": "Quote"}
+        FakeWSClient.responses["__mkt_notification__:quote"] = {
+            "quote_sub_id": 1,
+            "asset_pair": {"base": USDT, "quote": L_BTC},
+            "asset_type": "Quote",
+            "amount": 100_000,
+            "trade_dir": "Sell",
+            "status": {"Error": {"error_msg": "no_dealers"}},
+        }
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="no_dealers"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_no_market_for_pair_raises(self, swap_manager_setup):
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        # Empty market list — no L-BTC/USDt pair available
+        FakeWSClient.responses["mkt.list_markets"] = {"markets": []}
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="No SideSwap market"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_quote_send_amount_mismatch_raises(self, swap_manager_setup):
+        # If the dealer's quote contradicts what we asked for, abort. This is
+        # an additional belt-and-braces check on top of the PSET verifier.
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        # Pretend the dealer offered 200k of L-BTC instead of the 100k we asked
+        FakeWSClient.responses["__mkt_notification__:quote"]["status"]["Success"]["quote_amount"] = 200_000
+
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="send_amount mismatch"):
                 mgr.execute_swap(
                     asset_id=USDT, send_amount=100_000, wallet_name="default"
                 )
 
     def test_swap_status_returns_persisted(self, swap_manager_setup):
-        mgr, _, _, _, storage = swap_manager_setup
-        self._ws_responses_for_quote()
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
         with _patch_swap_layers():
             mgr.execute_swap(
                 asset_id=USDT, send_amount=100_000, wallet_name="default"
             )
-        result = mgr.status("ord_happy")
-        assert result["order_id"] == "ord_happy"
+        result = mgr.status("mkt_42")
+        assert result["order_id"] == "mkt_42"
         assert result["status"] == "broadcast"
         assert result["txid"] == "ee" * 32
         assert result["recv_asset"] == USDT
@@ -1564,40 +1870,19 @@ class TestSwapManagerExecute:
 
 
 class TestSwapManagerReverseExecute:
-    """Reverse direction: asset → L-BTC.
+    """Reverse direction: asset → L-BTC via the mkt::* flow.
 
     The dealer absorbs the network fee from their L-BTC contribution, so the
     wallet's effect is exact on both sides: -send_amount of asset and
-    +recv_amount of L-BTC. Crucially, the verifier must NOT allow any siphon
-    of the asset side via fee_tolerance — `fee_asset` is pinned to L-BTC.
+    +recv_amount of L-BTC. The verifier MUST NOT allow any siphon of the
+    asset side via fee_tolerance — `fee_asset` is pinned to L-BTC.
     """
-
-    def _ws_responses_reverse_quote(self):
-        FakeWSClient.responses["subscribe_price_stream"] = {
-            "asset": USDT,
-            "send_bitcoins": False,
-            "send_amount": 9_500_000,
-            "recv_amount": 100_000,
-            "price": 95.0,
-            "fixed_fee": 100,
-        }
-        FakeWSClient.responses["start_swap_web"] = {
-            "order_id": "ord_reverse",
-            "send_asset": USDT,
-            "send_amount": 9_500_000,
-            "recv_asset": L_BTC,
-            "recv_amount": 100_000,
-            "upload_url": "https://api-testnet.sideswap.io/upload/foo",
-        }
-        FakeWSClient.responses["unsubscribe_price_stream"] = {}
 
     def test_reverse_happy_path_end_to_end(self, swap_manager_setup):
         mgr, _, fake_wollet, fake_signer, storage = swap_manager_setup
-        # Wallet now holds USDt UTXOs and pset_details reflects the reverse
-        # direction's exact balance (no fee on either side; dealer absorbs)
         fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
         fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000}
-        self._ws_responses_reverse_quote()
+        _setup_mkt_responses_reverse()
 
         with _patch_swap_layers():
             swap = mgr.execute_swap(
@@ -1612,28 +1897,28 @@ class TestSwapManagerReverseExecute:
         assert swap.send_amount == 9_500_000
         assert swap.recv_asset == L_BTC
         assert swap.recv_amount == 100_000
-        # Must have signed and submitted
+        # Manager asked SideSwap with asset_type=Base, trade_dir=Sell
+        params = _start_quotes_call_args()
+        assert params["asset_type"] == "Base"
+        assert params["trade_dir"] == "Sell"
+        assert all(u["asset"] == USDT for u in params["utxos"])
+        # Signed once, submitted once
         assert len(fake_signer.signed) == 1
-        assert _FakeHTTPClient.last_swap_sign_call is not None
-        # Manager should have asked SideSwap with send_bitcoins=False
-        ws_calls = {m: p for m, p in FakeWSClient.calls}
-        assert ws_calls["subscribe_price_stream"]["send_bitcoins"] is False
-        assert ws_calls["start_swap_web"]["send_bitcoins"] is False
-        # Persisted
-        loaded = storage.load_sideswap_swap("ord_reverse")
+        taker_sign_calls = [(m, p) for m, p in FakeWSClient.calls if m == "mkt.taker_sign"]
+        assert len(taker_sign_calls) == 1
+        loaded = storage.load_sideswap_swap("mkt_99")
         assert loaded is not None
         assert loaded.send_asset == USDT
         assert loaded.recv_asset == L_BTC
 
     def test_reverse_aborts_on_asset_siphon_within_lbtc_tolerance(self, swap_manager_setup):
-        # The hostile case: server crafts a PSET that takes 9_500_500 USDT
-        # (500 sat siphon) but delivers the agreed L-BTC. If fee_asset were
-        # accidentally USDT, the 1000-sat tolerance would let this through.
-        # We ensure fee_asset is pinned to L-BTC, so the asset side is exact.
+        # Server takes 500 sat extra USDT but delivers correct L-BTC. If
+        # fee_asset were accidentally USDT, the 1000-sat tolerance would let
+        # this slip through. We pin fee_asset=L-BTC so the asset side is exact.
         mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
         fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
-        fake_wollet._balances = {USDT: -9_500_500, L_BTC: 100_000}  # siphon 500 USDT
-        self._ws_responses_reverse_quote()
+        fake_wollet._balances = {USDT: -9_500_500, L_BTC: 100_000}
+        _setup_mkt_responses_reverse()
 
         with _patch_swap_layers():
             with pytest.raises(PsetVerificationError, match="more than the agreed"):
@@ -1643,16 +1928,14 @@ class TestSwapManagerReverseExecute:
                     wallet_name="default",
                     send_bitcoins=False,
                 )
-        # And critically: did NOT sign, did NOT submit
         assert len(fake_signer.signed) == 0
-        assert _FakeHTTPClient.last_swap_sign_call is None
+        assert not any(m == "mkt.taker_sign" for m, _ in FakeWSClient.calls)
 
     def test_reverse_aborts_on_short_lbtc_delivery(self, swap_manager_setup):
         mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
         fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
-        # Server delivers 99k L-BTC instead of 100k
         fake_wollet._balances = {USDT: -9_500_000, L_BTC: 99_000}
-        self._ws_responses_reverse_quote()
+        _setup_mkt_responses_reverse()
 
         with _patch_swap_layers():
             with pytest.raises(PsetVerificationError, match="delivers 99000"):
@@ -1668,7 +1951,7 @@ class TestSwapManagerReverseExecute:
         mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
         fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
         fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000, EVIL: -1}
-        self._ws_responses_reverse_quote()
+        _setup_mkt_responses_reverse()
 
         with _patch_swap_layers():
             with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
@@ -1682,13 +1965,12 @@ class TestSwapManagerReverseExecute:
 
     def test_reverse_picks_asset_utxos_not_lbtc(self, swap_manager_setup):
         mgr, _, fake_wollet, _, _ = swap_manager_setup
-        # Wallet has both USDt and L-BTC; manager must select USDT only.
         fake_wollet._utxos = [
             _FakeUtxo("aa" * 32, 0, L_BTC, 5_000_000),
             _FakeUtxo("bb" * 32, 0, USDT, 50_000_000),
         ]
         fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000}
-        self._ws_responses_reverse_quote()
+        _setup_mkt_responses_reverse()
 
         with _patch_swap_layers():
             mgr.execute_swap(
@@ -1697,15 +1979,15 @@ class TestSwapManagerReverseExecute:
                 wallet_name="default",
                 send_bitcoins=False,
             )
-        sent_inputs = _FakeHTTPClient.last_swap_start_call["inputs"]
-        assert all(u["asset"] == USDT for u in sent_inputs)
-        assert len(sent_inputs) == 1
+        params = _start_quotes_call_args()
+        assert all(u["asset"] == USDT for u in params["utxos"])
+        assert len(params["utxos"]) == 1
 
     def test_reverse_insufficient_asset_balance_raises(self, swap_manager_setup):
         mgr, _, fake_wollet, _, _ = swap_manager_setup
-        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 1_000_000)]  # only 1M USDT
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 1_000_000)]
         fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000}
-        self._ws_responses_reverse_quote()
+        _setup_mkt_responses_reverse()
 
         with _patch_swap_layers():
             with pytest.raises(ValueError, match="Insufficient confidential balance"):


### PR DESCRIPTION
> **Stacked on top of #29** (which is itself stacked on #28 → #27). Once those land on \`main\`, GitHub will auto-rebase this PR's base.

## Summary

- Replaces the legacy \`start_swap_web\` + HTTP \`swap_start\`/\`swap_sign\` flow with SideSwap's modern \`mkt::*\` WebSocket-only flow.
- The legacy WS method and HTTP client stay in the module for compatibility / debugging but are no longer the live execution path.
- Adds 14 new tests, including all four malicious-PSET attack classes for both directions; all 397 tests pass.

## Why mkt::*

Honest answer to the question raised on PR #29: the previous PRs picked the legacy flow because it matched what AQUA Flutter ships and gave the clearest line of sight to the wire format. \`mkt::*\` is genuinely better:

- **WS-only** — no HTTP dance, no \`upload_url\` indirection
- **Deprecation path** — SideSwap's docs push \`mkt::*\`; \`start_swap_web\` is on a slow march to deprecation
- **No auth needed for takers** — only makers posting orders need the Schnorr challenge; we keep using anonymous \`login_client\`
- **Optional ephemeral-key verification** — \`get_quote\` returns \`receive_ephemeral_sk\` and \`change_ephemeral_sk\`. We still use \`pset_details\` for verification (same audit), but the keys are available as a documented fallback if real-world testing surfaces unblinding issues

## Wire format (verified)

Top-level method is \`\"market\"\`, params is a single-key object whose key is the snake_case \`mkt::Request\` variant. \`AssetType\` and \`TradeDir\` are PascalCase strings:

\`\`\`json
{\"id\":1, \"method\":\"market\", \"params\":{\"list_markets\":{}}}
{\"id\":2, \"method\":\"market\", \"params\":{\"start_quotes\":{
  \"asset_pair\":{\"base\":\"...\",\"quote\":\"...\"},
  \"asset_type\":\"Quote\",
  \"amount\":100000,
  \"trade_dir\":\"Sell\",
  \"utxos\":[...],
  \"receive_address\":\"lq1...\",
  \"change_address\":\"lq1...\",
  \"instant_swap\":true
}}}
{\"id\":3, \"method\":\"market\", \"params\":{\"get_quote\":{\"quote_id\":42}}}
{\"id\":4, \"method\":\"market\", \"params\":{\"taker_sign\":{\"quote_id\":42, \"pset\":\"...\"}}}
\`\`\`

Notification: \`{\"method\":\"market\", \"params\":{\"quote\":{\"status\":{\"Success\":{...}}}}}\`

## What changed

- New WS methods on \`SideSwapWSClient\`: \`mkt\`, \`mkt_list_markets\`, \`mkt_start_quotes\`, \`mkt_stop_quotes\`, \`mkt_get_quote\`, \`mkt_taker_sign\`, \`next_market_notification\` (filtered to \`market\` notifications by inner variant)
- New helpers: \`resolve_market\` (picks matching market + derives \`(asset_type, trade_dir)\`) and \`parse_quote_status\` (raises on \`LowBalance\` / \`Error\`)
- \`SideSwapSwapManager.execute_swap\` re-implemented end-to-end. Verifier (\`verify_pset_balances\` + \`pset_details\`) unchanged — same security contract, same audit. \`fee_asset\` still pinned to L-BTC so the asset side is strict-equality
- New sanity check: if the dealer's offered \`send_amount\` differs from what we asked for, abort *before* signing (belt-and-braces alongside the PSET verifier)
- Persistence: stores as \`f\"mkt_{quote_id}\"\` so the storage layer keeps a filename-safe id; \`submit_id\` slot holds the numeric quote_id

## Test plan

Helper tests:
- [x] \`resolve_market\` for forward, reverse, swapped base/quote, no-matching-market, malformed entries
- [x] \`parse_quote_status\` for Success, LowBalance, Error, missing, unknown variants

Manager (forward direction, \`L-BTC → USDt\`):
- [x] Happy path: signs once, broadcasts, persists
- [x] \`start_quotes\` carries the right \`(asset_type, trade_dir)\`, instant_swap=true, distinct receive + change addresses, only L-BTC UTXOs
- [x] PSET takes our L-BTC but delivers nothing → never signs, persists as \`failed\`
- [x] PSET overcharges send_asset → never signs
- [x] PSET moves an unrelated asset → never signs
- [x] LowBalance / Error quote responses → \`SideSwapWSError\`
- [x] Empty market list → \`SideSwapWSError\`
- [x] Dealer offers wrong send_amount vs what we requested → abort before signing
- [x] Status lookup returns persisted record

Manager (reverse direction, \`USDt → L-BTC\`):
- [x] Happy path with \`(asset_type=Base, trade_dir=Sell)\`
- [x] 500-sat USDT siphon attempt rejected (\`fee_asset\` pinned to L-BTC)
- [x] Short L-BTC delivery rejected
- [x] Unrelated asset movement rejected
- [x] Picks USDT UTXOs even when wallet also holds L-BTC
- [x] Insufficient asset balance raises ValueError
- [x] Rejects \`asset_id == policy_asset\`

- [ ] **Manual testnet smoke test** — same procedure as PRs #28 / #29; only the wire methods change

## Reviewer notes

- The \`receive_ephemeral_sk\` / \`change_ephemeral_sk\` fields from \`get_quote\` are intentionally not used for verification yet. \`wollet.pset_details(pset)\` is the audited path and should work because our \`recv_addr\` is from \`wollet.address(None)\` (master blinding key encoded in the address). If real-world testing reveals that SideSwap's PSETs don't unblind via \`pset_details\`, we'll add ephemeral-key verification as a follow-up — the keys are exposed for that purpose.
- The legacy \`start_swap_web\` WS method and \`SideSwapHTTPClient\` are still in the module. They cost nothing and might be useful for debugging. Their unit tests still pass.
- After this lands, the SideSwap surface is feature-complete for an MCP server's needs (pegs + bidirectional asset swaps + recommendations + quote helpers). Future SideSwap work will be reactive (protocol changes, new asset types) rather than the kind of \"build out the surface\" PRs we've been doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)