### PR TITLE
Add SideSwap atomic asset-swap execution via mkt::*

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ AI Assistant ←→ MCP Server (Python) ←→ LWK (Liquid) ──→ Electrum/E
 
 No local server required. Liquid uses Electrum/Esplora; Bitcoin uses Esplora only. All via Blockstream's public infrastructure.
 
-## Tools (30 total)
+## Tools (32 total)
 
 Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`; SideSwap tools are `sideswap_*`.
 
@@ -85,7 +85,9 @@ Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified 
 | `sideswap_peg_status` | Check status of a peg order (peg-in or peg-out). Returns confs, tx_state, lockup_txid, payout_txid. | `order_id`: string |
 | `sideswap_recommend` | Recommend peg vs swap-market for a BTC ↔ L-BTC conversion. Surfaces time-vs-fee trade-off and warns if amount exceeds hot-wallet liquidity. | `amount` (sats), `direction`: btc_to_lbtc/lbtc_to_btc, `network`: optional |
 | `sideswap_list_assets` | List Liquid assets supported by SideSwap (USDt, EURx, MEX, DePix, etc.). | `network`: optional |
-| `sideswap_quote` | **Read-only.** Get a price quote for a Liquid asset swap (e.g. L-BTC ↔ USDt). Execution is NOT yet implemented in agentic-aqua — direct user to AQUA mobile or sideswap.io. | `asset_id`, `send_amount` (sats) OR `recv_amount` (sats), `send_bitcoins`: optional, `network`: optional |
+| `sideswap_quote` | Read-only price quote for a Liquid asset swap (e.g. L-BTC ↔ USDt). Use BEFORE `sideswap_execute_swap` to confirm price with user. | `asset_id`, `send_amount` (sats) OR `recv_amount` (sats), `send_bitcoins`: optional, `network`: optional |
+| `sideswap_execute_swap` | Execute an atomic Liquid swap. Both directions supported via `send_bitcoins`: True = L-BTC → asset; False = asset → L-BTC. PSET verified locally against the agreed quote before signing; fee tolerance pinned to L-BTC so the asset side is always strict equality. | `asset_id`, `send_amount` (sats), `send_bitcoins`: optional (default true), `wallet_name`: optional, `password`: optional |
+| `sideswap_swap_status` | Get persisted status of an atomic swap. Pass the txid to `lw_tx_status` for on-chain confirmation. | `order_id`: string |
 
 > ⚠️ **Pegs vs swaps**: pegs charge 0.1% (vs 0.2% for instant swap-market trades) but require waiting for confirmations. Always call `sideswap_recommend` for amounts ≥ 0.01 BTC and surface the trade-off (and any 102-confirmation cold-wallet warning) before initiating a peg-in.
 
@@ -140,6 +142,8 @@ Wallet data stored in `~/.aqua/`:
 │   └── {swap_id}.json   # Contains swap details + status + optional preimage
 ├── sideswap_pegs/       # SideSwap peg orders (peg-in and peg-out)
 │   └── {order_id}.json  # Contains order, addresses, status, tx_state, payout_txid
+├── sideswap_swaps/      # SideSwap atomic asset swap orders (L-BTC → asset)
+│   └── {order_id}.json  # Contains quote, submit_id, status, txid, optional last_error
 └── cache/
     └── <wallet_name>/
         └── btc/
@@ -328,6 +332,7 @@ SideSwap (`sideswap.io`) provides BTC ↔ L-BTC pegs and Liquid asset swaps via 
 - `server_status` — fees, mins, hot-wallet balances
 - `peg_fee`, `peg`, `peg_status` — peg flow
 - `assets`, `subscribe_price_stream`, `unsubscribe_price_stream` — asset swap quoting
+- `market.list_markets`, `market.start_quotes`, `market.get_quote`, `market.taker_sign` — atomic asset swap execution (the modern `mkt::*` flow). Wire format wraps the inner variant in a single-key object: `{"id": N, "method": "market", "params": {"<variant_in_snake_case>": {...}}}`. `AssetType` and `TradeDir` are PascalCase on the wire (`"Base"|"Quote"`, `"Buy"|"Sell"`).
 
 **Fees**:
 - Pegs: 0.1% on send amount + small second-chain fee (~286 sats Liquid claim on peg-in)
@@ -341,7 +346,31 @@ SideSwap (`sideswap.io`) provides BTC ↔ L-BTC pegs and Liquid asset swaps via 
 - Peg-in: 2 BTC confs (~20 min) hot-wallet path; 102 BTC confs (~17 hours) if amount exceeds `PegInWalletBalance`
 - Peg-out: 2 Liquid confs + federation BTC sweep (typically 15–60 min total)
 
-**Asset swap execution is NOT implemented** in agentic-aqua: the legacy `start_swap_web` + HTTP `swap_start`/`swap_sign` flow requires local PSET output verification before signing (the server is trusted-but-verify; an unaudited verifier could be tricked into signing a PSET that pays the user nothing). `sideswap_quote` returns a price quote only; users execute via the AQUA mobile wallet or sideswap.io.
+**Asset swap execution** (`sideswap_execute_swap`) uses SideSwap's modern `mkt::*` flow over WebSocket only (no HTTP dance) and supports **both directions**:
+
+- **L-BTC → asset** (`send_bitcoins=True`): user's L-BTC change pays the network fee. Wallet net effect: `L-BTC: -(send_amount + fee)`, `asset: +recv_amount`.
+- **asset → L-BTC** (`send_bitcoins=False`): SideSwap dealer absorbs the network fee from their L-BTC contribution. Wallet net effect: `asset: -send_amount` (exact), `L-BTC: +recv_amount` (exact).
+
+**mkt::* flow steps**:
+1. `market.list_markets` — fetch available pairs and find one matching ours
+2. Resolve `(asset_type, trade_dir)` via `resolve_market` — always `Sell` with the asset_type matching the side we're sending
+3. `market.start_quotes` with our UTXOs + receive/change addresses + `instant_swap=true`
+4. Wait for a `quote` notification with `status=Success`; `parse_quote_status` raises on `LowBalance` / `Error`
+5. `market.get_quote {quote_id}` → returns the half-built PSET
+6. **Verify** with `wollet.pset_details(pset)` against the agreed quote — refuses to sign on mismatch
+7. `signer.sign(pset)` locally
+8. `market.taker_sign {quote_id, pset}` → server merges & broadcasts; returns the txid
+
+**Verification rules** (`verify_pset_balances` in `src/aqua/sideswap.py`):
+1. Wallet must gain *exactly* `recv_amount` of `recv_asset`.
+2. Wallet must lose at most `send_amount + fee_tolerance_sats` (default 1000) of `send_asset` *if* `send_asset == fee_asset`; otherwise strict equality.
+3. No other asset may have a non-zero balance change.
+
+The manager always passes `fee_asset = policy_asset` (L-BTC) regardless of direction, so the fee tolerance only relaxes constraints on the L-BTC side — never on a non-L-BTC asset, which would otherwise be a siphon vector on the reverse path.
+
+If any rule fails, `PsetVerificationError` is raised and signing is aborted — the order is persisted as `failed` for forensics. The order is also persisted at every flow step (`pending` → `verified` → `signed` → `broadcast`) for crash recovery.
+
+UTXO selection (`select_swap_utxos`): confidential (asset_bf and value_bf both non-zero), holding the requested send_asset, sorted descending by value, accumulated to cover `send_amount`. wpkh-only (matching the wallet's BIP84 m/84'/1776'/0' descriptor). No separate L-BTC fee inputs are required on either direction (mirroring AQUA Flutter's `swap_provider.dart`).
 
 ## Bitcoin Implementation Details
 

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -689,6 +689,17 @@ TOOL_SCHEMAS = {
                     "type": "string",
                     "description": "Password to decrypt mnemonic (if encrypted at rest)",
                 },
+                "flexible_small_amount": {
+                    "type": "boolean",
+                    "description": (
+                        "When True, accept dealer-rounded send_amount up to "
+                        "±3000 sats from what was requested. SideSwap's mkt::* "
+                        "dealer rounds internally; small swaps (e.g. 5k–25k "
+                        "sats) often come back at a slightly different amount. "
+                        "Off by default — strict equality is safer at scale."
+                    ),
+                    "default": False,
+                },
             },
             "required": ["asset_id", "send_amount"],
         },

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -619,9 +619,8 @@ TOOL_SCHEMAS = {
         "description": (
             "Get a read-only price quote for a SideSwap Liquid asset swap "
             "(e.g. L-BTC ↔ USDt). Provide exactly one of send_amount or "
-            "recv_amount. NOTE: this is a quote only — atomic swap execution "
-            "is not yet implemented in agentic-aqua (PSET output verification "
-            "needs an audit). To execute, use the AQUA mobile wallet or sideswap.io."
+            "recv_amount. Use this BEFORE sideswap_execute_swap so the user "
+            "can confirm the price."
         ),
         "inputSchema": {
             "type": "object",
@@ -650,6 +649,65 @@ TOOL_SCHEMAS = {
                 },
             },
             "required": ["asset_id"],
+        },
+    },
+    "sideswap_execute_swap": {
+        "description": (
+            "Execute a Liquid atomic swap on SideSwap. Both directions are "
+            "supported via send_bitcoins: True = L-BTC → asset (default), "
+            "False = asset → L-BTC. The PSET returned by SideSwap is verified "
+            "locally against the agreed quote BEFORE signing — the swap is "
+            "aborted if the wallet's net balance change does not exactly match "
+            "(refusing to sign protects against a hostile server). The fee "
+            "tolerance is pinned to L-BTC, so on the asset → L-BTC direction "
+            "the asset side is checked at strict equality. Order is persisted "
+            "at every step for crash recovery. ALWAYS call sideswap_quote "
+            "first and confirm the price with the user before invoking this tool."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "asset_id": {
+                    "type": "string",
+                    "description": "Non-L-BTC Liquid asset (e.g. USDt). The L-BTC side is always the policy asset.",
+                },
+                "send_amount": {
+                    "type": "integer",
+                    "description": "Send amount in sats (L-BTC if send_bitcoins, else asset)",
+                },
+                "send_bitcoins": {
+                    "type": "boolean",
+                    "description": "True = send L-BTC to receive asset; False = send asset to receive L-BTC",
+                    "default": True,
+                },
+                "wallet_name": {
+                    "type": "string",
+                    "description": "Liquid wallet to sign with",
+                    "default": "default",
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password to decrypt mnemonic (if encrypted at rest)",
+                },
+            },
+            "required": ["asset_id", "send_amount"],
+        },
+    },
+    "sideswap_swap_status": {
+        "description": (
+            "Get persisted status of a SideSwap atomic asset swap. Once the "
+            "swap is broadcast, pass the txid to lw_tx_status to track "
+            "on-chain confirmations."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "order_id": {
+                    "type": "string",
+                    "description": "Order ID returned from sideswap_execute_swap",
+                },
+            },
+            "required": ["order_id"],
         },
     },
 }
@@ -732,8 +790,11 @@ SIDESWAP (BTC ↔ L-BTC pegs and Liquid asset swaps):
   cold-wallet path: 102 BTC confirmations (~17 hours). Always check
   sideswap_server_status first and warn the user when this applies.
 - For Liquid asset swaps (e.g. L-BTC ↔ USDt), sideswap_quote returns a quote
-  but does NOT execute the swap — direct the user to the AQUA mobile wallet
-  or sideswap.io to complete it.
+  and sideswap_execute_swap performs the swap. Both directions are supported
+  via the send_bitcoins flag. The PSET returned by SideSwap is verified
+  LOCALLY against the agreed quote before signing — refusing to sign if the
+  recv balance does not match exactly. The fee tolerance is pinned to L-BTC,
+  so the non-L-BTC asset side is always checked at strict equality.
 
 WHEN TO RECOMMEND A PEG:
 - "I want to move my BTC to Liquid" → if amount ≥ 0.01 BTC, recommend peg-in.
@@ -1279,14 +1340,31 @@ Please:
 
 Please:
 1. Call sideswap_list_assets to show what's tradeable on SideSwap right now
-2. Ask me what I want to swap and which direction (sending L-BTC for an asset
-   vs sending an asset for L-BTC)
-3. Ask me for an amount (either send amount or receive amount, not both)
-4. Call sideswap_quote to get a price quote
-5. Show me the result clearly: send X → receive Y at price P, with fixed_fee
-6. IMPORTANT: tell me that agentic-aqua does NOT yet execute SideSwap atomic
-   swaps (PSET output verification needs an audit before live signing). To
-   execute, I need to use the AQUA mobile wallet or sideswap.io.""",
+2. Ask me what I want to swap and which direction:
+   - L-BTC → asset (send_bitcoins=true): I send L-BTC, receive an asset
+   - asset → L-BTC (send_bitcoins=false): I send an asset, receive L-BTC
+3. Ask me for the send_amount in the corresponding sats (L-BTC sats if
+   sending L-BTC; asset sats otherwise). For L-BTC, accept input in BTC
+   and convert.
+4. Show me my current balance for the send asset (lw_balance) so I have context
+5. Call sideswap_quote with the right send_bitcoins flag to get a price quote
+6. Show me a summary clearly:
+   - Send: X sats of [send asset]
+   - Receive: Y sats of [recv asset]
+   - Price + fixed_fee
+   - Net effective rate
+7. Ask for explicit confirmation
+8. If wallet is password-encrypted, ask me for the password
+9. Call sideswap_execute_swap with the same asset_id, send_amount, and
+   send_bitcoins flag.
+   The tool will: capture a fresh quote (price may have moved by a few
+   percent), request the PSET via SideSwap's market.get_quote, VERIFY it
+   locally against the quote, sign it, and submit via market.taker_sign.
+   If the verification fails the tool aborts WITHOUT signing — that's a
+   safety feature, not a bug; relay the error message to me.
+10. On success show me txid + the explorer link
+11. Tell me to use sideswap_swap_status with the order_id to recall details
+    later, and lw_tx_status with the txid to check on-chain confirmation""",
                         ),
                     )
                 ]

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -1232,6 +1232,15 @@ class SideSwapSwapManager:
         self.storage = storage
         self.wallet_manager = wallet_manager
 
+    # Tolerance applied when `flexible_small_amount=True` accepts a dealer
+    # send_amount that differs from the user's request. SideSwap's mkt::*
+    # dealer rounds amounts internally; on small swaps (e.g. 5_000 sats →
+    # USDt) the dealer's quote can come back at e.g. 5_050 sats. Accept the
+    # adjusted amount up to this delta so the user isn't bounced for
+    # rounding alone. Larger drift indicates a real price move and should
+    # still reject.
+    SMALL_AMOUNT_TOLERANCE_SATS = 3_000
+
     def execute_swap(
         self,
         asset_id: str,
@@ -1239,6 +1248,7 @@ class SideSwapSwapManager:
         wallet_name: str = "default",
         password: Optional[str] = None,
         send_bitcoins: bool = True,
+        flexible_small_amount: bool = False,
         *,
         fee_tolerance_sats: int = DEFAULT_FEE_TOLERANCE_SATS,
         quote_wait_seconds: float = QUOTE_WAIT_SECONDS,
@@ -1367,9 +1377,21 @@ class SideSwapSwapManager:
             send_amount_q = int(quote_data["quote_amount"])
             recv_amount_q = int(quote_data["base_amount"])
         if send_amount_q != send_amount:
-            raise SideSwapWSError(
-                f"Quote send_amount mismatch: requested {send_amount}, dealer offered {send_amount_q}"
-            )
+            delta = abs(send_amount_q - send_amount)
+            if flexible_small_amount and delta <= self.SMALL_AMOUNT_TOLERANCE_SATS:
+                # Dealer rounded the send amount slightly; caller has opted
+                # in to accepting the adjustment. The PSET verifier still
+                # checks the wallet's actual balance change against
+                # send_amount_q below, so the user is never debited more
+                # than the dealer's quote.
+                send_amount = send_amount_q
+            else:
+                raise SideSwapWSError(
+                    f"Quote send_amount mismatch: requested {send_amount}, "
+                    f"dealer offered {send_amount_q} (delta={delta} sats). "
+                    "Pass flexible_small_amount=True to accept dealer "
+                    f"adjustments up to ±{self.SMALL_AMOUNT_TOLERANCE_SATS} sats."
+                )
         recv_amount = recv_amount_q
 
         pset_b64 = get_quote_resp.get("pset")
@@ -1379,7 +1401,6 @@ class SideSwapSwapManager:
         # Persist the in-progress swap before signing.
         # `submit_id` is reused to hold the quote_id so existing storage stays
         # backward-compatible with the legacy flow.
-        price = float(quote_data.get("server_fee", 0)) and 0.0  # placeholder; filled below
         # SideSwap quote doesn't return a single 'price' field on mkt::*; derive
         # it from amounts. price = quote_amount / base_amount — but client may
         # interpret either side, so we just store recv/send ratio for reference.

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -659,7 +659,26 @@ def parse_quote_status(quote_notif: dict) -> dict:
     if not isinstance(status, dict) or not status:
         raise SideSwapWSError(f"Malformed quote status: {status!r}")
     if "Success" in status:
-        return status["Success"]
+        success = status["Success"]
+        if not isinstance(success, dict):
+            raise SideSwapWSError(f"Malformed Success quote: {success!r}")
+        # Validate the fields the caller will read so a malformed payload
+        # raises SideSwapWSError here, not a KeyError/TypeError far away in
+        # execute_swap when it indexes into the dict.
+        for key in ("quote_id", "base_amount", "quote_amount"):
+            value = success.get(key)
+            if value is None:
+                raise SideSwapWSError(
+                    f"Malformed Success quote: missing {key!r} ({success!r})"
+                )
+            try:
+                int(value)
+            except (TypeError, ValueError) as e:
+                raise SideSwapWSError(
+                    f"Malformed Success quote: {key} is not an integer "
+                    f"({value!r})"
+                ) from e
+        return success
     if "LowBalance" in status:
         lb = status["LowBalance"]
         raise SideSwapWSError(
@@ -1323,8 +1342,13 @@ class SideSwapSwapManager:
         recv_addr = str(wollet.address(None).address())
         change_addr = str(wollet.address(None).address())
 
-        async def _quote_to_pset() -> tuple[dict, dict, dict]:
-            """Open WS, run the mkt::* dance, return (market, quote, get_quote_resp)."""
+        # SideSwap binds quote_id to the WebSocket session that issued
+        # start_quotes / get_quote — submitting taker_sign on a fresh
+        # connection is rejected with `protocol error: wrong client_id`.
+        # The verify + sign steps in the middle are sync but cheap, so we
+        # hold one async with for the entire quote → sign → submit flow.
+        async def _full_swap() -> "SideSwapSwap":
+            nonlocal send_amount  # may be widened below by flexible_small_amount
             async with SideSwapWSClient(network) as client:
                 await client.login_client()
                 # Find a market that covers our pair
@@ -1344,135 +1368,124 @@ class SideSwapSwapManager:
                     instant_swap=True,
                 )
                 # Wait for the first usable quote — a `quote` notification with
-                # a Success status. parse_quote_status raises on LowBalance/Error.
+                # a Success status. parse_quote_status raises on LowBalance/Error
+                # AND validates that quote_id / base_amount / quote_amount are
+                # present and integral, so the int() casts below cannot KeyError.
                 quote_notif = await client.next_market_notification(
                     "quote", timeout=quote_wait_seconds
                 )
-                quote = parse_quote_status(quote_notif)
-                # Accept the quote and request the half-built PSET
-                get_quote_resp = await client.mkt_get_quote(int(quote["quote_id"]))
-                # Best-effort cleanup
+                quote_data = parse_quote_status(quote_notif)
+                # Accept the quote and request the half-built PSET on the same
+                # session so the server recognises us as the original taker.
+                get_quote_resp = await client.mkt_get_quote(int(quote_data["quote_id"]))
                 try:
                     await client.mkt_stop_quotes()
                 except Exception:
                     pass
-                return market, quote, get_quote_resp
 
-        market, quote_data, get_quote_resp = _run(_quote_to_pset())
+                # ---- Phase 2: validate + persist (sync, runs on the loop) ---
+                quote_id = int(quote_data["quote_id"])
+                order_id = f"mkt_{quote_id}"
+                # Re-derive recv/send amounts from the quote, not the user's
+                # request: the dealer's quote_amount/base_amount are canonical.
+                if send_asset == market["asset_pair"].get("base"):
+                    send_amount_q = int(quote_data["base_amount"])
+                    recv_amount_q = int(quote_data["quote_amount"])
+                else:
+                    send_amount_q = int(quote_data["quote_amount"])
+                    recv_amount_q = int(quote_data["base_amount"])
+                if send_amount_q != send_amount:
+                    delta = abs(send_amount_q - send_amount)
+                    if flexible_small_amount and delta <= self.SMALL_AMOUNT_TOLERANCE_SATS:
+                        # Dealer rounded the send amount slightly; caller has
+                        # opted in to accepting the adjustment. The PSET
+                        # verifier still checks the wallet's actual balance
+                        # change against send_amount_q below.
+                        send_amount = send_amount_q
+                    else:
+                        raise SideSwapWSError(
+                            f"Quote send_amount mismatch: requested {send_amount}, "
+                            f"dealer offered {send_amount_q} (delta={delta} sats). "
+                            "Pass flexible_small_amount=True to accept dealer "
+                            f"adjustments up to ±{self.SMALL_AMOUNT_TOLERANCE_SATS} sats."
+                        )
+                recv_amount = recv_amount_q
 
-        # Decide a stable order_id we control for persistence. SideSwap mkt::*
-        # gives us a `quote_id` (numeric) per quote; the `order_id` field is
-        # only used for marker resting orders. We persist the quote_id as a
-        # string in our `order_id` slot so the rest of the manager (status
-        # lookup, storage path) keeps the same shape.
-        quote_id = int(quote_data["quote_id"])
-        order_id = f"mkt_{quote_id}"
-        recv_amount = int(quote_data["quote_amount"]) if asset_id == market["asset_pair"]["base"] else int(quote_data["base_amount"])
-        # Re-derive recv/send amounts from the quote, not the user's request:
-        # the dealer's quote_amount/base_amount are the canonical numbers.
-        if send_asset == market["asset_pair"].get("base"):
-            send_amount_q = int(quote_data["base_amount"])
-            recv_amount_q = int(quote_data["quote_amount"])
-        else:
-            send_amount_q = int(quote_data["quote_amount"])
-            recv_amount_q = int(quote_data["base_amount"])
-        if send_amount_q != send_amount:
-            delta = abs(send_amount_q - send_amount)
-            if flexible_small_amount and delta <= self.SMALL_AMOUNT_TOLERANCE_SATS:
-                # Dealer rounded the send amount slightly; caller has opted
-                # in to accepting the adjustment. The PSET verifier still
-                # checks the wallet's actual balance change against
-                # send_amount_q below, so the user is never debited more
-                # than the dealer's quote.
-                send_amount = send_amount_q
-            else:
-                raise SideSwapWSError(
-                    f"Quote send_amount mismatch: requested {send_amount}, "
-                    f"dealer offered {send_amount_q} (delta={delta} sats). "
-                    "Pass flexible_small_amount=True to accept dealer "
-                    f"adjustments up to ±{self.SMALL_AMOUNT_TOLERANCE_SATS} sats."
+                pset_b64 = get_quote_resp.get("pset")
+                if not pset_b64:
+                    raise SideSwapWSError(
+                        f"Unexpected get_quote response: {get_quote_resp!r}"
+                    )
+
+                # SideSwap quote doesn't return a single 'price' field on
+                # mkt::*; derive it from recv/send for reference only.
+                price = recv_amount / send_amount if send_amount else 0.0
+
+                swap = SideSwapSwap(
+                    order_id=order_id,
+                    submit_id=str(quote_id),
+                    send_asset=send_asset,
+                    send_amount=send_amount,
+                    recv_asset=recv_asset,
+                    recv_amount=recv_amount,
+                    price=price,
+                    wallet_name=wallet_name,
+                    network=network,
+                    status="pending",
+                    created_at=datetime.now(UTC).isoformat(),
                 )
-        recv_amount = recv_amount_q
+                self.storage.save_sideswap_swap(swap)
 
-        pset_b64 = get_quote_resp.get("pset")
-        if not pset_b64:
-            raise SideSwapWSError(f"Unexpected get_quote response: {get_quote_resp!r}")
+                try:
+                    # ---- Phase 3: verify + sign (sync) ----------------------
+                    # fee_asset is pinned to the policy asset so the fee
+                    # tolerance only relaxes the L-BTC side — never the asset.
+                    self._verify_pset(
+                        pset_b64,
+                        wollet,
+                        send_asset=send_asset,
+                        send_amount=send_amount,
+                        recv_asset=recv_asset,
+                        recv_amount=recv_amount,
+                        fee_tolerance_sats=fee_tolerance_sats,
+                        fee_asset=policy_asset,
+                    )
+                    swap.status = "verified"
+                    self.storage.save_sideswap_swap(swap)
 
-        # Persist the in-progress swap before signing.
-        # `submit_id` is reused to hold the quote_id so existing storage stays
-        # backward-compatible with the legacy flow.
-        # SideSwap quote doesn't return a single 'price' field on mkt::*; derive
-        # it from amounts. price = quote_amount / base_amount — but client may
-        # interpret either side, so we just store recv/send ratio for reference.
-        price = recv_amount / send_amount if send_amount else 0.0
+                    signer = self.wallet_manager._signers[wallet_name]
+                    import lwk
 
-        swap = SideSwapSwap(
-            order_id=order_id,
-            submit_id=str(quote_id),
-            send_asset=send_asset,
-            send_amount=send_amount,
-            recv_asset=recv_asset,
-            recv_amount=recv_amount,
-            price=price,
-            wallet_name=wallet_name,
-            network=network,
-            status="pending",
-            created_at=datetime.now(UTC).isoformat(),
-        )
-        self.storage.save_sideswap_swap(swap)
+                    pset = lwk.Pset(pset_b64)
+                    signed = signer.sign(pset)
+                    signed_b64 = str(signed)
+                    swap.status = "signed"
+                    self.storage.save_sideswap_swap(swap)
 
-        try:
-            # Verify before signing — security-critical. fee_asset is pinned
-            # to the policy asset; on the reverse direction this prevents a
-            # 1000-sat siphon of the asset via the fee tolerance loophole.
-            self._verify_pset(
-                pset_b64,
-                wollet,
-                send_asset=send_asset,
-                send_amount=send_amount,
-                recv_asset=recv_asset,
-                recv_amount=recv_amount,
-                fee_tolerance_sats=fee_tolerance_sats,
-                fee_asset=policy_asset,
-            )
-            swap.status = "verified"
-            self.storage.save_sideswap_swap(swap)
+                    # ---- Phase 4: submit on the SAME WS --------------------
+                    sign_payload = await client.mkt_taker_sign(quote_id, signed_b64)
+                    txid = sign_payload.get("txid")
+                    if not txid:
+                        raise SideSwapWSError(
+                            f"Unexpected taker_sign response: {sign_payload!r}"
+                        )
+                    swap.txid = txid
+                    swap.status = "broadcast"
+                    self.storage.save_sideswap_swap(swap)
+                    return swap
 
-            # Sign locally
-            signer = self.wallet_manager._signers[wallet_name]
-            import lwk
+                except PsetVerificationError as e:
+                    swap.status = "failed"
+                    swap.last_error = f"PSET verification failed: {e}"
+                    self.storage.save_sideswap_swap(swap)
+                    raise
+                except Exception as e:
+                    swap.status = "failed"
+                    swap.last_error = str(e)
+                    self.storage.save_sideswap_swap(swap)
+                    raise
 
-            pset = lwk.Pset(pset_b64)
-            signed = signer.sign(pset)
-            signed_b64 = str(signed)
-            swap.status = "signed"
-            self.storage.save_sideswap_swap(swap)
-
-            # Submit signed PSET via mkt::taker_sign; server merges & broadcasts
-            async def _submit() -> dict:
-                async with SideSwapWSClient(network) as client:
-                    await client.login_client()
-                    return await client.mkt_taker_sign(quote_id, signed_b64)
-
-            sign_payload = _run(_submit())
-            txid = sign_payload.get("txid")
-            if not txid:
-                raise SideSwapWSError(f"Unexpected taker_sign response: {sign_payload!r}")
-            swap.txid = txid
-            swap.status = "broadcast"
-            self.storage.save_sideswap_swap(swap)
-            return swap
-
-        except PsetVerificationError as e:
-            swap.status = "failed"
-            swap.last_error = f"PSET verification failed: {e}"
-            self.storage.save_sideswap_swap(swap)
-            raise
-        except Exception as e:
-            swap.status = "failed"
-            swap.last_error = str(e)
-            self.storage.save_sideswap_swap(swap)
-            raise
+        return _run(_full_swap())
 
     def _verify_pset(
         self,

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -1,4 +1,4 @@
-"""SideSwap integration for BTC ↔ L-BTC pegs and Liquid asset swap quoting.
+"""SideSwap integration for BTC ↔ L-BTC pegs and Liquid asset swaps.
 
 Wire formats (mirroring the AQUA Flutter wallet's `sideswap_websocket_provider`):
 
@@ -14,20 +14,38 @@ Wire formats (mirroring the AQUA Flutter wallet's `sideswap_websocket_provider`)
 
 Methods used here:
 
-- `login_client`         — anonymous (api_key=None), identifies us as agentic-aqua
-- `server_status`        — fees, min amounts, hot-wallet balances
-- `peg_fee`              — quote fee for a given amount and direction
-- `peg`                  — initiate peg-in (BTC→L-BTC) or peg-out (L-BTC→BTC)
-- `peg_status`           — poll order status
-- `assets`               — list supported assets for swap quoting
+- `login_client`           — anonymous (api_key=None), identifies us as agentic-aqua
+- `server_status`          — fees, min amounts, hot-wallet balances
+- `peg_fee`                — quote fee for a given amount and direction
+- `peg`                    — initiate peg-in (BTC→L-BTC) or peg-out (L-BTC→BTC)
+- `peg_status`             — poll order status
+- `assets`                 — list supported assets for swap quoting
 - `subscribe_price_stream` / `unsubscribe_price_stream`
-                         — get a price quote for a Liquid asset swap (read-only)
+                           — get a price quote for a Liquid asset swap
+- `market.list_markets`    — find the market for an asset pair
+- `market.start_quotes`    — open a quote stream with our UTXOs + addresses
+- `market.get_quote`       — receive the half-built PSET to sign
+- `market.taker_sign`      — submit the locally-signed PSET; server broadcasts
 
-Asset swap *execution* (`start_swap_web` + HTTP `swap_start`/`swap_sign` with
-local PSET verification) is intentionally NOT implemented in this module: the
-PSET output check is security-critical and must be audited against LWK's
-unblinding API before live signing. Use this module to fetch quotes and direct
-users to AQUA / SideSwap for execution.
+PSET verification (security-critical): before signing, we call
+`wollet.pset_details(pset).balance.balances()` and confirm the wallet's net
+balance change matches the agreed quote (recv_asset gains exactly recv_amount,
+send_asset loses no more than send_amount + fee_tolerance, no other assets
+move). The server is trusted-but-verify; without this check, a hostile or
+buggy server could craft a PSET that takes our funds and pays us nothing.
+
+Execution (`SideSwapSwapManager.execute_swap`) supports both directions:
+
+  - `send_bitcoins=True`: L-BTC → asset (e.g. L-BTC → USDt). The Liquid network
+    fee comes out of the user's L-BTC change output, so the wallet's L-BTC
+    delta is `-(send_amount + fee)`.
+  - `send_bitcoins=False`: asset → L-BTC (e.g. USDt → L-BTC). The dealer
+    absorbs the network fee from their L-BTC contribution, so the wallet's
+    asset delta is `-send_amount` and L-BTC delta is `+recv_amount` exactly.
+
+The verifier's `fee_asset` parameter is always pinned to the policy asset so
+the fee tolerance only relaxes constraints on the L-BTC side — never on a
+non-L-BTC asset, which would otherwise be a siphon vector on the reverse path.
 """
 
 from __future__ import annotations
@@ -48,13 +66,6 @@ logger = logging.getLogger(__name__)
 SIDESWAP_WS_URL = {
     "mainnet": "wss://api.sideswap.io/json-rpc-ws",
     "testnet": "wss://api-testnet.sideswap.io/json-rpc-ws",
-}
-
-# REST base for legacy `swap_start` / `swap_sign` (returned as `upload_url`
-# by `start_swap_web`; included here for documentation/fallback)
-SIDESWAP_HTTP_URL = {
-    "mainnet": "https://api.sideswap.io",
-    "testnet": "https://api-testnet.sideswap.io",
 }
 
 USER_AGENT = "agentic-aqua"
@@ -171,6 +182,141 @@ class SideSwapPriceQuote:
 
     def to_dict(self) -> dict:
         return asdict(self)
+
+
+@dataclass
+class SideSwapSwap:
+    """Persistent record of an executed Liquid asset swap on SideSwap."""
+
+    order_id: str
+    submit_id: Optional[str]  # Returned by swap_start; needed for swap_sign
+    send_asset: str
+    send_amount: int
+    recv_asset: str
+    recv_amount: int
+    price: float
+    wallet_name: str
+    network: str  # "mainnet" | "testnet"
+    status: str  # "pending" | "verified" | "signed" | "submitted" | "broadcast" | "failed"
+    created_at: str
+    txid: Optional[str] = None
+    last_error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SideSwapSwap":
+        data = {**data}
+        for f in ("submit_id", "txid", "last_error"):
+            data.setdefault(f, None)
+        return cls(**data)
+
+
+# ---------------------------------------------------------------------------
+# PSET verification — security-critical
+# ---------------------------------------------------------------------------
+
+
+class PsetVerificationError(RuntimeError):
+    """Raised when the PSET returned by SideSwap does not match the agreed quote.
+
+    On this exception the caller MUST NOT sign the PSET — the server may have
+    crafted a transaction that takes our funds and pays us nothing.
+    """
+
+
+def verify_pset_balances(
+    balances: dict[str, int],
+    *,
+    send_asset: str,
+    send_amount: int,
+    recv_asset: str,
+    recv_amount: int,
+    fee_tolerance_sats: int = 1_000,
+    fee_asset: Optional[str] = None,
+) -> None:
+    """Verify a Liquid PSET's effect on the wallet matches the agreed quote.
+
+    Pure function — operates only on the dict returned by
+    `wollet.pset_details(pset).balance.balances()` (mapping asset_id → signed
+    int sats; negative = wallet is sending, positive = wallet is receiving).
+
+    Verification rules (any failure raises `PsetVerificationError`):
+
+    1. The wallet must gain at least `recv_amount` of `recv_asset`. Strict
+       equality is required — the server should not deliver a different amount
+       than what it quoted.
+    2. The wallet must lose **at most** `send_amount + fee_tolerance_sats` of
+       `send_asset`. We allow a small overage to cover the network fee when it
+       comes from the same asset (which is typical for L-BTC sends, since the
+       Liquid network fee is denominated in L-BTC).
+    3. No other asset may have a non-zero balance change. This blocks "extra
+       output" attacks where the server siphons a bit of an unrelated asset.
+
+    Args:
+        balances: Net balance change per asset id (from LWK pset_details).
+        send_asset: Asset id we agreed to send.
+        send_amount: Amount we agreed to send (sats, positive).
+        recv_asset: Asset id we agreed to receive.
+        recv_amount: Amount we agreed to receive (sats, positive).
+        fee_tolerance_sats: How many extra sats of `send_asset` we'll tolerate
+            being deducted to cover the on-chain fee. Default 1000 — Liquid
+            fees are in the tens of sats range, so this is comfortably above
+            normal but well below an attacker payday.
+        fee_asset: If set, only this asset is allowed to absorb the fee
+            tolerance. If unset, defaults to `send_asset`.
+    """
+    if send_amount <= 0:
+        raise ValueError("send_amount must be positive")
+    if recv_amount <= 0:
+        raise ValueError("recv_amount must be positive")
+    if fee_tolerance_sats < 0:
+        raise ValueError("fee_tolerance_sats must be non-negative")
+    if send_asset == recv_asset:
+        # SideSwap doesn't quote same-asset swaps and we can't reason about
+        # net balances unambiguously if it did.
+        raise PsetVerificationError(
+            f"send_asset and recv_asset are the same ({send_asset!r}); refusing to sign"
+        )
+    fee_asset = fee_asset or send_asset
+
+    # Rule 1: receive amount is exactly what was agreed
+    recv_delta = balances.get(recv_asset, 0)
+    if recv_delta != recv_amount:
+        raise PsetVerificationError(
+            f"PSET delivers {recv_delta} sats of recv_asset {recv_asset[:8]}…, "
+            f"expected exactly {recv_amount} sats"
+        )
+
+    # Rule 2: send amount is within tolerance
+    send_delta = balances.get(send_asset, 0)
+    # send_delta is negative when we're sending. Convert to "sats sent" (positive).
+    sats_sent = -send_delta
+    if send_asset == fee_asset:
+        max_sats_sent = send_amount + fee_tolerance_sats
+    else:
+        max_sats_sent = send_amount
+    if sats_sent > max_sats_sent:
+        raise PsetVerificationError(
+            f"PSET deducts {sats_sent} sats of send_asset {send_asset[:8]}…, "
+            f"more than the agreed {send_amount} (tolerance {max_sats_sent - send_amount})"
+        )
+    if sats_sent < send_amount:
+        # Sending less than agreed is suspicious too — could be a bait-and-switch
+        # where the server later reverses the swap or delivers a malformed tx.
+        raise PsetVerificationError(
+            f"PSET deducts only {sats_sent} sats of send_asset, less than agreed {send_amount}"
+        )
+
+    # Rule 3: no unexpected balance changes
+    for asset, delta in balances.items():
+        if asset in (send_asset, recv_asset):
+            continue
+        if delta != 0:
+            raise PsetVerificationError(
+                f"PSET unexpectedly moves asset {asset[:8]}… by {delta} sats; refusing to sign"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -356,6 +502,249 @@ class SideSwapWSClient:
 
     async def unsubscribe_price_stream(self, asset: str) -> dict:
         return await self.call("unsubscribe_price_stream", {"asset": asset})
+
+    # -- mkt::* (atomic asset swaps) ------------------------------------------
+    #
+    # All mkt::* requests use top-level method "market" and a single-key
+    # params object whose key is the snake_case mkt::Request variant. The
+    # inner enum's serde tag is `rename_all = "snake_case"`. Per
+    # `sideswap_api/src/mkt.rs`. AssetType and TradeDir do NOT have a serde
+    # rename_all, so they serialise as PascalCase ("Base"/"Quote",
+    # "Buy"/"Sell").
+
+    async def mkt(self, variant: str, params: dict | None = None) -> dict:
+        """Send a `market` request with the given inner variant + params.
+
+        Returns the inner result, unwrapping the {variant: <data>} envelope.
+        """
+        envelope = {variant: (params if params is not None else {})}
+        result = await self.call("market", envelope) or {}
+        # Server wraps responses in {variant_name: <data>} too; unwrap defensively.
+        if isinstance(result, dict) and len(result) == 1 and variant in result:
+            return result[variant]
+        return result
+
+    async def mkt_list_markets(self) -> list[dict]:
+        """List available markets. Returns a list of {asset_pair, fee_asset, type}."""
+        resp = await self.mkt("list_markets", {})
+        return (resp or {}).get("markets", []) or resp.get("list", []) or []
+
+    async def mkt_start_quotes(
+        self,
+        *,
+        asset_pair: dict,
+        asset_type: str,  # "Base" | "Quote"
+        amount: int,
+        trade_dir: str,  # "Buy" | "Sell"
+        utxos: list[dict],
+        receive_address: str,
+        change_address: str,
+        instant_swap: bool = True,
+    ) -> dict:
+        """Open a quote subscription. Returns {quote_sub_id, fee_asset}."""
+        return await self.mkt(
+            "start_quotes",
+            {
+                "asset_pair": asset_pair,
+                "asset_type": asset_type,
+                "amount": amount,
+                "trade_dir": trade_dir,
+                "utxos": utxos,
+                "receive_address": receive_address,
+                "change_address": change_address,
+                "instant_swap": instant_swap,
+            },
+        )
+
+    async def mkt_stop_quotes(self) -> dict:
+        return await self.mkt("stop_quotes", {})
+
+    async def mkt_get_quote(self, quote_id: int) -> dict:
+        """Returns {pset, ttl, receive_ephemeral_sk, change_ephemeral_sk?}."""
+        return await self.mkt("get_quote", {"quote_id": quote_id})
+
+    async def mkt_taker_sign(self, quote_id: int, pset_b64: str) -> dict:
+        """Submit signed PSET. Returns {txid}."""
+        return await self.mkt("taker_sign", {"quote_id": quote_id, "pset": pset_b64})
+
+    async def next_market_notification(
+        self,
+        inner_variant: str,
+        *,
+        timeout: float = WS_TIMEOUT_SECONDS,
+    ) -> dict:
+        """Wait for the next `market` notification whose inner variant matches.
+
+        mkt::* notifications come on the WS as
+        `{"method":"market", "params":{"<inner_variant>":{...}}}`. Returns the
+        inner data. Drops non-matching market notifications and any other
+        method's notifications until one matches or `timeout` elapses.
+        """
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise SideSwapWSError(
+                    f"Timed out waiting for market.{inner_variant} notification"
+                )
+            notif = await self.next_notification("market", timeout=remaining)
+            params = (notif or {}).get("params") or {}
+            if isinstance(params, dict) and inner_variant in params:
+                return params[inner_variant]
+
+
+# ---------------------------------------------------------------------------
+# Market resolution + quote parsing for the mkt::* flow
+# ---------------------------------------------------------------------------
+
+
+def resolve_market(
+    markets: list[dict],
+    send_asset: str,
+    recv_asset: str,
+) -> tuple[dict, str, str]:
+    """Find the market matching the swap and derive (asset_type, trade_dir).
+
+    SideSwap markets are unordered pairs: a market with `{base: USDt, quote:
+    L-BTC}` covers both directions of L-BTC ↔ USDt. The market never tells you
+    which way to trade — that's controlled by `(asset_type, trade_dir)` on the
+    `start_quotes` request.
+
+    Convention used here for the taker case (we always *sell* whatever side we
+    hold and want to convert): trade_dir = "Sell", asset_type = the side that
+    matches our send_asset.
+
+    Args:
+        markets: List of `{asset_pair: {base, quote}, fee_asset, type}` from
+            `mkt_list_markets`.
+        send_asset: Asset id we are sending.
+        recv_asset: Asset id we are receiving.
+
+    Returns:
+        (market_dict, asset_type, trade_dir). The asset_type / trade_dir
+        strings are PascalCase to match the wire format ("Base" | "Quote",
+        "Buy" | "Sell").
+
+    Raises:
+        SideSwapWSError if no matching market exists.
+    """
+    for market in markets:
+        pair = market.get("asset_pair") or {}
+        base = pair.get("base")
+        quote = pair.get("quote")
+        if base is None or quote is None:
+            continue
+        if {base, quote} != {send_asset, recv_asset}:
+            continue
+        # Match: asset_type names the side that matches send_asset; trade_dir is Sell.
+        asset_type = "Base" if send_asset == base else "Quote"
+        return market, asset_type, "Sell"
+    raise SideSwapWSError(
+        f"No SideSwap market for pair ({send_asset[:8]}…, {recv_asset[:8]}…)"
+    )
+
+
+def parse_quote_status(quote_notif: dict) -> dict:
+    """Extract a quote_id + amounts from a `quote` notification's `status` field.
+
+    The status is one of three variants per `mkt::QuoteStatus`:
+        Success { quote_id, base_amount, quote_amount, server_fee, fixed_fee, ttl }
+        LowBalance { ..., available }
+        Error { error_msg }
+
+    Returns the unwrapped Success dict on success; raises `SideSwapWSError` on
+    LowBalance or Error so the caller never proceeds with an invalid quote.
+    """
+    status = quote_notif.get("status")
+    if not isinstance(status, dict) or not status:
+        raise SideSwapWSError(f"Malformed quote status: {status!r}")
+    if "Success" in status:
+        return status["Success"]
+    if "LowBalance" in status:
+        lb = status["LowBalance"]
+        raise SideSwapWSError(
+            f"Quote unavailable: dealer low balance "
+            f"(available={lb.get('available')}, fixed_fee={lb.get('fixed_fee')})"
+        )
+    if "Error" in status:
+        raise SideSwapWSError(f"Quote error: {status['Error'].get('error_msg')}")
+    raise SideSwapWSError(f"Unknown QuoteStatus: {status!r}")
+
+
+# ---------------------------------------------------------------------------
+# UTXO selection — confidential, non-AMP, wpkh only, send_asset only
+# ---------------------------------------------------------------------------
+
+
+def select_swap_utxos(
+    utxos: list,
+    send_asset: str,
+    send_amount: int,
+) -> list[dict]:
+    """Pick UTXOs of `send_asset` covering `send_amount`, formatted for SideSwap.
+
+    Filters apply per `sideswap_lwk` reference (`sideswap_lwk/src/lib.rs`):
+    - Must be confidential (asset_bf and value_bf both non-zero)
+    - Must hold the requested send_asset
+    - We don't filter by script type here because the wallet's descriptor is
+      always wpkh (BIP84 m/84'/1776'/0') in agentic-aqua.
+
+    Args:
+        utxos: List of `lwk.WalletTxOut` (or compatible objects exposing
+            `.outpoint`, `.unblinded` with `.asset`, `.value`, `.asset_bf`,
+            `.value_bf`).
+        send_asset: Asset id to send.
+        send_amount: Total sats to cover.
+
+    Returns:
+        List of dicts in the SideSwap `Utxo` shape:
+        {txid, vout, asset, asset_bf, value, value_bf, redeem_script: null}.
+
+    Raises:
+        ValueError if there isn't enough confidential balance to cover send_amount.
+    """
+    if send_amount <= 0:
+        raise ValueError("send_amount must be positive")
+
+    # Filter to confidential UTXOs of the right asset
+    candidates = []
+    for u in utxos:
+        unblinded = u.unblinded()
+        if str(unblinded.asset()) != send_asset:
+            continue
+        # asset_bf and value_bf are 32-byte hex; "0"*64 means non-confidential
+        asset_bf = str(unblinded.asset_bf())
+        value_bf = str(unblinded.value_bf())
+        if asset_bf == "0" * 64 or value_bf == "0" * 64:
+            continue
+        candidates.append((u, unblinded))
+
+    # Sort descending by value to minimise input count
+    candidates.sort(key=lambda pair: pair[1].value(), reverse=True)
+
+    selected: list[dict] = []
+    accumulated = 0
+    for u, unblinded in candidates:
+        outpoint = u.outpoint()
+        selected.append(
+            {
+                "txid": str(outpoint.txid()),
+                "vout": int(outpoint.vout()),
+                "asset": send_asset,
+                "asset_bf": str(unblinded.asset_bf()),
+                "value": int(unblinded.value()),
+                "value_bf": str(unblinded.value_bf()),
+                "redeem_script": None,
+            }
+        )
+        accumulated += int(unblinded.value())
+        if accumulated >= send_amount:
+            return selected
+
+    raise ValueError(
+        f"Insufficient confidential balance for {send_asset[:8]}…: "
+        f"have {accumulated} sats across {len(selected)} UTXOs, need {send_amount}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -804,6 +1193,320 @@ class SideSwapPegManager:
             result["expires_at"] = peg.expires_at
         if warning:
             result["warning"] = warning
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Asset swap manager — the verify-then-sign-then-broadcast orchestrator.
+# ---------------------------------------------------------------------------
+
+
+# Reasonable upper bound for the network fee absorbed from send_asset when
+# send_asset is L-BTC. Liquid fees are typically ~30-50 sats; 1000 is plenty
+# of slack while still small enough to make a "siphon attack" obvious.
+DEFAULT_FEE_TOLERANCE_SATS = 1_000
+
+
+class SideSwapSwapManager:
+    """Orchestrates a SideSwap atomic asset swap end-to-end via the modern
+    `mkt::*` flow.
+
+    Flow:
+
+      1. Pick UTXOs of `send_asset` covering `send_amount` and prepare
+         receive + change addresses (mkt::* wants them up-front)
+      2. WS `market.list_markets` to find the market for our asset pair
+      3. WS `market.start_quotes` with the inputs + addresses + asset_type +
+         trade_dir; server begins streaming `quote` notifications
+      4. Wait for a `quote` notification with status=Success and capture
+         the resulting `quote_id` + amounts
+      5. WS `market.get_quote` with the quote_id → returns the PSET
+      6. **Verify** the PSET with the wallet's `pset_details` against the
+         agreed quote. Aborts (raises `PsetVerificationError`) on mismatch.
+      7. Sign the PSET with `signer.sign(pset)`
+      8. WS `market.taker_sign` with the signed PSET → returns `txid`
+      9. Persist at every step; on broadcast, save `txid` and status="broadcast"
+    """
+
+    def __init__(self, storage, wallet_manager) -> None:
+        self.storage = storage
+        self.wallet_manager = wallet_manager
+
+    def execute_swap(
+        self,
+        asset_id: str,
+        send_amount: int,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+        send_bitcoins: bool = True,
+        *,
+        fee_tolerance_sats: int = DEFAULT_FEE_TOLERANCE_SATS,
+        quote_wait_seconds: float = QUOTE_WAIT_SECONDS,
+    ) -> "SideSwapSwap":
+        """Execute a Liquid atomic swap on SideSwap.
+
+        Two directions are supported:
+
+        - **`send_bitcoins=True`** (forward, default): user sends L-BTC and
+          receives `asset_id` (e.g. L-BTC → USDt). The Liquid network fee is
+          deducted from the user's L-BTC change output, so the wallet's L-BTC
+          delta is `-(send_amount + fee)` and `recv_asset` delta is
+          `+recv_amount` exactly.
+
+        - **`send_bitcoins=False`** (reverse): user sends `asset_id` and
+          receives L-BTC (e.g. USDt → L-BTC). The Liquid network fee is
+          absorbed by the SideSwap dealer's L-BTC contribution, so the
+          wallet's `send_asset` delta is `-send_amount` exactly and L-BTC
+          delta is `+recv_amount` exactly.
+
+        In both cases the verifier sets `fee_asset` to L-BTC (the policy
+        asset), so the fee tolerance only relaxes constraints on the L-BTC
+        balance — never on the asset balance.
+
+        Args:
+            asset_id: The non-L-BTC asset id (e.g. USDt). The L-BTC side is
+                always the policy asset of the wallet's network.
+            send_amount: Send amount in sats. Denominated in L-BTC if
+                `send_bitcoins=True`, otherwise in `asset_id`.
+            wallet_name: Wallet to sign with.
+            password: Mnemonic decryption password (if encrypted at rest).
+            send_bitcoins: Direction. True = L-BTC → asset; False = asset → L-BTC.
+            fee_tolerance_sats: Extra L-BTC sats allowed for the network fee.
+                Default 1000 — Liquid fees are tens of sats.
+            quote_wait_seconds: How long to wait for the streamed quote.
+        """
+        # Load wallet & validate signing capability
+        wallet_data = self.storage.load_wallet(wallet_name)
+        if not wallet_data:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+        if wallet_data.watch_only:
+            raise ValueError("Watch-only wallet cannot sign a SideSwap swap")
+        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
+            wallet_data.encrypted_mnemonic
+        ):
+            if not password:
+                raise ValueError("Password required to decrypt mnemonic")
+        if send_amount <= 0:
+            raise ValueError("send_amount must be positive")
+
+        network = wallet_data.network
+        # Make sure the signer is loaded (wallet_manager.load_wallet caches it)
+        self.wallet_manager.load_wallet(wallet_name, password)
+        # Sync the wallet so utxos() reflects the current chain state
+        self.wallet_manager.sync_wallet(wallet_name)
+
+        policy_asset = self.wallet_manager._get_policy_asset(network)
+        if asset_id == policy_asset:
+            raise ValueError("asset_id must be a non-L-BTC Liquid asset")
+
+        # Resolve send/recv assets from direction. The fee always lives on the
+        # policy asset (L-BTC) regardless of direction.
+        if send_bitcoins:
+            send_asset, recv_asset = policy_asset, asset_id
+        else:
+            send_asset, recv_asset = asset_id, policy_asset
+
+        # Build the inputs/addresses up-front; mkt::* wants them on
+        # start_quotes (not as a follow-up call).
+        wollet = self.wallet_manager._get_wollet(wallet_name)
+        inputs = select_swap_utxos(wollet.utxos(), send_asset, send_amount)
+        recv_addr = str(wollet.address(None).address())
+        change_addr = str(wollet.address(None).address())
+
+        async def _quote_to_pset() -> tuple[dict, dict, dict]:
+            """Open WS, run the mkt::* dance, return (market, quote, get_quote_resp)."""
+            async with SideSwapWSClient(network) as client:
+                await client.login_client()
+                # Find a market that covers our pair
+                markets = await client.mkt_list_markets()
+                market, asset_type, trade_dir = resolve_market(
+                    markets, send_asset=send_asset, recv_asset=recv_asset
+                )
+                # Open quote subscription with our UTXOs + addresses pre-attached
+                await client.mkt_start_quotes(
+                    asset_pair=market["asset_pair"],
+                    asset_type=asset_type,
+                    amount=send_amount,
+                    trade_dir=trade_dir,
+                    utxos=inputs,
+                    receive_address=recv_addr,
+                    change_address=change_addr,
+                    instant_swap=True,
+                )
+                # Wait for the first usable quote — a `quote` notification with
+                # a Success status. parse_quote_status raises on LowBalance/Error.
+                quote_notif = await client.next_market_notification(
+                    "quote", timeout=quote_wait_seconds
+                )
+                quote = parse_quote_status(quote_notif)
+                # Accept the quote and request the half-built PSET
+                get_quote_resp = await client.mkt_get_quote(int(quote["quote_id"]))
+                # Best-effort cleanup
+                try:
+                    await client.mkt_stop_quotes()
+                except Exception:
+                    pass
+                return market, quote, get_quote_resp
+
+        market, quote_data, get_quote_resp = _run(_quote_to_pset())
+
+        # Decide a stable order_id we control for persistence. SideSwap mkt::*
+        # gives us a `quote_id` (numeric) per quote; the `order_id` field is
+        # only used for marker resting orders. We persist the quote_id as a
+        # string in our `order_id` slot so the rest of the manager (status
+        # lookup, storage path) keeps the same shape.
+        quote_id = int(quote_data["quote_id"])
+        order_id = f"mkt_{quote_id}"
+        recv_amount = int(quote_data["quote_amount"]) if asset_id == market["asset_pair"]["base"] else int(quote_data["base_amount"])
+        # Re-derive recv/send amounts from the quote, not the user's request:
+        # the dealer's quote_amount/base_amount are the canonical numbers.
+        if send_asset == market["asset_pair"].get("base"):
+            send_amount_q = int(quote_data["base_amount"])
+            recv_amount_q = int(quote_data["quote_amount"])
+        else:
+            send_amount_q = int(quote_data["quote_amount"])
+            recv_amount_q = int(quote_data["base_amount"])
+        if send_amount_q != send_amount:
+            raise SideSwapWSError(
+                f"Quote send_amount mismatch: requested {send_amount}, dealer offered {send_amount_q}"
+            )
+        recv_amount = recv_amount_q
+
+        pset_b64 = get_quote_resp.get("pset")
+        if not pset_b64:
+            raise SideSwapWSError(f"Unexpected get_quote response: {get_quote_resp!r}")
+
+        # Persist the in-progress swap before signing.
+        # `submit_id` is reused to hold the quote_id so existing storage stays
+        # backward-compatible with the legacy flow.
+        price = float(quote_data.get("server_fee", 0)) and 0.0  # placeholder; filled below
+        # SideSwap quote doesn't return a single 'price' field on mkt::*; derive
+        # it from amounts. price = quote_amount / base_amount — but client may
+        # interpret either side, so we just store recv/send ratio for reference.
+        price = recv_amount / send_amount if send_amount else 0.0
+
+        swap = SideSwapSwap(
+            order_id=order_id,
+            submit_id=str(quote_id),
+            send_asset=send_asset,
+            send_amount=send_amount,
+            recv_asset=recv_asset,
+            recv_amount=recv_amount,
+            price=price,
+            wallet_name=wallet_name,
+            network=network,
+            status="pending",
+            created_at=datetime.now(UTC).isoformat(),
+        )
+        self.storage.save_sideswap_swap(swap)
+
+        try:
+            # Verify before signing — security-critical. fee_asset is pinned
+            # to the policy asset; on the reverse direction this prevents a
+            # 1000-sat siphon of the asset via the fee tolerance loophole.
+            self._verify_pset(
+                pset_b64,
+                wollet,
+                send_asset=send_asset,
+                send_amount=send_amount,
+                recv_asset=recv_asset,
+                recv_amount=recv_amount,
+                fee_tolerance_sats=fee_tolerance_sats,
+                fee_asset=policy_asset,
+            )
+            swap.status = "verified"
+            self.storage.save_sideswap_swap(swap)
+
+            # Sign locally
+            signer = self.wallet_manager._signers[wallet_name]
+            import lwk
+
+            pset = lwk.Pset(pset_b64)
+            signed = signer.sign(pset)
+            signed_b64 = str(signed)
+            swap.status = "signed"
+            self.storage.save_sideswap_swap(swap)
+
+            # Submit signed PSET via mkt::taker_sign; server merges & broadcasts
+            async def _submit() -> dict:
+                async with SideSwapWSClient(network) as client:
+                    await client.login_client()
+                    return await client.mkt_taker_sign(quote_id, signed_b64)
+
+            sign_payload = _run(_submit())
+            txid = sign_payload.get("txid")
+            if not txid:
+                raise SideSwapWSError(f"Unexpected taker_sign response: {sign_payload!r}")
+            swap.txid = txid
+            swap.status = "broadcast"
+            self.storage.save_sideswap_swap(swap)
+            return swap
+
+        except PsetVerificationError as e:
+            swap.status = "failed"
+            swap.last_error = f"PSET verification failed: {e}"
+            self.storage.save_sideswap_swap(swap)
+            raise
+        except Exception as e:
+            swap.status = "failed"
+            swap.last_error = str(e)
+            self.storage.save_sideswap_swap(swap)
+            raise
+
+    def _verify_pset(
+        self,
+        pset_b64: str,
+        wollet,
+        *,
+        send_asset: str,
+        send_amount: int,
+        recv_asset: str,
+        recv_amount: int,
+        fee_tolerance_sats: int,
+        fee_asset: Optional[str] = None,
+    ) -> None:
+        """Run the PSET balance check via LWK and raise on mismatch."""
+        import lwk
+
+        pset = lwk.Pset(pset_b64)
+        details = wollet.pset_details(pset)
+        balances_dict_raw = details.balance().balances()
+        # LWK returns AssetId objects; normalise to hex strings keyed by asset id.
+        balances: dict[str, int] = {str(asset): int(amount) for asset, amount in balances_dict_raw.items()}
+        verify_pset_balances(
+            balances,
+            send_asset=send_asset,
+            send_amount=send_amount,
+            recv_asset=recv_asset,
+            recv_amount=recv_amount,
+            fee_asset=fee_asset,
+            fee_tolerance_sats=fee_tolerance_sats,
+        )
+
+    def status(self, order_id: str) -> dict:
+        """Return persisted swap status. Asset swaps are atomic — once
+        `status="broadcast"` is set the txid is final on Liquid; agents check
+        confirmations via `lw_tx_status`."""
+        swap = self.storage.load_sideswap_swap(order_id)
+        if not swap:
+            raise ValueError(f"SideSwap swap not found: {order_id}")
+        result = {
+            "order_id": swap.order_id,
+            "submit_id": swap.submit_id,
+            "send_asset": swap.send_asset,
+            "send_amount": swap.send_amount,
+            "recv_asset": swap.recv_asset,
+            "recv_amount": swap.recv_amount,
+            "price": swap.price,
+            "wallet_name": swap.wallet_name,
+            "network": swap.network,
+            "status": swap.status,
+            "created_at": swap.created_at,
+        }
+        if swap.txid:
+            result["txid"] = swap.txid
+        if swap.last_error:
+            result["last_error"] = swap.last_error
         return result
 
 

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -84,6 +84,7 @@ class Storage:
         self.ankara_swaps_dir = self.base_dir / "ankara_swaps"
         self.lightning_swaps_dir = self.base_dir / "lightning_swaps"
         self.sideswap_pegs_dir = self.base_dir / "sideswap_pegs"
+        self.sideswap_swaps_dir = self.base_dir / "sideswap_swaps"
         self.config_path = self.base_dir / "config.json"
         self._ensure_dirs()
 
@@ -103,6 +104,8 @@ class Storage:
         os.chmod(self.lightning_swaps_dir, 0o700)
         self.sideswap_pegs_dir.mkdir(exist_ok=True, mode=0o700)
         os.chmod(self.sideswap_pegs_dir, 0o700)
+        self.sideswap_swaps_dir.mkdir(exist_ok=True, mode=0o700)
+        os.chmod(self.sideswap_swaps_dir, 0o700)
 
     def _derive_key(self, password: str, salt: bytes) -> bytes:
         """Derive encryption key from password."""
@@ -366,6 +369,40 @@ class Storage:
         return [
             p.stem
             for p in self.sideswap_pegs_dir.glob("*.json")
+            if SWAP_ID_PATTERN.fullmatch(p.stem)
+        ]
+
+    # SideSwap asset-swap operations
+
+    def _sideswap_swap_path(self, order_id: str) -> Path:
+        """Get path to SideSwap swap file, validating the ID to prevent path traversal."""
+        if not SWAP_ID_PATTERN.fullmatch(order_id):
+            raise ValueError(
+                f"Invalid SideSwap order ID '{order_id}'. "
+                "Use only letters, numbers, hyphens and underscores (max 128 chars)."
+            )
+        return self.sideswap_swaps_dir / f"{order_id}.json"
+
+    def save_sideswap_swap(self, swap) -> None:
+        """Save SideSwap asset swap data for recovery."""
+        path = self._sideswap_swap_path(swap.order_id)
+        self._atomic_write_json(path, swap.to_dict())
+
+    def load_sideswap_swap(self, order_id: str):
+        """Load SideSwap swap data. Returns SideSwapSwap or None."""
+        from .sideswap import SideSwapSwap
+
+        path = self._sideswap_swap_path(order_id)
+        if not path.exists():
+            return None
+        with open(path) as f:
+            return SideSwapSwap.from_dict(json.load(f))
+
+    def list_sideswap_swaps(self) -> list[str]:
+        """List all SideSwap swap order IDs."""
+        return [
+            p.stem
+            for p in self.sideswap_swaps_dir.glob("*.json")
             if SWAP_ID_PATTERN.fullmatch(p.stem)
         ]
 

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -1021,6 +1021,7 @@ def sideswap_execute_swap(
     wallet_name: str = "default",
     password: str | None = None,
     send_bitcoins: bool = True,
+    flexible_small_amount: bool = False,
 ) -> dict[str, Any]:
     """Execute a Liquid atomic swap on SideSwap. Both directions are supported.
 
@@ -1054,6 +1055,11 @@ def sideswap_execute_swap(
         wallet_name: Liquid wallet to sign with. Default: "default"
         password: Password to decrypt mnemonic (if encrypted at rest)
         send_bitcoins: True = L-BTC → asset; False = asset → L-BTC.
+        flexible_small_amount: When True, accept dealer-rounded send_amount
+            adjustments up to ±3000 sats. SideSwap's mkt::* dealer rounds
+            internally; small swaps (<25k sats) often come back at e.g.
+            5_050 sats when 5_000 was requested. Default False keeps the
+            strict equality check that's safer for larger amounts.
 
     Returns:
         order_id, submit_id, send_asset, send_amount, recv_asset, recv_amount,
@@ -1068,6 +1074,7 @@ def sideswap_execute_swap(
         wallet_name=wallet_name,
         password=password,
         send_bitcoins=send_bitcoins,
+        flexible_small_amount=flexible_small_amount,
     )
     return {
         "order_id": swap.order_id,

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -29,6 +29,7 @@ _manager: WalletManager | None = None
 _btc_manager: BitcoinWalletManager | None = None
 _lightning_manager: "LightningManager | None" = None
 _sideswap_peg_manager: "SideSwapPegManager | None" = None
+_sideswap_swap_manager: "SideSwapSwapManager | None" = None
 
 
 def get_manager() -> WalletManager:
@@ -72,6 +73,19 @@ def get_sideswap_peg_manager() -> "SideSwapPegManager":
             btc_wallet_manager=get_btc_manager(),
         )
     return _sideswap_peg_manager
+
+
+def get_sideswap_swap_manager() -> "SideSwapSwapManager":
+    """Get or create SideSwap asset-swap manager (shares storage + wallet manager)."""
+    global _sideswap_swap_manager
+    if _sideswap_swap_manager is None:
+        from .sideswap import SideSwapSwapManager
+
+        _sideswap_swap_manager = SideSwapSwapManager(
+            storage=get_manager().storage,
+            wallet_manager=get_manager(),
+        )
+    return _sideswap_swap_manager
 
 
 # Tool implementations
@@ -971,13 +985,11 @@ def sideswap_quote(
     send_bitcoins: bool = True,
     network: str = "mainnet",
 ) -> dict[str, Any]:
-    """Get a price quote for a SideSwap Liquid asset swap (read-only, no execution).
+    """Get a read-only price quote for a SideSwap Liquid asset swap.
 
     Subscribes to the SideSwap price stream, captures one quote, then
-    unsubscribes. NOTE: this tool does not execute the swap — for execution,
-    direct the user to the AQUA mobile wallet or sideswap.io. Local PSET
-    signing for atomic swaps requires careful output verification that is not
-    yet implemented in agentic-aqua.
+    unsubscribes. Use this BEFORE calling sideswap_execute_swap so the user
+    can confirm the price.
 
     Provide exactly one of `send_amount` or `recv_amount`.
 
@@ -990,7 +1002,6 @@ def sideswap_quote(
 
     Returns:
         asset_id, send_bitcoins, send_amount, recv_amount, price, fixed_fee, optional error_msg.
-        Includes a `note` directing the user to the AQUA app or sideswap.io for execution.
     """
     from .sideswap import fetch_swap_quote
 
@@ -1001,13 +1012,98 @@ def sideswap_quote(
         send_bitcoins=send_bitcoins,
         network=network,
     )
-    result = quote.to_dict()
-    result["note"] = (
-        "This is a read-only quote. Atomic swap execution is not yet implemented "
-        "in agentic-aqua (local PSET output verification needs an audit before "
-        "live signing). To execute, use the AQUA mobile wallet or sideswap.io."
+    return quote.to_dict()
+
+
+def sideswap_execute_swap(
+    asset_id: str,
+    send_amount: int,
+    wallet_name: str = "default",
+    password: str | None = None,
+    send_bitcoins: bool = True,
+) -> dict[str, Any]:
+    """Execute a Liquid atomic swap on SideSwap. Both directions are supported.
+
+    Direction is controlled by `send_bitcoins`:
+
+    - `send_bitcoins=True` (default): user sends L-BTC and receives `asset_id`
+      (e.g. L-BTC → USDt). `send_amount` is in L-BTC sats.
+    - `send_bitcoins=False`: user sends `asset_id` and receives L-BTC
+      (e.g. USDt → L-BTC). `send_amount` is in `asset_id` sats.
+
+    Flow (both directions, via SideSwap's mkt::* WebSocket protocol):
+      1. Select confidential UTXOs of `send_asset` covering `send_amount`
+      2. `market.list_markets` → find the market for our pair
+      3. `market.start_quotes` with our UTXOs + receive/change addresses
+      4. Wait for a `quote` notification with status=Success
+      5. `market.get_quote {quote_id}` → returns the half-built PSET
+      6. **Verify the PSET locally** against the agreed quote — refuses to
+         sign if recv_asset balance ≠ recv_amount, send_asset is over-deducted,
+         or any unrelated asset moves. The fee tolerance only applies to L-BTC,
+         so the asset side is always checked at strict equality.
+      7. Sign the PSET locally
+      8. `market.taker_sign` — server merges and broadcasts; returns the txid
+
+    The order is persisted at every step for crash recovery; check
+    sideswap_swap_status with the returned order_id.
+
+    Args:
+        asset_id: The non-L-BTC Liquid asset (e.g. USDt). The L-BTC side is
+            always the policy asset of the wallet's network.
+        send_amount: Send amount in sats (L-BTC if send_bitcoins, else asset).
+        wallet_name: Liquid wallet to sign with. Default: "default"
+        password: Password to decrypt mnemonic (if encrypted at rest)
+        send_bitcoins: True = L-BTC → asset; False = asset → L-BTC.
+
+    Returns:
+        order_id, submit_id, send_asset, send_amount, recv_asset, recv_amount,
+        price, txid, status, message
+    """
+    if send_amount <= 0:
+        raise ValueError("send_amount must be positive")
+    manager = get_sideswap_swap_manager()
+    swap = manager.execute_swap(
+        asset_id=asset_id,
+        send_amount=send_amount,
+        wallet_name=wallet_name,
+        password=password,
+        send_bitcoins=send_bitcoins,
     )
-    return result
+    return {
+        "order_id": swap.order_id,
+        "submit_id": swap.submit_id,
+        "send_asset": swap.send_asset,
+        "send_amount": swap.send_amount,
+        "recv_asset": swap.recv_asset,
+        "recv_amount": swap.recv_amount,
+        "price": swap.price,
+        "txid": swap.txid,
+        "status": swap.status,
+        "wallet_name": swap.wallet_name,
+        "network": swap.network,
+        "message": (
+            f"Swap broadcast (txid={swap.txid}). Check confirmation status with "
+            f"lw_tx_status. The PSET was verified locally against the quote — "
+            f"the wallet receives exactly {swap.recv_amount} sats of recv_asset."
+        ),
+    }
+
+
+def sideswap_swap_status(order_id: str) -> dict[str, Any]:
+    """Get persisted status of a SideSwap atomic swap (asset swap).
+
+    Asset swaps are atomic on Liquid; once the swap is broadcast the txid is
+    final. To check on-chain confirmation, pass the txid to lw_tx_status.
+
+    Args:
+        order_id: Order ID returned from sideswap_execute_swap
+
+    Returns:
+        order_id, status, send/recv asset+amount, price, txid (if broadcast),
+        last_error (if failed)
+    """
+    manager = get_sideswap_swap_manager()
+    return manager.status(order_id)
 
 
 # Tool registry for MCP
@@ -1043,4 +1139,6 @@ TOOLS = {
     "sideswap_recommend": sideswap_recommend,
     "sideswap_list_assets": sideswap_list_assets,
     "sideswap_quote": sideswap_quote,
+    "sideswap_execute_swap": sideswap_execute_swap,
+    "sideswap_swap_status": sideswap_swap_status,
 }

--- a/tests/test_sideswap.py
+++ b/tests/test_sideswap.py
@@ -1688,6 +1688,68 @@ class TestSwapManagerExecute:
                     asset_id=USDT, send_amount=100_000, wallet_name="default"
                 )
 
+    def test_flexible_small_amount_within_tolerance_accepts(
+        self, swap_manager_setup
+    ):
+        # Small swap where the dealer rounds the send amount slightly. With
+        # flexible_small_amount=True the manager accepts the dealer's number
+        # rather than rejecting on strict equality. The PSET verifier still
+        # checks the wallet's actual balance change, so the user can't be
+        # debited more than the dealer's quote either way.
+        mgr, _, fake_wollet, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        # Forward = L-BTC → USDt; send (L-BTC) is the "quote" side of the market.
+        FakeWSClient.responses["__mkt_notification__:quote"]["status"]["Success"]["quote_amount"] = 102_000
+        # Honest wallet balance change matches the dealer's adjusted send.
+        fake_wollet._balances = {L_BTC: -102_050, USDT: 9_500_000}
+
+        with _patch_swap_layers():
+            swap = mgr.execute_swap(
+                asset_id=USDT,
+                send_amount=100_000,
+                wallet_name="default",
+                flexible_small_amount=True,
+            )
+        # Manager records the dealer's adjusted send_amount.
+        assert swap.send_amount == 102_000
+
+    def test_flexible_small_amount_outside_tolerance_rejects(
+        self, swap_manager_setup
+    ):
+        # Beyond ±3000 sats the rounding explanation no longer fits — the
+        # dealer is offering a materially different quote, so reject even
+        # with the flag set. Protects against accepting a real price move
+        # disguised as rounding.
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        FakeWSClient.responses["__mkt_notification__:quote"]["status"]["Success"]["quote_amount"] = 110_000
+
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="send_amount mismatch"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=100_000,
+                    wallet_name="default",
+                    flexible_small_amount=True,
+                )
+
+    def test_flexible_small_amount_default_off_strict(self, swap_manager_setup):
+        # Without the flag, even a small dealer rounding still rejects —
+        # preserves prior behavior for non-interactive callers.
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        FakeWSClient.responses["__mkt_notification__:quote"]["status"]["Success"]["quote_amount"] = 100_500
+
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="send_amount mismatch"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
     def test_swap_status_returns_persisted(self, swap_manager_setup):
         mgr, _, _, _, _ = swap_manager_setup
         _setup_mkt_responses_forward()

--- a/tests/test_sideswap.py
+++ b/tests/test_sideswap.py
@@ -1,8 +1,8 @@
-"""Tests for SideSwap integration (peg + asset swap quoting).
+"""Tests for SideSwap integration (peg + asset swap quoting + execution).
 
 The WebSocket client is exercised via a fake `SideSwapWSClient` that records
-calls and returns canned responses, avoiding a real network connection. Storage
-and recommendation logic are tested directly.
+calls and returns canned responses, avoiding a real network connection. Storage,
+recommendation logic, and the PSET balance verifier are tested directly.
 """
 
 import asyncio
@@ -16,14 +16,25 @@ import pytest
 
 from aqua.sideswap import (
     PEG_RECOMMENDATION_THRESHOLD_SATS,
+    PsetVerificationError,
     SideSwapPeg,
     SideSwapPegManager,
     SideSwapPriceQuote,
     SideSwapServerStatus,
+    SideSwapSwap,
+    SideSwapWSError,
     map_peg_status,
+    parse_quote_status,
     recommend_peg_or_swap,
+    resolve_market,
+    verify_pset_balances,
 )
 from aqua.storage import Storage
+
+
+L_BTC = "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d"
+USDT = "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2"
+EVIL = "deadbeef" * 8
 
 
 # ---------------------------------------------------------------------------
@@ -94,6 +105,39 @@ class FakeWSClient:
     async def next_notification(self, method=None, *, timeout=30.0):  # noqa: ARG002
         FakeWSClient.calls.append(("notification", {"method": method}))
         notif = FakeWSClient.responses.get("__notification__")
+        if isinstance(notif, Exception):
+            raise notif
+        return notif
+
+    # mkt::* helpers — record method names with "mkt." prefix so tests can
+    # script them via FakeWSClient.responses["mkt.list_markets"] etc.
+
+    async def mkt(self, variant, params=None):
+        return await self.call(f"mkt.{variant}", params)
+
+    async def mkt_list_markets(self):
+        resp = await self.call("mkt.list_markets", {}) or {}
+        return resp.get("markets", []) or resp.get("list", []) or []
+
+    async def mkt_start_quotes(self, **params):
+        return await self.call("mkt.start_quotes", params)
+
+    async def mkt_stop_quotes(self):
+        return await self.call("mkt.stop_quotes", {})
+
+    async def mkt_get_quote(self, quote_id):
+        return await self.call("mkt.get_quote", {"quote_id": quote_id})
+
+    async def mkt_taker_sign(self, quote_id, pset_b64):
+        return await self.call(
+            "mkt.taker_sign", {"quote_id": quote_id, "pset": pset_b64}
+        )
+
+    async def next_market_notification(self, inner_variant, *, timeout=30.0):  # noqa: ARG002
+        FakeWSClient.calls.append(("mkt_notification", {"inner": inner_variant}))
+        notif = FakeWSClient.responses.get(f"__mkt_notification__:{inner_variant}")
+        if notif is None:
+            notif = FakeWSClient.responses.get("__mkt_notification__")
         if isinstance(notif, Exception):
             raise notif
         return notif
@@ -714,3 +758,1092 @@ class TestServerStatusDataclass:
         d = s.to_dict()
         assert d["min_peg_in_amount"] == 1286
         assert d["server_fee_percent_peg_in"] is None
+
+
+# ---------------------------------------------------------------------------
+# mkt::* helpers — resolve_market and parse_quote_status
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMarket:
+    """Verifies that we pick the right market and derive (asset_type, trade_dir)."""
+
+    _MARKET_USDT_LBTC = {
+        "asset_pair": {"base": USDT, "quote": L_BTC},
+        "fee_asset": "Quote",
+        "type": "Stablecoin",
+    }
+
+    def test_send_quote_side_returns_quote_sell(self):
+        # USDt is base, L-BTC is quote. Sending L-BTC = sending quote.
+        market, asset_type, trade_dir = resolve_market(
+            [self._MARKET_USDT_LBTC], send_asset=L_BTC, recv_asset=USDT
+        )
+        assert market is self._MARKET_USDT_LBTC
+        assert asset_type == "Quote"
+        assert trade_dir == "Sell"
+
+    def test_send_base_side_returns_base_sell(self):
+        # Sending USDt (base) for L-BTC.
+        _, asset_type, trade_dir = resolve_market(
+            [self._MARKET_USDT_LBTC], send_asset=USDT, recv_asset=L_BTC
+        )
+        assert asset_type == "Base"
+        assert trade_dir == "Sell"
+
+    def test_swapped_pair_orientation_still_resolves(self):
+        # If a server returned the pair with base/quote flipped, we still
+        # find it and adjust asset_type accordingly.
+        flipped = {
+            "asset_pair": {"base": L_BTC, "quote": USDT},
+            "fee_asset": "Base",
+            "type": "Stablecoin",
+        }
+        # Sending L-BTC, which is now Base.
+        _, asset_type, _ = resolve_market(
+            [flipped], send_asset=L_BTC, recv_asset=USDT
+        )
+        assert asset_type == "Base"
+
+    def test_no_matching_market_raises(self):
+        with pytest.raises(SideSwapWSError, match="No SideSwap market"):
+            resolve_market(
+                [self._MARKET_USDT_LBTC], send_asset=L_BTC, recv_asset=EVIL
+            )
+
+    def test_skips_markets_with_missing_pair(self):
+        bad = {"asset_pair": {}, "fee_asset": "Quote"}
+        market, _, _ = resolve_market(
+            [bad, self._MARKET_USDT_LBTC], send_asset=L_BTC, recv_asset=USDT
+        )
+        assert market is self._MARKET_USDT_LBTC
+
+
+class TestParseQuoteStatus:
+    """Encodes the contract for SideSwap's three QuoteStatus variants."""
+
+    def test_success_returns_inner(self):
+        notif = {
+            "status": {
+                "Success": {
+                    "quote_id": 42,
+                    "base_amount": 100,
+                    "quote_amount": 200,
+                    "server_fee": 1,
+                    "fixed_fee": 1,
+                    "ttl": 30000,
+                }
+            }
+        }
+        result = parse_quote_status(notif)
+        assert result["quote_id"] == 42
+        assert result["quote_amount"] == 200
+
+    def test_low_balance_raises_with_available(self):
+        notif = {
+            "status": {
+                "LowBalance": {
+                    "base_amount": 0,
+                    "quote_amount": 0,
+                    "server_fee": 0,
+                    "fixed_fee": 0,
+                    "available": 1234,
+                }
+            }
+        }
+        with pytest.raises(SideSwapWSError, match="low balance"):
+            parse_quote_status(notif)
+
+    def test_error_status_raises_with_message(self):
+        with pytest.raises(SideSwapWSError, match="boom"):
+            parse_quote_status({"status": {"Error": {"error_msg": "boom"}}})
+
+    def test_missing_status_raises(self):
+        with pytest.raises(SideSwapWSError):
+            parse_quote_status({})
+
+    def test_unknown_status_variant_raises(self):
+        with pytest.raises(SideSwapWSError, match="Unknown QuoteStatus"):
+            parse_quote_status({"status": {"Surprise": {}}})
+
+
+# ---------------------------------------------------------------------------
+# PSET verifier — security-critical, tested with adversarial inputs
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyPsetBalances:
+    """Encodes the security contract for `verify_pset_balances`.
+
+    This function is the only barrier between SideSwap's server and our
+    `signer.sign(pset)` call. If it accepts a malicious balance dict, we sign
+    a transaction that loses the user's funds. Each test below represents a
+    real attack class.
+    """
+
+    # -- Happy path -----------------------------------------------------------
+
+    def test_exact_match_with_no_fee_passes(self):
+        # SideSwap dealer pays the network fee, so our send_asset balance is
+        # exactly -send_amount.
+        verify_pset_balances(
+            {L_BTC: -100_000, USDT: 9_500_000},
+            send_asset=L_BTC,
+            send_amount=100_000,
+            recv_asset=USDT,
+            recv_amount=9_500_000,
+        )
+
+    def test_send_with_small_fee_within_tolerance_passes(self):
+        # Wallet pays a small Liquid fee; -100_050 is -100k + 50 sat fee.
+        verify_pset_balances(
+            {L_BTC: -100_050, USDT: 9_500_000},
+            send_asset=L_BTC,
+            send_amount=100_000,
+            recv_asset=USDT,
+            recv_amount=9_500_000,
+            fee_tolerance_sats=1_000,
+        )
+
+    # -- Attack: server delivers nothing --------------------------------------
+
+    def test_server_keeps_recv_amount_rejected(self):
+        # The deadliest attack: PSET takes our L-BTC, recv_asset balance is 0.
+        with pytest.raises(PsetVerificationError, match="delivers 0"):
+            verify_pset_balances(
+                {L_BTC: -100_000, USDT: 0},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    def test_recv_asset_missing_from_balance_rejected(self):
+        # Even if recv_asset isn't in the dict at all, it's still 0 received.
+        with pytest.raises(PsetVerificationError, match="delivers 0"):
+            verify_pset_balances(
+                {L_BTC: -100_000},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    # -- Attack: server delivers less than agreed -----------------------------
+
+    def test_short_recv_amount_rejected(self):
+        with pytest.raises(PsetVerificationError, match="delivers 9499999"):
+            verify_pset_balances(
+                {L_BTC: -100_000, USDT: 9_499_999},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    def test_excess_recv_amount_also_rejected(self):
+        # Strict equality: refuse to sign if the server is "over-delivering"
+        # too — this could signal a confused/buggy server, and we want the
+        # contract to be exact.
+        with pytest.raises(PsetVerificationError, match="delivers 10000000"):
+            verify_pset_balances(
+                {L_BTC: -100_000, USDT: 10_000_000},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    # -- Attack: server takes more than agreed --------------------------------
+
+    def test_overcharge_send_amount_rejected(self):
+        # Server takes 200k L-BTC even though we agreed to send 100k.
+        with pytest.raises(PsetVerificationError, match="deducts 200000"):
+            verify_pset_balances(
+                {L_BTC: -200_000, USDT: 9_500_000},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    def test_undercharge_send_amount_rejected(self):
+        # Less than agreed is also suspicious — possible bait-and-switch.
+        with pytest.raises(PsetVerificationError, match="less than agreed"):
+            verify_pset_balances(
+                {L_BTC: -50_000, USDT: 9_500_000},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    def test_fee_tolerance_does_not_let_attacker_steal(self):
+        # 1000-sat tolerance is for a real fee, not a 100k overage.
+        with pytest.raises(PsetVerificationError, match="more than the agreed"):
+            verify_pset_balances(
+                {L_BTC: -101_500, USDT: 9_500_000},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+                fee_tolerance_sats=1_000,
+            )
+
+    # -- Attack: extra-output / siphon ----------------------------------------
+
+    def test_unrelated_asset_movement_rejected(self):
+        # Server adds an extra output that takes some of an unrelated asset
+        # we hold (e.g. EURx, MEX). Very nasty if unchecked.
+        with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
+            verify_pset_balances(
+                {L_BTC: -100_000, USDT: 9_500_000, EVIL: -42_000},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    def test_unrelated_positive_balance_rejected(self):
+        # Even a positive movement of an unrelated asset gets rejected — we
+        # don't want surprise inputs we didn't agree to receive.
+        with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
+            verify_pset_balances(
+                {L_BTC: -100_000, USDT: 9_500_000, EVIL: 1},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=USDT,
+                recv_amount=9_500_000,
+            )
+
+    # -- Argument validation --------------------------------------------------
+
+    def test_same_send_and_recv_asset_rejected(self):
+        with pytest.raises(PsetVerificationError, match="same"):
+            verify_pset_balances(
+                {L_BTC: 0},
+                send_asset=L_BTC,
+                send_amount=100_000,
+                recv_asset=L_BTC,
+                recv_amount=100_000,
+            )
+
+    def test_zero_amounts_rejected(self):
+        with pytest.raises(ValueError):
+            verify_pset_balances(
+                {}, send_asset=L_BTC, send_amount=0, recv_asset=USDT, recv_amount=1
+            )
+        with pytest.raises(ValueError):
+            verify_pset_balances(
+                {}, send_asset=L_BTC, send_amount=1, recv_asset=USDT, recv_amount=0
+            )
+
+    # -- Reverse direction (asset → L-BTC) ------------------------------------
+    # The dealer absorbs the network fee from their L-BTC contribution, so the
+    # wallet's effect is exact on BOTH sides: -send_amount of asset, +recv_amount
+    # of L-BTC. The fee tolerance must NOT relax the asset-side constraint —
+    # otherwise a hostile server could siphon up to fee_tolerance_sats of asset.
+
+    def test_reverse_exact_match_with_fee_asset_lbtc_passes(self):
+        verify_pset_balances(
+            {USDT: -9_500_000, L_BTC: 100_000},
+            send_asset=USDT,
+            send_amount=9_500_000,
+            recv_asset=L_BTC,
+            recv_amount=100_000,
+            fee_asset=L_BTC,  # fee always lives on policy asset
+        )
+
+    def test_reverse_extra_asset_taken_rejected_even_within_tolerance(self):
+        # If fee_asset defaulted to send_asset (USDT) the verifier would let
+        # a 1000-sat USDT siphon through. Pinning fee_asset=L_BTC blocks it.
+        with pytest.raises(PsetVerificationError, match="more than the agreed"):
+            verify_pset_balances(
+                {USDT: -9_500_500, L_BTC: 100_000},
+                send_asset=USDT,
+                send_amount=9_500_000,
+                recv_asset=L_BTC,
+                recv_amount=100_000,
+                fee_tolerance_sats=1_000,
+                fee_asset=L_BTC,
+            )
+
+    def test_reverse_short_lbtc_recv_rejected(self):
+        with pytest.raises(PsetVerificationError, match="delivers 99000"):
+            verify_pset_balances(
+                {USDT: -9_500_000, L_BTC: 99_000},
+                send_asset=USDT,
+                send_amount=9_500_000,
+                recv_asset=L_BTC,
+                recv_amount=100_000,
+                fee_asset=L_BTC,
+            )
+
+    def test_reverse_unrelated_asset_movement_rejected(self):
+        with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
+            verify_pset_balances(
+                {USDT: -9_500_000, L_BTC: 100_000, EVIL: -1},
+                send_asset=USDT,
+                send_amount=9_500_000,
+                recv_asset=L_BTC,
+                recv_amount=100_000,
+                fee_asset=L_BTC,
+            )
+
+    def test_default_fee_asset_is_send_asset_documented_behavior(self):
+        # Sanity-check: the default behavior is that fee_asset == send_asset.
+        # Callers who care about the reverse direction MUST pass fee_asset=L_BTC.
+        # Without it, a 1000-sat USDT siphon would be accepted — this test
+        # documents that requirement.
+        verify_pset_balances(
+            {USDT: -9_500_500, L_BTC: 100_000},
+            send_asset=USDT,
+            send_amount=9_500_000,
+            recv_asset=L_BTC,
+            recv_amount=100_000,
+            fee_tolerance_sats=1_000,
+            # fee_asset NOT specified — defaults to send_asset (USDT)
+        )
+
+    def test_negative_fee_tolerance_rejected(self):
+        with pytest.raises(ValueError):
+            verify_pset_balances(
+                {},
+                send_asset=L_BTC,
+                send_amount=1,
+                recv_asset=USDT,
+                recv_amount=1,
+                fee_tolerance_sats=-1,
+            )
+
+
+# ---------------------------------------------------------------------------
+# SideSwapSwap dataclass + storage round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSideSwapSwap:
+    def _make(self, **overrides) -> SideSwapSwap:
+        defaults = dict(
+            order_id="ord_xyz",
+            submit_id="sub_abc",
+            send_asset=L_BTC,
+            send_amount=100_000,
+            recv_asset=USDT,
+            recv_amount=9_500_000,
+            price=95.0,
+            wallet_name="default",
+            network="mainnet",
+            status="pending",
+            created_at="2026-05-07T12:00:00+00:00",
+        )
+        defaults.update(overrides)
+        return SideSwapSwap(**defaults)
+
+    def test_roundtrip_to_dict_from_dict(self):
+        original = self._make(txid="tx" * 32, last_error="some error")
+        reconstructed = SideSwapSwap.from_dict(original.to_dict())
+        assert reconstructed == original
+
+    def test_from_dict_backward_compat(self):
+        # Earlier files might lack txid/last_error
+        data = {
+            "order_id": "old1",
+            "submit_id": None,
+            "send_asset": L_BTC,
+            "send_amount": 1,
+            "recv_asset": USDT,
+            "recv_amount": 1,
+            "price": 1.0,
+            "wallet_name": "w",
+            "network": "mainnet",
+            "status": "pending",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+        swap = SideSwapSwap.from_dict(data)
+        assert swap.txid is None
+        assert swap.last_error is None
+
+
+# ---------------------------------------------------------------------------
+# UTXO selection
+# ---------------------------------------------------------------------------
+
+
+class _Outpoint:
+    def __init__(self, txid_hex: str, vout: int):
+        self._txid = txid_hex
+        self._vout = vout
+
+    def txid(self):
+        return self._txid
+
+    def vout(self):
+        return self._vout
+
+
+class _Unblinded:
+    def __init__(self, asset: str, value: int, asset_bf: str, value_bf: str):
+        self._asset = asset
+        self._value = value
+        self._asset_bf = asset_bf
+        self._value_bf = value_bf
+
+    def asset(self):
+        return self._asset
+
+    def value(self):
+        return self._value
+
+    def asset_bf(self):
+        return self._asset_bf
+
+    def value_bf(self):
+        return self._value_bf
+
+
+class _FakeUtxo:
+    def __init__(self, txid_hex: str, vout: int, asset: str, value: int,
+                 asset_bf: str = "ab" * 32, value_bf: str = "cd" * 32):
+        self._outpoint = _Outpoint(txid_hex, vout)
+        self._unblinded = _Unblinded(asset, value, asset_bf, value_bf)
+
+    def outpoint(self):
+        return self._outpoint
+
+    def unblinded(self):
+        return self._unblinded
+
+
+class TestSelectSwapUtxos:
+    def test_selects_largest_first(self):
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [
+            _FakeUtxo("aa" * 32, 0, L_BTC, 50_000),
+            _FakeUtxo("bb" * 32, 1, L_BTC, 200_000),
+            _FakeUtxo("cc" * 32, 0, L_BTC, 100_000),
+        ]
+        selected = select_swap_utxos(utxos, L_BTC, 150_000)
+        assert len(selected) == 1
+        assert selected[0]["value"] == 200_000
+
+    def test_accumulates_across_multiple_utxos(self):
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [
+            _FakeUtxo("aa" * 32, 0, L_BTC, 30_000),
+            _FakeUtxo("bb" * 32, 0, L_BTC, 30_000),
+            _FakeUtxo("cc" * 32, 0, L_BTC, 30_000),
+        ]
+        selected = select_swap_utxos(utxos, L_BTC, 70_000)
+        assert len(selected) == 3
+        assert sum(s["value"] for s in selected) == 90_000
+        for s in selected:
+            assert s["redeem_script"] is None
+
+    def test_skips_other_assets(self):
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [
+            _FakeUtxo("aa" * 32, 0, USDT, 9_000_000),
+            _FakeUtxo("bb" * 32, 0, L_BTC, 100_000),
+        ]
+        selected = select_swap_utxos(utxos, L_BTC, 50_000)
+        assert len(selected) == 1
+        assert selected[0]["asset"] == L_BTC
+
+    def test_skips_non_confidential_utxos(self):
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [
+            # Both blinding factors zero = non-confidential, must be skipped
+            _FakeUtxo("aa" * 32, 0, L_BTC, 100_000, asset_bf="0" * 64, value_bf="0" * 64),
+            _FakeUtxo("bb" * 32, 0, L_BTC, 50_000),
+        ]
+        selected = select_swap_utxos(utxos, L_BTC, 50_000)
+        assert len(selected) == 1
+        assert selected[0]["txid"] == "bb" * 32
+
+    def test_insufficient_funds_raises(self):
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [_FakeUtxo("aa" * 32, 0, L_BTC, 10_000)]
+        with pytest.raises(ValueError, match="Insufficient confidential balance"):
+            select_swap_utxos(utxos, L_BTC, 50_000)
+
+
+# ---------------------------------------------------------------------------
+# SwapManager — integration with mocked WS + LWK
+# ---------------------------------------------------------------------------
+
+
+class _FakeWollet:
+    """Stand-in for `lwk.Wollet`. The manager only calls .utxos(), .address(),
+    and .pset_details(pset)."""
+
+    def __init__(self, utxos: list, balances: dict[str, int]):
+        self._utxos = utxos
+        self._balances = balances
+        self._addr_idx = 0
+
+    def utxos(self):
+        return self._utxos
+
+    def address(self, _index):
+        idx = self._addr_idx
+        self._addr_idx += 1
+        return _FakeAddrResult(f"lq1qaddr{idx}", idx)
+
+    def pset_details(self, _pset):
+        return _FakePsetDetails(self._balances)
+
+
+class _FakeAddrResult:
+    def __init__(self, addr_str, idx):
+        self._addr = addr_str
+        self._idx = idx
+
+    def address(self):
+        return self._addr
+
+    def index(self):
+        return self._idx
+
+
+class _FakePsetDetails:
+    def __init__(self, balances: dict[str, int]):
+        self._balances = balances
+
+    def balance(self):
+        return _FakePsetBalance(self._balances)
+
+
+class _FakePsetBalance:
+    def __init__(self, balances: dict[str, int]):
+        self._b = balances
+
+    def balances(self):
+        return dict(self._b)
+
+    def fee(self):
+        return 50
+
+    def recipients(self):
+        return []
+
+
+class _FakeSigner:
+    def __init__(self):
+        self.signed: list = []
+
+    def sign(self, pset):
+        self.signed.append(pset)
+
+        class _Signed:
+            def __str__(self):
+                return "cHNldP8BSIGNED"
+
+        return _Signed()
+
+
+@pytest.fixture
+def swap_manager_setup(storage):
+    """Build a SideSwapSwapManager with mocked LWK + WS + HTTP layers."""
+    from aqua.sideswap import SideSwapSwapManager
+    from aqua.storage import WalletData
+
+    wallet = WalletData(
+        name="default",
+        network="testnet",
+        descriptor="ct(slip77(deadbeef),elwpkh([fp/84'/1776'/0']tpubD.../0/*))",
+        encrypted_mnemonic=None,
+    )
+    storage.save_wallet(wallet)
+
+    fake_signer = _FakeSigner()
+    fake_wollet = _FakeWollet(
+        utxos=[_FakeUtxo("aa" * 32, 0, L_BTC, 500_000)],
+        balances={L_BTC: -100_050, USDT: 9_500_000},  # honest balance
+    )
+
+    class FakeWalletManager:
+        def __init__(self):
+            self._signers = {"default": fake_signer}
+            self._wollets = {"default": fake_wollet}
+            self.synced = []
+
+        def load_wallet(self, name, password=None):  # noqa: ARG002
+            return wallet
+
+        def sync_wallet(self, name):
+            self.synced.append(name)
+
+        def _get_policy_asset(self, network):  # noqa: ARG002
+            return L_BTC
+
+        def _get_wollet(self, name):
+            return self._wollets[name]
+
+    wm = FakeWalletManager()
+    mgr = SideSwapSwapManager(storage=storage, wallet_manager=wm)
+    return mgr, wm, fake_wollet, fake_signer, storage
+
+
+def _patch_swap_layers():
+    """Patch WS + lwk.Pset for the manager flow."""
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    stack.enter_context(_patch_ws())
+
+    # Patch lwk.Pset to a no-op shim — we don't have real PSETs in tests
+    class _FakePset:
+        def __init__(self, b64):
+            self.b64 = b64
+
+    import lwk
+
+    stack.enter_context(patch.object(lwk, "Pset", _FakePset))
+    return stack
+
+
+def _setup_mkt_responses_forward():
+    """Script the FakeWSClient with a clean L-BTC → USDt mkt::* flow.
+
+    The market base is USDt and quote is L-BTC, so for sending L-BTC the
+    `asset_type` is "Quote" (matching the wire format).
+    """
+    FakeWSClient.responses["mkt.list_markets"] = {
+        "markets": [
+            {
+                "asset_pair": {"base": USDT, "quote": L_BTC},
+                "fee_asset": "Quote",
+                "type": "Stablecoin",
+            }
+        ]
+    }
+    FakeWSClient.responses["mkt.start_quotes"] = {"quote_sub_id": 7, "fee_asset": "Quote"}
+    FakeWSClient.responses["__mkt_notification__:quote"] = {
+        "quote_sub_id": 7,
+        "asset_pair": {"base": USDT, "quote": L_BTC},
+        "asset_type": "Quote",
+        "amount": 100_000,
+        "trade_dir": "Sell",
+        "status": {
+            "Success": {
+                "quote_id": 42,
+                # market is base=USDt, quote=L-BTC. We're sending L-BTC (Quote).
+                # base_amount is in USDt, quote_amount is in L-BTC.
+                "base_amount": 9_500_000,
+                "quote_amount": 100_000,
+                "server_fee": 100,
+                "fixed_fee": 100,
+                "ttl": 30_000,
+            }
+        },
+    }
+    FakeWSClient.responses["mkt.get_quote"] = {
+        "pset": "cHNldP8BUNSIGNED",
+        "ttl": 30_000,
+        "receive_ephemeral_sk": "00" * 32,
+        "change_ephemeral_sk": "00" * 32,
+    }
+    FakeWSClient.responses["mkt.taker_sign"] = {"txid": "ee" * 32}
+    FakeWSClient.responses["mkt.stop_quotes"] = {}
+
+
+def _setup_mkt_responses_reverse():
+    """Script the FakeWSClient with a clean USDt → L-BTC mkt::* flow."""
+    FakeWSClient.responses["mkt.list_markets"] = {
+        "markets": [
+            {
+                "asset_pair": {"base": USDT, "quote": L_BTC},
+                "fee_asset": "Quote",
+                "type": "Stablecoin",
+            }
+        ]
+    }
+    FakeWSClient.responses["mkt.start_quotes"] = {"quote_sub_id": 7, "fee_asset": "Quote"}
+    FakeWSClient.responses["__mkt_notification__:quote"] = {
+        "quote_sub_id": 7,
+        "asset_pair": {"base": USDT, "quote": L_BTC},
+        "asset_type": "Base",  # we're sending USDt = Base
+        "amount": 9_500_000,
+        "trade_dir": "Sell",
+        "status": {
+            "Success": {
+                "quote_id": 99,
+                "base_amount": 9_500_000,
+                "quote_amount": 100_000,
+                "server_fee": 100,
+                "fixed_fee": 100,
+                "ttl": 30_000,
+            }
+        },
+    }
+    FakeWSClient.responses["mkt.get_quote"] = {
+        "pset": "cHNldP8BUNSIGNED",
+        "ttl": 30_000,
+        "receive_ephemeral_sk": "00" * 32,
+        "change_ephemeral_sk": "00" * 32,
+    }
+    FakeWSClient.responses["mkt.taker_sign"] = {"txid": "ee" * 32}
+    FakeWSClient.responses["mkt.stop_quotes"] = {}
+
+
+def _start_quotes_call_args():
+    """Return the params dict from the most recent `mkt.start_quotes` call."""
+    for method, params in reversed(FakeWSClient.calls):
+        if method == "mkt.start_quotes":
+            return params
+    return None
+
+
+class TestSwapManagerExecute:
+    """Forward direction (L-BTC → USDt) via the mkt::* flow."""
+
+    def test_happy_path_end_to_end(self, swap_manager_setup):
+        mgr, _, _, fake_signer, storage = swap_manager_setup
+        _setup_mkt_responses_forward()
+
+        with _patch_swap_layers():
+            swap = mgr.execute_swap(
+                asset_id=USDT, send_amount=100_000, wallet_name="default"
+            )
+
+        assert swap.status == "broadcast"
+        assert swap.txid == "ee" * 32
+        # quote_id 42 → order_id "mkt_42" (so the storage layer keeps a
+        # filename-safe stable id even though the protocol identifies a swap
+        # by quote_id, not order_id)
+        assert swap.order_id == "mkt_42"
+        assert swap.submit_id == "42"
+        # We did sign exactly once
+        assert len(fake_signer.signed) == 1
+        # taker_sign call carried the signed PSET
+        taker_sign_calls = [(m, p) for m, p in FakeWSClient.calls if m == "mkt.taker_sign"]
+        assert len(taker_sign_calls) == 1
+        assert taker_sign_calls[0][1]["pset"] == "cHNldP8BSIGNED"
+        # Persisted across the whole flow
+        loaded = storage.load_sideswap_swap("mkt_42")
+        assert loaded is not None
+        assert loaded.status == "broadcast"
+
+    def test_start_quotes_uses_sell_and_correct_asset_type(self, swap_manager_setup):
+        # For L-BTC → USDt with a market where USDt is base and L-BTC is quote,
+        # we send the quote side. asset_type must be "Quote", trade_dir "Sell".
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        with _patch_swap_layers():
+            mgr.execute_swap(asset_id=USDT, send_amount=100_000, wallet_name="default")
+        params = _start_quotes_call_args()
+        assert params["asset_type"] == "Quote"
+        assert params["trade_dir"] == "Sell"
+        assert params["amount"] == 100_000
+        assert params["instant_swap"] is True
+        assert params["receive_address"] is not None
+        assert params["change_address"] is not None
+        assert params["receive_address"] != params["change_address"]
+        assert all(u["asset"] == L_BTC for u in params["utxos"])
+
+    def test_aborts_when_pset_balance_does_not_match(self, swap_manager_setup):
+        # The deadly attack: server crafts a PSET that takes our L-BTC but the
+        # recv_asset balance is 0.
+        mgr, _, fake_wollet, fake_signer, storage = swap_manager_setup
+        _setup_mkt_responses_forward()
+        fake_wollet._balances = {L_BTC: -100_000, USDT: 0}
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+        # Critically: never signed, never submitted via taker_sign
+        assert len(fake_signer.signed) == 0
+        assert not any(m == "mkt.taker_sign" for m, _ in FakeWSClient.calls)
+        # Persisted as failed for forensics
+        loaded = storage.load_sideswap_swap("mkt_42")
+        assert loaded is not None
+        assert loaded.status == "failed"
+        assert "PSET verification failed" in (loaded.last_error or "")
+
+    def test_aborts_when_pset_takes_extra_lbtc(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        fake_wollet._balances = {L_BTC: -200_000, USDT: 9_500_000}
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="more than the agreed"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+        assert len(fake_signer.signed) == 0
+
+    def test_aborts_when_pset_moves_unrelated_asset(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        fake_wollet._balances = {L_BTC: -100_050, USDT: 9_500_000, EVIL: -500}
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+        assert len(fake_signer.signed) == 0
+
+    def test_rejects_swap_lbtc_for_lbtc(self, swap_manager_setup):
+        mgr, _, _, _, _ = swap_manager_setup
+        with _patch_swap_layers():
+            with pytest.raises(ValueError, match="non-L-BTC"):
+                mgr.execute_swap(
+                    asset_id=L_BTC, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_rejects_unknown_wallet(self, swap_manager_setup):
+        mgr, _, _, _, _ = swap_manager_setup
+        with pytest.raises(ValueError, match="not found"):
+            mgr.execute_swap(
+                asset_id=USDT, send_amount=100_000, wallet_name="ghost"
+            )
+
+    def test_quote_lowbalance_raises(self, swap_manager_setup):
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        FakeWSClient.responses["mkt.list_markets"] = {
+            "markets": [{"asset_pair": {"base": USDT, "quote": L_BTC}, "fee_asset": "Quote", "type": "Stablecoin"}]
+        }
+        FakeWSClient.responses["mkt.start_quotes"] = {"quote_sub_id": 1, "fee_asset": "Quote"}
+        FakeWSClient.responses["__mkt_notification__:quote"] = {
+            "quote_sub_id": 1,
+            "asset_pair": {"base": USDT, "quote": L_BTC},
+            "asset_type": "Quote",
+            "amount": 100_000,
+            "trade_dir": "Sell",
+            "status": {
+                "LowBalance": {
+                    "base_amount": 0,
+                    "quote_amount": 0,
+                    "server_fee": 0,
+                    "fixed_fee": 0,
+                    "available": 1_000,
+                }
+            },
+        }
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="low balance"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_quote_error_raises(self, swap_manager_setup):
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        FakeWSClient.responses["mkt.list_markets"] = {
+            "markets": [{"asset_pair": {"base": USDT, "quote": L_BTC}, "fee_asset": "Quote", "type": "Stablecoin"}]
+        }
+        FakeWSClient.responses["mkt.start_quotes"] = {"quote_sub_id": 1, "fee_asset": "Quote"}
+        FakeWSClient.responses["__mkt_notification__:quote"] = {
+            "quote_sub_id": 1,
+            "asset_pair": {"base": USDT, "quote": L_BTC},
+            "asset_type": "Quote",
+            "amount": 100_000,
+            "trade_dir": "Sell",
+            "status": {"Error": {"error_msg": "no_dealers"}},
+        }
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="no_dealers"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_no_market_for_pair_raises(self, swap_manager_setup):
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        # Empty market list — no L-BTC/USDt pair available
+        FakeWSClient.responses["mkt.list_markets"] = {"markets": []}
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="No SideSwap market"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_quote_send_amount_mismatch_raises(self, swap_manager_setup):
+        # If the dealer's quote contradicts what we asked for, abort. This is
+        # an additional belt-and-braces check on top of the PSET verifier.
+        from aqua.sideswap import SideSwapWSError
+
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        # Pretend the dealer offered 200k of L-BTC instead of the 100k we asked
+        FakeWSClient.responses["__mkt_notification__:quote"]["status"]["Success"]["quote_amount"] = 200_000
+
+        with _patch_swap_layers():
+            with pytest.raises(SideSwapWSError, match="send_amount mismatch"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+
+    def test_swap_status_returns_persisted(self, swap_manager_setup):
+        mgr, _, _, _, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        with _patch_swap_layers():
+            mgr.execute_swap(
+                asset_id=USDT, send_amount=100_000, wallet_name="default"
+            )
+        result = mgr.status("mkt_42")
+        assert result["order_id"] == "mkt_42"
+        assert result["status"] == "broadcast"
+        assert result["txid"] == "ee" * 32
+        assert result["recv_asset"] == USDT
+        assert result["recv_amount"] == 9_500_000
+
+    def test_swap_status_unknown_raises(self, swap_manager_setup):
+        mgr, _, _, _, _ = swap_manager_setup
+        with pytest.raises(ValueError, match="not found"):
+            mgr.status("doesnotexist")
+
+
+class TestSwapManagerReverseExecute:
+    """Reverse direction: asset → L-BTC via the mkt::* flow.
+
+    The dealer absorbs the network fee from their L-BTC contribution, so the
+    wallet's effect is exact on both sides: -send_amount of asset and
+    +recv_amount of L-BTC. The verifier MUST NOT allow any siphon of the
+    asset side via fee_tolerance — `fee_asset` is pinned to L-BTC.
+    """
+
+    def test_reverse_happy_path_end_to_end(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, storage = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000}
+        _setup_mkt_responses_reverse()
+
+        with _patch_swap_layers():
+            swap = mgr.execute_swap(
+                asset_id=USDT,
+                send_amount=9_500_000,
+                wallet_name="default",
+                send_bitcoins=False,
+            )
+
+        assert swap.status == "broadcast"
+        assert swap.send_asset == USDT
+        assert swap.send_amount == 9_500_000
+        assert swap.recv_asset == L_BTC
+        assert swap.recv_amount == 100_000
+        # Manager asked SideSwap with asset_type=Base, trade_dir=Sell
+        params = _start_quotes_call_args()
+        assert params["asset_type"] == "Base"
+        assert params["trade_dir"] == "Sell"
+        assert all(u["asset"] == USDT for u in params["utxos"])
+        # Signed once, submitted once
+        assert len(fake_signer.signed) == 1
+        taker_sign_calls = [(m, p) for m, p in FakeWSClient.calls if m == "mkt.taker_sign"]
+        assert len(taker_sign_calls) == 1
+        loaded = storage.load_sideswap_swap("mkt_99")
+        assert loaded is not None
+        assert loaded.send_asset == USDT
+        assert loaded.recv_asset == L_BTC
+
+    def test_reverse_aborts_on_asset_siphon_within_lbtc_tolerance(self, swap_manager_setup):
+        # Server takes 500 sat extra USDT but delivers correct L-BTC. If
+        # fee_asset were accidentally USDT, the 1000-sat tolerance would let
+        # this slip through. We pin fee_asset=L-BTC so the asset side is exact.
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
+        fake_wollet._balances = {USDT: -9_500_500, L_BTC: 100_000}
+        _setup_mkt_responses_reverse()
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="more than the agreed"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=9_500_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )
+        assert len(fake_signer.signed) == 0
+        assert not any(m == "mkt.taker_sign" for m, _ in FakeWSClient.calls)
+
+    def test_reverse_aborts_on_short_lbtc_delivery(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 99_000}
+        _setup_mkt_responses_reverse()
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="delivers 99000"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=9_500_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )
+        assert len(fake_signer.signed) == 0
+
+    def test_reverse_aborts_on_unrelated_asset_movement(self, swap_manager_setup):
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 50_000_000)]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000, EVIL: -1}
+        _setup_mkt_responses_reverse()
+
+        with _patch_swap_layers():
+            with pytest.raises(PsetVerificationError, match="unexpectedly moves"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=9_500_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )
+        assert len(fake_signer.signed) == 0
+
+    def test_reverse_picks_asset_utxos_not_lbtc(self, swap_manager_setup):
+        mgr, _, fake_wollet, _, _ = swap_manager_setup
+        fake_wollet._utxos = [
+            _FakeUtxo("aa" * 32, 0, L_BTC, 5_000_000),
+            _FakeUtxo("bb" * 32, 0, USDT, 50_000_000),
+        ]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000}
+        _setup_mkt_responses_reverse()
+
+        with _patch_swap_layers():
+            mgr.execute_swap(
+                asset_id=USDT,
+                send_amount=9_500_000,
+                wallet_name="default",
+                send_bitcoins=False,
+            )
+        params = _start_quotes_call_args()
+        assert all(u["asset"] == USDT for u in params["utxos"])
+        assert len(params["utxos"]) == 1
+
+    def test_reverse_insufficient_asset_balance_raises(self, swap_manager_setup):
+        mgr, _, fake_wollet, _, _ = swap_manager_setup
+        fake_wollet._utxos = [_FakeUtxo("aa" * 32, 0, USDT, 1_000_000)]
+        fake_wollet._balances = {USDT: -9_500_000, L_BTC: 100_000}
+        _setup_mkt_responses_reverse()
+
+        with _patch_swap_layers():
+            with pytest.raises(ValueError, match="Insufficient confidential balance"):
+                mgr.execute_swap(
+                    asset_id=USDT,
+                    send_amount=9_500_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )
+
+    def test_reverse_rejects_lbtc_as_asset_id(self, swap_manager_setup):
+        mgr, _, _, _, _ = swap_manager_setup
+        with _patch_swap_layers():
+            with pytest.raises(ValueError, match="non-L-BTC"):
+                mgr.execute_swap(
+                    asset_id=L_BTC,
+                    send_amount=100_000,
+                    wallet_name="default",
+                    send_bitcoins=False,
+                )

--- a/tests/test_sideswap.py
+++ b/tests/test_sideswap.py
@@ -866,6 +866,42 @@ class TestParseQuoteStatus:
         with pytest.raises(SideSwapWSError, match="Unknown QuoteStatus"):
             parse_quote_status({"status": {"Surprise": {}}})
 
+    def test_success_missing_quote_id_raises_ws_error_not_keyerror(self):
+        # Without validation, the int() in execute_swap would KeyError —
+        # which surfaces as a generic exception far from the cause.
+        with pytest.raises(SideSwapWSError, match="missing 'quote_id'"):
+            parse_quote_status(
+                {
+                    "status": {
+                        "Success": {
+                            "base_amount": 1,
+                            "quote_amount": 2,
+                            "server_fee": 0,
+                            "fixed_fee": 0,
+                            "ttl": 30000,
+                        }
+                    }
+                }
+            )
+
+    def test_success_non_integer_amount_raises_ws_error(self):
+        with pytest.raises(SideSwapWSError, match="not an integer"):
+            parse_quote_status(
+                {
+                    "status": {
+                        "Success": {
+                            "quote_id": 1,
+                            "base_amount": "not-a-number",
+                            "quote_amount": 2,
+                        }
+                    }
+                }
+            )
+
+    def test_success_non_dict_payload_raises(self):
+        with pytest.raises(SideSwapWSError, match="Malformed Success"):
+            parse_quote_status({"status": {"Success": "stringified"}})
+
 
 # ---------------------------------------------------------------------------
 # PSET verifier — security-critical, tested with adversarial inputs

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -728,6 +728,8 @@ class TestToolRegistry:
             "sideswap_recommend",
             "sideswap_list_assets",
             "sideswap_quote",
+            "sideswap_execute_swap",
+            "sideswap_swap_status",
         }
         assert set(TOOLS.keys()) == expected
 


### PR DESCRIPTION
> **Stacked on top of #27** (the peg integration). Once #27 lands on `main`, GitHub will auto-rebase this PR's base.
>
> **Supersedes and replaces #28, #29, #30.** Those three PRs were incrementally building toward this end state — first the legacy `start_swap_web`+HTTP path, then bidirectional support, then a migration to `mkt::*`. The legacy path got entirely replaced by mkt::*, so reviewers would have been auditing scaffolding that never runs in production. This PR lands only the code that actually runs. **#28, #29, #30 will be closed in favour of this one.**

## Summary

- Adds atomic asset swap execution on Liquid via SideSwap's modern `mkt::*` WebSocket flow.
- Both directions in one go: L-BTC → asset (e.g. L-BTC → USDt) and asset → L-BTC.
- Local PSET verification before signing — refuses to sign if the wallet's net balance change does not match the agreed quote exactly.
- 2 new MCP tools (`sideswap_execute_swap`, `sideswap_swap_status`), 52 new tests; all 393 in suite passing.

## The verifier (security-critical)

`verify_pset_balances` is a pure function operating on the dict returned by `wollet.pset_details(pset).balance.balances()`. Three rules; any failure raises `PsetVerificationError` and signing is aborted before any tx hits the wire.

| Rule | Why it matters |
|---|---|
| Wallet must gain *exactly* `recv_amount` of `recv_asset` | Blocks the canonical attack: server's PSET takes our funds and pays us nothing |
| Wallet must lose at most `send_amount + fee_tolerance_sats` of `send_asset` (only if `send_asset == fee_asset`) | Blocks overcharge attacks; tolerance covers Liquid's tens-of-sats network fee |
| No other asset may have a non-zero balance change | Blocks extra-output / siphon attacks |

Manager always passes `fee_asset = policy_asset` (L-BTC), so the tolerance only ever relaxes the L-BTC side.

## Fee model (verified against AQUA Flutter + sideswap_lwk)

| Direction | Fee paid by | Wallet effect |
|---|---|---|
| L-BTC → asset | User's L-BTC change | L-BTC `-(send + fee)`, asset `+recv` |
| asset → L-BTC | Dealer's L-BTC change | asset `-send` exact, L-BTC `+recv` exact |

UTXO selection picks only `send_asset` inputs in both cases — no separate L-BTC fee inputs needed. Mirrors `swap_provider.dart` `executeTransaction()` in aquawallet/aqua-wallet.

## What's in this PR

- `verify_pset_balances` (pure) + `PsetVerificationError`
- `SideSwapWSClient.mkt`, `mkt_list_markets`, `mkt_start_quotes`, `mkt_stop_quotes`, `mkt_get_quote`, `mkt_taker_sign`, `next_market_notification`
- `resolve_market` — picks matching market + derives `(asset_type, trade_dir)` (always `Sell` with asset_type matching the side we're sending)
- `parse_quote_status` — raises on `LowBalance` / `Error` so callers never proceed with an invalid quote
- `select_swap_utxos` — confidential UTXOs of `send_asset` only, largest-first
- `SideSwapSwap` dataclass + storage helpers (`~/.aqua/sideswap_swaps/{order_id}.json`, mode `0o600`, atomic writes; saved at every step for crash recovery)
- `SideSwapSwapManager.execute_swap` — end-to-end orchestrator with `fee_asset` pinned to the policy asset
- New MCP tools: `sideswap_execute_swap` (with `send_bitcoins` parameter for direction) and `sideswap_swap_status`
- Updated `swap_assets` prompt to drive the full quote → confirm → execute → status flow

Wire format mirrors `sideswap_api/src/mkt.rs` exactly — see the module docstring for the request/notification shapes.

## Test plan

Verifier (19):
- [x] Exact-match passes for both directions
- [x] Canonical attacks rejected: server keeps recv, short delivery, excess delivery, overcharge, undercharge, unrelated asset movement
- [x] Fee tolerance does not let attacker steal beyond the network fee
- [x] Same send/recv asset rejected; argument validation
- [x] Reverse direction: 500-sat asset-side siphon rejected with `fee_asset=L_BTC`; default-`fee_asset=send_asset` documented as intentional caller responsibility

Helpers (10):
- [x] `resolve_market`: forward, reverse, swapped base/quote, no-matching-market, malformed entries skipped
- [x] `parse_quote_status`: Success returns inner; LowBalance and Error raise; missing/unknown variant raises

UTXO selector (5):
- [x] Largest-first, accumulation across multiple UTXOs, skips other assets, skips non-confidential, insufficient funds raises

Manager forward direction (12):
- [x] Happy path signs once, broadcasts, persists at every step
- [x] `start_quotes` carries the right `(asset_type, trade_dir)`, `instant_swap=true`, distinct receive + change addresses, only `send_asset` UTXOs
- [x] Three malicious-PSET classes never call `signer.sign()` and never POST `taker_sign`
- [x] Rejects `asset_id == policy_asset` and unknown wallet
- [x] LowBalance / Error quote responses → `SideSwapWSError`
- [x] Empty market list → `SideSwapWSError`
- [x] Dealer offers wrong send_amount vs requested → abort before signing
- [x] Status lookup returns persisted; unknown order raises

Manager reverse direction (7):
- [x] Happy path with `(asset_type=Base, trade_dir=Sell)`
- [x] 500-sat asset-side siphon rejected (the security tightening this PR enforces)
- [x] Short L-BTC delivery rejected
- [x] Unrelated asset movement rejected
- [x] Picks asset UTXOs even when wallet also holds L-BTC
- [x] Insufficient asset balance raises ValueError
- [x] Rejects `asset_id == policy_asset`

- [ ] **Manual testnet smoke test** — required before mainnet sign-off

## Manual testnet smoke test (REQUIRED)

This part can't run in CI — it needs a funded testnet wallet and is interactive.

1. Set up a testnet wallet with at least 100k sats of testnet L-BTC (faucet: https://liquidtestnet.com/faucet) and some testnet USDt
2. Run `agentic-aqua` configured for testnet
3. **Forward direction**: `sideswap_execute_swap(asset_id="<testnet USDt>", send_amount=10000, send_bitcoins=true, password="...")`
4. **Reverse direction**: `sideswap_execute_swap(asset_id="<testnet USDt>", send_amount=1000000, send_bitcoins=false, password="...")`
5. Confirm in both directions:
   - Order persists through `pending` → `verified` → `signed` → `broadcast`
   - Returned `txid` is on Liquid testnet (`https://blockstream.info/liquidtestnet/tx/{txid}`)
   - Wallet balances change by *exactly* the quoted amounts on the asset side
   - L-BTC side absorbs the network fee correctly per the fee model table above
6. Try a deliberately-stale quote (long delay) to confirm SideSwap's quote expiry is handled gracefully (clean error, not a crash)

## Reviewer notes

- The `receive_ephemeral_sk` / `change_ephemeral_sk` fields from `get_quote` are exposed but not currently used — `wollet.pset_details(pset)` is the audited path. If real-world testing shows SideSwap's PSETs don't unblind via `pset_details`, ephemeral-key verification will follow up.
- After this lands, the SideSwap surface (combined with #27) is feature-complete for an MCP server's needs: pegs + bidirectional asset swaps + recommendations + quote helpers.
- The `test_default_fee_asset_is_send_asset_documented_behavior` test documents the contract that callers omitting `fee_asset` would accept the asset siphon. Manager always passes `fee_asset=policy_asset` so this default never bites in production, but if anyone changes the default they'll see this test flip.

closes #13 