### PR TITLE
Add SideShift.ai cross-chain swap integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,7 +318,7 @@ SideShift.ai (`https://sideshift.ai/api/v2`) is a custodial multi-chain swap ser
 
 **API**: REST/JSON, anonymous (no auth), affiliate ID identifies us in request bodies.
 
-**Affiliate ID**: `PVmPh4Mp3` — same one AQUA Flutter wallet ships with (publicly committed in their `lib/config/constants/api_keys.dart`). Commission accrues to JAN3's SideShift account. Override with `SIDESHIFT_AFFILIATE_ID` env var. Pass an empty string to `SideShiftClient(affiliate_id="")` to disable affiliate identification (no commission).
+**Affiliate ID**: `PVmPh4Mp3` — same one AQUA Flutter wallet ships with (publicly committed in their `lib/config/constants/api_keys.dart`). Commission accrues to JAN3's SideShift account. Pass an empty string to `SideShiftClient(affiliate_id="")` to disable affiliate identification (no commission).
 
 **Curated pair allowlist**: `ALLOWED_PAIRS` in `src/aqua/sideshift.py` mirrors AQUA Flutter's `SideshiftAsset` factories — USDt across 7 chains (ethereum, tron, bsc, solana, polygon, ton, liquid) plus BTC mainchain. `send_shift` / `receive_shift` validate both legs against this set; off-allowlist pairs raise `ValueError`. Set `SIDESHIFT_ALLOW_ALL_NETWORKS=1` to bypass. Drift from AQUA's list is detected by `tests/test_sideshift.py::TestAllowedPairs::test_allowlist_matches_aqua_flutter` so any change forces a conscious update of both sides.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ Both legs of a `sideshift_send` / `sideshift_receive` call must be in this set. 
 > ⚠️ **SideShift trust model**: Custodial. SideShift takes the deposit on the source chain and sends to your destination from their hot wallet. Always supply a refund address on sends (the manager does this automatically using the wallet's own deposit-chain address). On receives, strongly encourage the user to provide an external refund address — without one, a stuck shift requires manual intervention via SideShift's web UI.
 
 > ⚠️ **Memo networks**: Some networks (TON, Stellar, BNB Beacon, etc.) require a memo on the deposit. SideShift returns `depositMemo` in the order response for those. Surface it to the user clearly when present.
+
+> ⚠️ **Non-L-BTC Liquid deposits**: when `deposit_network="liquid"` and `deposit_coin != "btc"` (e.g. USDt-Liquid → USDt-Tron), `liquid_asset_id` must be passed and must be the asset's hex id, **not** the L-BTC policy asset id. Without it the wallet would default to L-BTC and silently broadcast the wrong asset to SideShift's deposit address. `sideshift_send` rejects both cases before contacting SideShift.
 ### SideSwap (BTC ↔ L-BTC Pegs and Liquid Asset Swaps)
 
 | Tool | Description | Parameters |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,9 @@ AI Assistant ←→ MCP Server (Python) ←→ LWK (Liquid) ──→ Electrum/E
 
 No local server required. Liquid uses Electrum/Esplora; Bitcoin uses Esplora only. All via Blockstream's public infrastructure.
 
-## Tools (22 total)
+## Tools (29 total)
 
-Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`.
+Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`; SideShift cross-chain tools are `sideshift_*`.
 
 ### Wallet Management
 
@@ -74,6 +74,31 @@ Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified 
 | `lightning_send` | Pay a Lightning invoice using L-BTC via Boltz submarine swap. Fees: ~0.1% + miner fees. Limits: 100 – 25,000,000 sats | `invoice`: BOLT11 string (lnbc... or lntb...), `wallet_name`: optional, `password`: optional |
 | `lightning_transaction_status` | Check status of a Lightning swap (send or receive). For receive: auto-claims L-BTC when settled. For send: retrieves preimage when claimed. | `swap_id`: string |
 
+### SideShift (Custodial Cross-Chain Swaps)
+
+SideShift.ai is a custodial cross-chain swap service that complements SideSwap (which is Liquid-only or pegs through the Liquid Federation). Use SideShift for pairs where at least one leg is on a non-Liquid chain (Ethereum, Tron, Solana, USDt-on-other-chains, etc.). The trust model is "trust SideShift the company" — they take the deposit and send the converted asset from their hot wallet — so it's not as trustless as SideSwap. Use `sideshift_recommend` to decide.
+
+**Curated pair allowlist** (mirrors AQUA Flutter's `SideshiftAsset` factories in `lib/features/sideshift/models/sideshift_assets.dart`):
+
+- **USDt** on `ethereum`, `tron`, `bsc`, `solana`, `polygon`, `ton`, `liquid`
+- **BTC** on `bitcoin`
+
+Both legs of a `sideshift_send` / `sideshift_receive` call must be in this set. L-BTC (`btc-liquid`) is intentionally excluded — for L-BTC ↔ external use SideSwap, or chain through USDt-Liquid (e.g. L-BTC → USDt-Liquid via SideSwap, then USDt-Liquid → USDt-Tron via SideShift). Set `SIDESHIFT_ALLOW_ALL_NETWORKS=1` in the environment to bypass for testing or power use. `sideshift_pair_info`, `sideshift_quote`, `sideshift_list_coins`, and `sideshift_status` are not affected — they're discovery / read-only and may reference pairs outside the allowlist.
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `sideshift_list_coins` | List supported coins and networks | (none) |
+| `sideshift_pair_info` | Rate / min / max for a pair | `from_coin`, `from_network`, `to_coin`, `to_network`, `amount`: optional |
+| `sideshift_quote` | Fixed-rate quote (~15 min TTL); use BEFORE `sideshift_send` | `deposit_coin`, `deposit_network`, `settle_coin`, `settle_network`, exactly one of `deposit_amount`/`settle_amount` (decimal strings) |
+| `sideshift_send` | Send funds OUT via fixed-rate shift; deposit chain MUST be `bitcoin` or `liquid`; refund address is set to the wallet's own deposit-chain address automatically | `deposit_coin`, `deposit_network` (bitcoin/liquid), `settle_coin`, `settle_network`, `settle_address`, one of `deposit_amount`/`settle_amount`, `wallet_name`: optional, `password`: optional, `liquid_asset_id`: optional (required for non-L-BTC Liquid assets like USDt-Liquid), `settle_memo`/`refund_memo`: optional |
+| `sideshift_receive` | Receive funds IN via variable-rate shift; settle chain MUST be `bitcoin` or `liquid`; STRONGLY recommend passing `external_refund_address` | `deposit_coin`, `deposit_network`, `settle_coin`, `settle_network` (bitcoin/liquid), `wallet_name`: optional, `external_refund_address`: optional but recommended, `external_refund_memo`/`settle_memo`: optional |
+| `sideshift_status` | Check status of a shift order (returns `is_final`, `is_success`, `is_failed`) | `shift_id`: string |
+| `sideshift_recommend` | Helper: SideSwap when both legs are Bitcoin/Liquid (atomic), SideShift otherwise (custodial) | `from_coin`, `from_network`, `to_coin`, `to_network` |
+
+> ⚠️ **SideShift trust model**: Custodial. SideShift takes the deposit on the source chain and sends to your destination from their hot wallet. Always supply a refund address on sends (the manager does this automatically using the wallet's own deposit-chain address). On receives, strongly encourage the user to provide an external refund address — without one, a stuck shift requires manual intervention via SideShift's web UI.
+
+> ⚠️ **Memo networks**: Some networks (TON, Stellar, BNB Beacon, etc.) require a memo on the deposit. SideShift returns `depositMemo` in the order response for those. Surface it to the user clearly when present.
+
 ## Resources (3 total)
 
 MCP resources provide static documentation to AI assistants.
@@ -84,7 +109,7 @@ MCP resources provide static documentation to AI assistants.
 | `aqua://docs/networks` | Network Reference | Bitcoin and Liquid network details, address formats, explorers, common assets |
 | `aqua://docs/security` | Security Best Practices | Password usage, at-rest encryption, backup, watch-only wallets, recovery |
 
-## Prompts (14 total)
+## Prompts (16 total)
 
 MCP prompts provide pre-built conversation starters for common workflows.
 
@@ -104,6 +129,8 @@ MCP prompts provide pre-built conversation starters for common workflows.
 | `export_descriptor` | Export descriptor for watch-only wallet | `wallet_name`: optional |
 | `delete_wallet` | Safely delete a wallet with balance check and seed backup reminder | `wallet_name`: required |
 | `pay_lightning` | Pay a Lightning invoice using Liquid Bitcoin | `wallet_name`: optional |
+| `cross_chain_send` | Send Liquid/BTC funds out to another chain via SideShift (e.g. USDt-Liquid → USDt-Tron, L-BTC → ETH). Walks through quote, confirmation, and broadcast. | `wallet_name`: optional |
+| `cross_chain_receive` | Receive funds into Liquid/BTC from another chain via SideShift (e.g. USDt-Tron → USDt-Liquid). Returns a deposit address for the external sender. | `wallet_name`: optional |
 
 ## Data Storage
 
@@ -120,6 +147,8 @@ Wallet data stored in `~/.aqua/`:
 │   └── {swap_id}.json   # Contains swap details + preimage when settled
 ├── lightning_swaps/     # Unified Lightning swap data (send & receive)
 │   └── {swap_id}.json   # Contains swap details + status + optional preimage
+├── sideshift_shifts/    # SideShift cross-chain shift orders
+│   └── {shift_id}.json  # Contains direction, type, addresses, status, txids
 └── cache/
     └── <wallet_name>/
         └── btc/
@@ -283,6 +312,39 @@ Ankara backend (`test.aquabtc.com`) provides Lightning → L-BTC swaps (receive 
 
 **Amount Limits**: 100 – 25,000,000 sats (no authentication required)
 
+## SideShift Integration
+
+SideShift.ai (`https://sideshift.ai/api/v2`) is a custodial multi-chain swap service. Used for cross-chain conversions where SideSwap can't help (e.g. anything involving Ethereum, Tron, Solana, USDt-on-other-chains, etc.).
+
+**API**: REST/JSON, anonymous (no auth), affiliate ID identifies us in request bodies.
+
+**Affiliate ID**: `PVmPh4Mp3` — same one AQUA Flutter wallet ships with (publicly committed in their `lib/config/constants/api_keys.dart`). Commission accrues to JAN3's SideShift account. Override with `SIDESHIFT_AFFILIATE_ID` env var. Pass an empty string to `SideShiftClient(affiliate_id="")` to disable affiliate identification (no commission).
+
+**Curated pair allowlist**: `ALLOWED_PAIRS` in `src/aqua/sideshift.py` mirrors AQUA Flutter's `SideshiftAsset` factories — USDt across 7 chains (ethereum, tron, bsc, solana, polygon, ton, liquid) plus BTC mainchain. `send_shift` / `receive_shift` validate both legs against this set; off-allowlist pairs raise `ValueError`. Set `SIDESHIFT_ALLOW_ALL_NETWORKS=1` to bypass. Drift from AQUA's list is detected by `tests/test_sideshift.py::TestAllowedPairs::test_allowlist_matches_aqua_flutter` so any change forces a conscious update of both sides.
+
+**Endpoints used**:
+- `GET /v2/coins` — supported coins + networks
+- `GET /v2/permissions` — geo / availability check
+- `GET /v2/pair/{from}/{to}` — rate, min, max for a pair (path uses `coin-network` IDs lowercase, e.g. `usdt-tron`)
+- `POST /v2/quotes` — fixed quote (~15 min TTL)
+- `POST /v2/shifts/fixed` — create fixed shift from a quote
+- `POST /v2/shifts/variable` — create variable shift (no quote required; rate set when deposit confirms)
+- `GET /v2/shifts/{id}` — shift status
+
+**Wire-format quirks**:
+- Coin tickers are uppercase on the wire (`USDT`, `BTC`); networks are lowercase (`tron`, `liquid`, `bitcoin`).
+- L-BTC is identified as `coin: "BTC", network: "liquid"` (NOT `lbtc-liquid`).
+- USDt-Liquid is identified as `coin: "USDT", network: "liquid"`.
+- All amounts are decimal strings (e.g. `"0.0005"`, `"100"`) to preserve precision. The manager converts to integer sats internally before calling our wallet send methods.
+
+**Status state machine** (lowercase): `waiting` → `pending` → `processing` → `settling` → `settled` (success). Failure paths: `refund` → `refunding` → `refunded`, or `expired`. Helpers: `shift_is_final`, `shift_is_success`, `shift_is_failed`.
+
+**Trust model**: Custodial. SideShift takes the deposit and sends the converted asset from their hot wallet. This is NOT atomic — different from SideSwap (atomic on Liquid) or Lightning (Boltz, atomic). Always supply a refund address; the manager does this automatically on send (refunds back to the wallet's own deposit-chain address).
+
+**Memo networks**: TON, Stellar, BNB Beacon, etc. require a memo on either the deposit or settle side. SideShift returns `depositMemo` in the order response when the deposit chain needs one; surface it to the user prominently. For sends with `settle_memo`, the user must provide the memo upfront.
+
+**Deposit chain limitation**: We can only sign on Bitcoin and Liquid, so `sideshift_send` requires `deposit_network ∈ {bitcoin, liquid}`. For receives, only `settle_network ∈ {bitcoin, liquid}` (we hold addresses there). For everything else, the user provides an external address.
+
 ## Bitcoin Implementation Details
 
 ### BDK Constants
@@ -394,14 +456,23 @@ agentic-aqua/
 │   └── aqua/
 │       ├── __init__.py
 │       ├── server.py   # MCP server entry point (tools, resources, prompts)
-│       ├── tools.py    # Tool implementations (lw_*, btc_*, unified_*, lightning_*)
+│       ├── tools.py    # Tool implementations (lw_*, btc_*, unified_*, lightning_*, sideshift_*)
 │       ├── wallet.py   # Liquid wallet (LWK)
 │       ├── bitcoin.py  # Bitcoin wallet (BDK)
 │       ├── lightning.py # Lightning abstraction layer (unified send/receive manager)
 │       ├── boltz.py    # Boltz Exchange integration (submarine swaps, send)
 │       ├── ankara.py   # Ankara backend integration (Lightning receive)
+│       ├── sideshift.py # SideShift.ai integration (custodial cross-chain swaps)
 │       ├── assets.py   # Asset registry
-│       └── storage.py  # Persistence layer (encryption, config, wallet data)
+│       ├── storage.py  # Persistence layer (encryption, config, wallet data)
+│       └── cli/
+│           ├── main.py       # Root `aqua` Click group
+│           ├── commands.py   # Subcommand registration
+│           ├── liquid.py / btc.py / lightning.py
+│           ├── sideshift.py  # `aqua sideshift …` (cross-chain swap commands)
+│           ├── wallet.py / serve.py
+│           ├── output.py     # JSON / pretty rendering
+│           └── password.py   # Secret resolution helpers
 └── tests/
     ├── test_tools.py
     ├── test_lightning.py
@@ -409,6 +480,7 @@ agentic-aqua/
     ├── test_bitcoin.py
     ├── test_boltz.py
     ├── test_ankara.py
+    ├── test_sideshift.py
     └── test_server.py
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,13 +314,13 @@ Ankara backend (`test.aquabtc.com`) provides Lightning → L-BTC swaps (receive 
 
 ## SideShift Integration
 
-SideShift.ai (`https://sideshift.ai/api/v2`) is a custodial multi-chain swap service. Used for cross-chain conversions where SideSwap can't help (e.g. anything involving Ethereum, Tron, Solana, USDt-on-other-chains, etc.).
+Technical detail for `src/aqua/sideshift.py`. Tool semantics, trust model, refund-address guidance, and memo-network warnings live in the **SideShift (Custodial Cross-Chain Swaps)** section under Tools.
 
-**API**: REST/JSON, anonymous (no auth), affiliate ID identifies us in request bodies.
+**API**: `https://sideshift.ai/api/v2`, REST/JSON, anonymous (no auth), affiliate ID identifies us in request bodies.
 
 **Affiliate ID**: `PVmPh4Mp3` — same one AQUA Flutter wallet ships with (publicly committed in their `lib/config/constants/api_keys.dart`). Commission accrues to JAN3's SideShift account. Pass an empty string to `SideShiftClient(affiliate_id="")` to disable affiliate identification (no commission).
 
-**Curated pair allowlist**: `ALLOWED_PAIRS` in `src/aqua/sideshift.py` mirrors AQUA Flutter's `SideshiftAsset` factories — USDt across 7 chains (ethereum, tron, bsc, solana, polygon, ton, liquid) plus BTC mainchain. `send_shift` / `receive_shift` validate both legs against this set; off-allowlist pairs raise `ValueError`. Set `SIDESHIFT_ALLOW_ALL_NETWORKS=1` to bypass. Drift from AQUA's list is detected by `tests/test_sideshift.py::TestAllowedPairs::test_allowlist_matches_aqua_flutter` so any change forces a conscious update of both sides.
+**Curated pair allowlist enforcement**: `ALLOWED_PAIRS` in `src/aqua/sideshift.py` is the source of truth. `send_shift` / `receive_shift` validate both legs and raise `ValueError` for off-allowlist pairs. Set `SIDESHIFT_ALLOW_ALL_NETWORKS=1` to bypass. Drift from AQUA Flutter's `SideshiftAsset` factories is detected by `tests/test_sideshift.py::TestAllowedPairs::test_allowlist_matches_aqua_flutter` so any change forces a conscious update on both sides.
 
 **Endpoints used**:
 - `GET /v2/coins` — supported coins + networks
@@ -336,12 +336,9 @@ SideShift.ai (`https://sideshift.ai/api/v2`) is a custodial multi-chain swap ser
 - L-BTC is identified as `coin: "BTC", network: "liquid"` (NOT `lbtc-liquid`).
 - USDt-Liquid is identified as `coin: "USDT", network: "liquid"`.
 - All amounts are decimal strings (e.g. `"0.0005"`, `"100"`) to preserve precision. The manager converts to integer sats internally before calling our wallet send methods.
+- Memo-network deposits surface as `depositMemo` in the order response. For sends targeting a memo-network settle chain, `settle_memo` must be supplied upfront.
 
 **Status state machine** (lowercase): `waiting` → `pending` → `processing` → `settling` → `settled` (success). Failure paths: `refund` → `refunding` → `refunded`, or `expired`. Helpers: `shift_is_final`, `shift_is_success`, `shift_is_failed`.
-
-**Trust model**: Custodial. SideShift takes the deposit and sends the converted asset from their hot wallet. This is NOT atomic — different from SideSwap (atomic on Liquid) or Lightning (Boltz, atomic). Always supply a refund address; the manager does this automatically on send (refunds back to the wallet's own deposit-chain address).
-
-**Memo networks**: TON, Stellar, BNB Beacon, etc. require a memo on either the deposit or settle side. SideShift returns `depositMemo` in the order response when the deposit chain needs one; surface it to the user prominently. For sends with `settle_memo`, the user must provide the memo upfront.
 
 **Deposit chain limitation**: We can only sign on Bitcoin and Liquid, so `sideshift_send` requires `deposit_network ∈ {bitcoin, liquid}`. For receives, only `settle_network ∈ {bitcoin, liquid}` (we hold addresses there). For everything else, the user provides an external address.
 

--- a/src/aqua/assets.py
+++ b/src/aqua/assets.py
@@ -15,19 +15,25 @@ class AssetInfo:
     precision: int  # Number of decimal places (e.g. 8 means divide by 10^8)
 
 
+# Well-known asset IDs. Liquid policy assets are global constants — these will
+# never change, so importing the canonical id is preferable to redefining it.
+LBTC_ASSET_ID = "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d"
+USDT_LIQUID_ASSET_ID = "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2"
+
+
 # Mainnet known assets
 MAINNET_ASSETS: dict[str, AssetInfo] = {
     info.asset_id: info
     for info in [
         AssetInfo(
-            asset_id="6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d",
+            asset_id=LBTC_ASSET_ID,
             name="Liquid Bitcoin",
             ticker="L-BTC",
             logo="https://aqua-asset-logos.s3.us-west-2.amazonaws.com/L-BTC.svg",
             precision=8,
         ),
         AssetInfo(
-            asset_id="ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2",
+            asset_id=USDT_LIQUID_ASSET_ID,
             name="Tether USDt",
             ticker="USDt",
             logo="https://aqua-asset-logos.s3.us-west-2.amazonaws.com/USDt.svg",

--- a/src/aqua/cli/commands.py
+++ b/src/aqua/cli/commands.py
@@ -12,12 +12,14 @@ def register_commands(cli):
     from .lightning import lightning
     from .liquid import liquid
     from .serve import serve
+    from .sideshift import sideshift
     from .wallet import wallet
 
     cli.add_command(wallet)
     cli.add_command(liquid)
     cli.add_command(btc)
     cli.add_command(lightning)
+    cli.add_command(sideshift)
     cli.add_command(serve)
     cli.add_command(balance)
 

--- a/src/aqua/cli/sideshift.py
+++ b/src/aqua/cli/sideshift.py
@@ -167,6 +167,7 @@ def send(ctx, deposit_coin, deposit_network, settle_coin, settle_network,
     if (deposit_amount is None) == (settle_amount is None):
         raise click.UsageError("Provide exactly one of --deposit-amount or --settle-amount.")
 
+    quote_id: str | None = None
     if not skip_confirm:
         click.echo("Fetching quote from SideShift…", err=True)
         try:
@@ -184,6 +185,9 @@ def send(ctx, deposit_coin, deposit_network, settle_coin, settle_network,
             err=True,
         )
         click.confirm("Proceed with this swap?", abort=True, err=True)
+        # Reuse the confirmed quote so the shift executes at the rate the
+        # user just saw, not whatever a fresh quote returns moments later.
+        quote_id = preview.get("id")
 
     password = resolve_secret(
         "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
@@ -205,6 +209,7 @@ def send(ctx, deposit_coin, deposit_network, settle_coin, settle_network,
                 "liquid_asset_id": liquid_asset_id,
                 "settle_memo": settle_memo,
                 "refund_memo": refund_memo,
+                "quote_id": quote_id,
             },
         ),
     )

--- a/src/aqua/cli/sideshift.py
+++ b/src/aqua/cli/sideshift.py
@@ -1,0 +1,270 @@
+"""SideShift CLI commands — custodial cross-chain swaps via sideshift.ai."""
+
+from __future__ import annotations
+
+import click
+
+from ..tools import (
+    sideshift_list_coins,
+    sideshift_pair_info,
+    sideshift_quote,
+    sideshift_receive,
+    sideshift_recommend,
+    sideshift_send,
+    sideshift_status,
+)
+from .output import run_tool
+from .password import handle_password_retry, resolve_secret
+
+
+_NATIVE_NETWORK = click.Choice(["bitcoin", "liquid"])
+_PASSWORD_HELP = (
+    "Read wallet password from stdin (piped) or prompt interactively. "
+    "Without this flag, falls back to the AQUA_PASSWORD environment variable, "
+    "then to no password."
+)
+
+
+@click.group()
+def sideshift():
+    """SideShift — custodial cross-chain swaps (USDt across networks, BTC ↔ USDt-on-X, etc.).
+
+    SideShift is a custodial service: they take the deposit and send the
+    converted asset from their hot wallet. The trust model is "trust SideShift
+    the company" rather than "trust an on-chain protocol." For pairs where
+    both legs are on Bitcoin or Liquid, prefer `aqua sideswap` (atomic on
+    Liquid, or Liquid Federation peg).
+
+    Curated pair allowlist (mirrors AQUA Flutter):
+      USDt on ethereum / tron / bsc / solana / polygon / ton / liquid
+      BTC on bitcoin
+
+    Off-allowlist pairs raise an error from `send` and `receive`. Set
+    SIDESHIFT_ALLOW_ALL_NETWORKS=1 in the environment to bypass.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Discovery / quote
+# ---------------------------------------------------------------------------
+
+
+@sideshift.command("coins")
+@click.pass_obj
+def coins(ctx):
+    """List the coins and networks SideShift supports."""
+    run_tool(ctx, lambda: sideshift_list_coins())
+
+
+@sideshift.command("pair-info")
+@click.option("--from-coin", required=True, help="Deposit coin ticker (e.g. USDT).")
+@click.option("--from-network", required=True, help="Deposit network (e.g. liquid, tron).")
+@click.option("--to-coin", required=True, help="Settle coin ticker.")
+@click.option("--to-network", required=True, help="Settle network.")
+@click.option("--amount", default=None, help="Optional reference amount in deposit-coin units (decimal string).")
+@click.pass_obj
+def pair_info(ctx, from_coin, from_network, to_coin, to_network, amount):
+    """Show rate / min / max for a SideShift pair."""
+    run_tool(
+        ctx,
+        lambda: sideshift_pair_info(from_coin, from_network, to_coin, to_network, amount),
+    )
+
+
+@sideshift.command("quote")
+@click.option("--deposit-coin", required=True)
+@click.option("--deposit-network", required=True)
+@click.option("--settle-coin", required=True)
+@click.option("--settle-network", required=True)
+@click.option(
+    "--deposit-amount", default=None,
+    help="Amount the user is sending (decimal string). One of deposit/settle required.",
+)
+@click.option(
+    "--settle-amount", default=None,
+    help="Amount the user wants to receive (decimal string). One of deposit/settle required.",
+)
+@click.pass_obj
+def quote(ctx, deposit_coin, deposit_network, settle_coin, settle_network,
+          deposit_amount, settle_amount):
+    """Request a fixed-rate SideShift quote (~15 min TTL)."""
+    if (deposit_amount is None) == (settle_amount is None):
+        raise click.UsageError("Provide exactly one of --deposit-amount or --settle-amount.")
+    run_tool(
+        ctx,
+        lambda: sideshift_quote(
+            deposit_coin, deposit_network, settle_coin, settle_network,
+            deposit_amount=deposit_amount, settle_amount=settle_amount,
+        ),
+    )
+
+
+@sideshift.command("recommend")
+@click.option("--from-coin", required=True)
+@click.option("--from-network", required=True)
+@click.option("--to-coin", required=True)
+@click.option("--to-network", required=True)
+@click.pass_obj
+def recommend(ctx, from_coin, from_network, to_coin, to_network):
+    """Recommend SideSwap vs SideShift for a given pair."""
+    run_tool(
+        ctx,
+        lambda: sideshift_recommend(from_coin, from_network, to_coin, to_network),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Send (we sign on Liquid/BTC, user provides external settle address)
+# ---------------------------------------------------------------------------
+
+
+@sideshift.command("send")
+@click.option(
+    "--deposit-coin", required=True,
+    help="L-BTC: 'btc' (network='liquid'); BTC mainchain: 'btc'; USDt-Liquid: 'usdt'.",
+)
+@click.option(
+    "--deposit-network", required=True, type=_NATIVE_NETWORK,
+    help="Chain we sign on — must be 'bitcoin' or 'liquid'.",
+)
+@click.option("--settle-coin", required=True, help="Settle coin ticker (any SideShift-supported coin).")
+@click.option("--settle-network", required=True, help="Settle network (any SideShift-supported network).")
+@click.option("--settle-address", required=True, help="Where SideShift sends the converted asset.")
+@click.option(
+    "--deposit-amount", default=None,
+    help="User sends this much (decimal string). One of deposit/settle required.",
+)
+@click.option(
+    "--settle-amount", default=None,
+    help="User wants to receive exactly this much (decimal string). One of deposit/settle required.",
+)
+@click.option("--wallet-name", default="default", show_default=True)
+@click.option(
+    "--liquid-asset-id", default=None,
+    help="Hex asset id; required when deposit-coin is a non-L-BTC Liquid asset.",
+)
+@click.option("--settle-memo", default=None, help="Required for memo networks (TON, BNB, etc.).")
+@click.option("--refund-memo", default=None)
+@click.option(
+    "--yes", "-y", "skip_confirm", is_flag=True, default=False,
+    help="Skip the interactive quote-confirmation prompt.",
+)
+@click.option(
+    "--password-stdin", "password_stdin", is_flag=True, default=False,
+    help=_PASSWORD_HELP,
+)
+@click.pass_obj
+def send(ctx, deposit_coin, deposit_network, settle_coin, settle_network,
+         settle_address, deposit_amount, settle_amount, wallet_name,
+         liquid_asset_id, settle_memo, refund_memo, skip_confirm, password_stdin):
+    """Send funds via a SideShift fixed-rate shift.
+
+    Gets a quote, creates the shift, and broadcasts the deposit from the
+    local wallet. A refund address is set automatically (the wallet's own
+    deposit-chain address). For non-L-BTC Liquid assets like USDt-Liquid,
+    pass `--liquid-asset-id <hex>`.
+    """
+    if (deposit_amount is None) == (settle_amount is None):
+        raise click.UsageError("Provide exactly one of --deposit-amount or --settle-amount.")
+
+    if not skip_confirm:
+        click.echo("Fetching quote from SideShift…", err=True)
+        try:
+            preview = sideshift_quote(
+                deposit_coin, deposit_network, settle_coin, settle_network,
+                deposit_amount=deposit_amount, settle_amount=settle_amount,
+            )
+        except Exception as e:
+            raise click.UsageError(f"Could not fetch quote: {e}") from e
+        click.echo(
+            f"Send: {preview.get('depositAmount')} {deposit_coin.upper()} on {deposit_network}\n"
+            f"Recv: {preview.get('settleAmount')} {settle_coin.upper()} at {settle_address} on {settle_network}\n"
+            f"Rate: {preview.get('rate')}\n"
+            f"Quote expires: {preview.get('expiresAt')}",
+            err=True,
+        )
+        click.confirm("Proceed with this swap?", abort=True, err=True)
+
+    password = resolve_secret(
+        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
+    )
+    run_tool(
+        ctx,
+        lambda: handle_password_retry(
+            sideshift_send,
+            {
+                "deposit_coin": deposit_coin,
+                "deposit_network": deposit_network,
+                "settle_coin": settle_coin,
+                "settle_network": settle_network,
+                "settle_address": settle_address,
+                "deposit_amount": deposit_amount,
+                "settle_amount": settle_amount,
+                "wallet_name": wallet_name,
+                "password": password,
+                "liquid_asset_id": liquid_asset_id,
+                "settle_memo": settle_memo,
+                "refund_memo": refund_memo,
+            },
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Receive (we provide Liquid/BTC settle address, user sends from external)
+# ---------------------------------------------------------------------------
+
+
+@sideshift.command("receive")
+@click.option("--deposit-coin", required=True, help="Source coin ticker (any SideShift-supported coin).")
+@click.option("--deposit-network", required=True, help="Source network (any SideShift-supported network).")
+@click.option(
+    "--settle-coin", required=True,
+    help="L-BTC: 'btc' (settle-network='liquid'); BTC: 'btc'; USDt-Liquid: 'usdt'.",
+)
+@click.option(
+    "--settle-network", required=True, type=_NATIVE_NETWORK,
+    help="Settle chain — must be 'bitcoin' or 'liquid'.",
+)
+@click.option("--wallet-name", default="default", show_default=True)
+@click.option(
+    "--external-refund-address", default=None,
+    help="Deposit-chain refund address (STRONGLY RECOMMENDED).",
+)
+@click.option("--external-refund-memo", default=None)
+@click.option("--settle-memo", default=None)
+@click.pass_obj
+def receive(ctx, deposit_coin, deposit_network, settle_coin, settle_network,
+            wallet_name, external_refund_address, external_refund_memo, settle_memo):
+    """Create a variable-rate SideShift to receive into the local wallet.
+
+    Returns a deposit address on the source chain. The user (or external
+    sender) sends to it from any wallet. Without an `--external-refund-address`,
+    a stuck shift requires manual intervention via SideShift's web UI.
+    """
+    run_tool(
+        ctx,
+        lambda: sideshift_receive(
+            deposit_coin=deposit_coin,
+            deposit_network=deposit_network,
+            settle_coin=settle_coin,
+            settle_network=settle_network,
+            wallet_name=wallet_name,
+            external_refund_address=external_refund_address,
+            external_refund_memo=external_refund_memo,
+            settle_memo=settle_memo,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+
+@sideshift.command("status")
+@click.option("--shift-id", required=True, help="ID returned from `aqua sideshift send` or `… receive`.")
+@click.pass_obj
+def status(ctx, shift_id):
+    """Check the status of a SideShift shift order."""
+    run_tool(ctx, lambda: sideshift_status(shift_id))

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -453,6 +453,155 @@ TOOL_SCHEMAS = {
             "required": ["swap_id"],
         },
     },
+    "sideshift_list_coins": {
+        "description": (
+            "List the coins and networks SideShift supports for cross-chain swaps. "
+            "Use to discover valid (coin, network) IDs for the other sideshift_* tools."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    "sideshift_pair_info": {
+        "description": (
+            "Get rate, min, and max for a SideShift pair (e.g. USDt-Liquid → USDt-Tron). "
+            "Returns decimal-string rate / min / max in deposit-coin units."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "from_coin": {"type": "string", "description": "Deposit coin ticker (e.g. 'USDT')"},
+                "from_network": {"type": "string", "description": "Deposit network (e.g. 'liquid', 'tron', 'ethereum')"},
+                "to_coin": {"type": "string", "description": "Settle coin ticker"},
+                "to_network": {"type": "string", "description": "Settle network"},
+                "amount": {
+                    "type": "string",
+                    "description": "Optional reference amount in deposit-coin units (decimal string)",
+                },
+            },
+            "required": ["from_coin", "from_network", "to_coin", "to_network"],
+        },
+    },
+    "sideshift_quote": {
+        "description": (
+            "Request a fixed-rate SideShift quote (~15 min TTL). Provide exactly one "
+            "of deposit_amount or settle_amount as a decimal string. Use BEFORE "
+            "sideshift_send to confirm the quote with the user."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "deposit_coin": {"type": "string"},
+                "deposit_network": {"type": "string"},
+                "settle_coin": {"type": "string"},
+                "settle_network": {"type": "string"},
+                "deposit_amount": {"type": "string", "description": "User sends this much (decimal string)"},
+                "settle_amount": {"type": "string", "description": "User receives this much (decimal string)"},
+            },
+            "required": ["deposit_coin", "deposit_network", "settle_coin", "settle_network"],
+        },
+    },
+    "sideshift_send": {
+        "description": (
+            "Send funds out via SideShift. Gets a fixed-rate quote, creates the shift, "
+            "and broadcasts the deposit from the local wallet. Deposit chain MUST be "
+            "'bitcoin' or 'liquid'. Both legs must be in the curated allowlist (USDt on "
+            "ethereum/tron/bsc/solana/polygon/ton/liquid, or BTC on bitcoin) — mirrors "
+            "AQUA Flutter's supported pairs. Set SIDESHIFT_ALLOW_ALL_NETWORKS=1 to bypass. "
+            "A refund address is set automatically (the wallet's own deposit-chain "
+            "address). For non-L-BTC Liquid assets (e.g. USDt-Liquid), pass liquid_asset_id. "
+            "ALWAYS call sideshift_quote first and confirm the price with the user."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "deposit_coin": {"type": "string", "description": "L-BTC: 'btc' (network='liquid'); BTC: 'btc'; USDt-Liquid: 'usdt'"},
+                "deposit_network": {
+                    "type": "string",
+                    "enum": ["bitcoin", "liquid"],
+                    "description": "Chain we sign on",
+                },
+                "settle_coin": {"type": "string"},
+                "settle_network": {"type": "string"},
+                "settle_address": {"type": "string", "description": "Where SideShift sends the converted asset"},
+                "deposit_amount": {"type": "string"},
+                "settle_amount": {"type": "string"},
+                "wallet_name": {"type": "string", "default": "default"},
+                "password": {"type": "string", "description": "Password to decrypt mnemonic (if encrypted)"},
+                "liquid_asset_id": {
+                    "type": "string",
+                    "description": "Hex asset id; required when sending a non-L-BTC Liquid asset",
+                },
+                "settle_memo": {"type": "string", "description": "Required for memo networks (TON, BNB, etc.)"},
+                "refund_memo": {"type": "string"},
+            },
+            "required": [
+                "deposit_coin", "deposit_network", "settle_coin",
+                "settle_network", "settle_address",
+            ],
+        },
+    },
+    "sideshift_receive": {
+        "description": (
+            "Receive into the local wallet via a SideShift variable-rate shift. "
+            "Returns a deposit address on the deposit chain — the user (or external "
+            "sender) sends to it from any wallet. Settle chain MUST be 'bitcoin' or "
+            "'liquid'. Both legs must be in the curated allowlist (USDt on "
+            "ethereum/tron/bsc/solana/polygon/ton/liquid, or BTC on bitcoin) — mirrors "
+            "AQUA Flutter's supported pairs. Set SIDESHIFT_ALLOW_ALL_NETWORKS=1 to bypass. "
+            "STRONGLY RECOMMEND passing external_refund_address (the deposit-side "
+            "sender's address) so a stuck shift can refund automatically."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "deposit_coin": {"type": "string"},
+                "deposit_network": {"type": "string"},
+                "settle_coin": {"type": "string", "description": "'btc' or 'usdt' typically"},
+                "settle_network": {
+                    "type": "string",
+                    "enum": ["bitcoin", "liquid"],
+                },
+                "wallet_name": {"type": "string", "default": "default"},
+                "external_refund_address": {
+                    "type": "string",
+                    "description": "Deposit-chain refund address (strongly recommended)",
+                },
+                "external_refund_memo": {"type": "string"},
+                "settle_memo": {"type": "string"},
+            },
+            "required": ["deposit_coin", "deposit_network", "settle_coin", "settle_network"],
+        },
+    },
+    "sideshift_status": {
+        "description": (
+            "Check the status of a SideShift shift order. Returns the shift record "
+            "plus is_final / is_success / is_failed booleans."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "shift_id": {"type": "string", "description": "ID from sideshift_send or sideshift_receive"},
+            },
+            "required": ["shift_id"],
+        },
+    },
+    "sideshift_recommend": {
+        "description": (
+            "Recommend SideSwap vs SideShift for a cross-asset conversion. "
+            "SideSwap when both legs are on Bitcoin/Liquid (atomic, lower fees); "
+            "SideShift when at least one leg is on a non-Liquid chain (custodial, "
+            "covers 30+ chains)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "from_coin": {"type": "string"},
+                "from_network": {"type": "string"},
+                "to_coin": {"type": "string"},
+                "to_network": {"type": "string"},
+            },
+            "required": ["from_coin", "from_network", "to_coin", "to_network"],
+        },
+    },
 }
 
 
@@ -519,6 +668,23 @@ LIGHTNING:
 - Use lightning_send to pay a BOLT11 invoice using L-BTC (submarine swap via Boltz)
   Fees: ~0.1% + miner fees, Limits: 100 - 25,000,000 Sats
 - Use lightning_transaction_status to check status of any Lightning swap (send or receive)
+
+SIDESHIFT (custodial cross-chain swaps):
+- Use sideshift_send when the user wants to send funds OUT of Liquid/Bitcoin to
+  another chain (e.g. USDt-Liquid → USDt-Tron, L-BTC → ETH, BTC → SOL).
+- Use sideshift_receive when the user wants to receive funds INTO Liquid/Bitcoin
+  from another chain (e.g. USDt-Tron → USDt-Liquid, ETH → L-BTC).
+- ALWAYS call sideshift_quote first for sends so the user can confirm the
+  rate before signing. Quotes expire in ~15 minutes.
+- ALWAYS encourage providing external_refund_address on receives — without it,
+  a stuck shift requires manual intervention via the SideShift web UI.
+- Use sideshift_status to poll a shift; the response includes is_final /
+  is_success / is_failed booleans so you don't have to memorise the state machine.
+- TRUST MODEL: SideShift is custodial. They take the deposit and send from
+  their hot wallet. This is different from SideSwap (atomic on Liquid) and
+  Lightning (Boltz submarine, atomic). Communicate this trade-off to the user.
+- Memo networks (TON, BNB Beacon, Stellar, etc.) require a memo on either
+  the deposit or settle side — pass settle_memo / refund_memo when prompted.
 
 WATCH-ONLY WALLETS:
 - For a Bitcoin-only watch wallet: btc_import_descriptor (BIP84 wpkh xpub).
@@ -647,6 +813,27 @@ WALLET DELETION:
             Prompt(
                 name="pay_lightning",
                 description="Pay a Lightning invoice using Liquid Bitcoin (via Boltz submarine swap)",
+                arguments=[
+                    PromptArgument(name="wallet_name", description="Wallet name", required=False),
+                ],
+            ),
+            # SideShift (cross-chain)
+            Prompt(
+                name="cross_chain_send",
+                description=(
+                    "Send funds from Liquid or Bitcoin to another chain via SideShift "
+                    "(e.g. USDt-Liquid → USDt-Tron, L-BTC → ETH)"
+                ),
+                arguments=[
+                    PromptArgument(name="wallet_name", description="Wallet name", required=False),
+                ],
+            ),
+            Prompt(
+                name="cross_chain_receive",
+                description=(
+                    "Receive funds from another chain into Liquid or Bitcoin via SideShift "
+                    "(e.g. USDt-Tron → USDt-Liquid, ETH → L-BTC)"
+                ),
                 arguments=[
                     PromptArgument(name="wallet_name", description="Wallet name", required=False),
                 ],
@@ -981,6 +1168,89 @@ Please:
    - Preimage (proof of payment)
    - Explorer link for lockup transaction
 8. If swap fails, explain that L-BTC is locked until timeout and can be refunded""",
+                        ),
+                    )
+                ]
+            )
+
+        elif name == "cross_chain_send":
+            return GetPromptResult(
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(
+                            type="text",
+                            text=f"""I want to send funds out to another chain via SideShift, from wallet '{wallet_name}'.
+
+SideShift is a custodial cross-chain swap service — they take the deposit and
+send the converted asset from their hot wallet. The trust model is "trust
+SideShift the company" rather than "trust an on-chain protocol." Make sure I
+understand this trade-off.
+
+Please:
+1. Ask me what I want to send (e.g. USDt-Liquid, L-BTC, BTC) and to which
+   coin/network on the receive side (USDt-Tron, ETH-Ethereum, etc.)
+2. If both legs are on Bitcoin or Liquid, suggest using SideSwap instead
+   (atomic, lower fees) — call sideshift_recommend to confirm
+3. Ask me for:
+   - The destination address on the settle network (must belong to me or
+     someone I trust)
+   - The amount: either how much to send (deposit_amount) or how much to
+     receive (settle_amount), as a DECIMAL STRING (e.g. "0.0005", "100")
+4. Call sideshift_pair_info to show me the rate, min, max for the pair
+5. Validate my amount against min/max
+6. Call sideshift_quote to get a fixed-rate quote
+7. Show me a clear summary BEFORE proceeding:
+   - Send: X [deposit_coin] on [deposit_network]
+   - Receive: Y [settle_coin] at [settle_address] on [settle_network]
+   - Quote rate, expires in ~15 min
+8. Ask for explicit confirmation
+9. If wallet is password-encrypted, ask me for the password
+10. For non-L-BTC Liquid assets (USDt-Liquid, etc.), look up the asset_id
+    from lw_list_assets and pass liquid_asset_id when calling sideshift_send
+11. Call sideshift_send with the same parameters; this gets a fresh quote,
+    creates the shift, and broadcasts the deposit from my wallet
+12. Show me shift_id + deposit_hash + the SideShift order URL
+    (https://sideshift.ai/orders/<shift_id>)
+13. Tell me to use sideshift_status with the shift_id to track progress""",
+                        ),
+                    )
+                ]
+            )
+
+        elif name == "cross_chain_receive":
+            return GetPromptResult(
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(
+                            type="text",
+                            text=f"""I want to receive funds from another chain into my '{wallet_name}' wallet via SideShift.
+
+SideShift is a custodial cross-chain swap service — they take the deposit
+on the source chain and send to my Liquid or Bitcoin address from their
+hot wallet. The trust model is "trust SideShift the company." Make sure I
+understand this trade-off.
+
+Please:
+1. Ask me which coin/network the deposit is coming from (USDt-Tron, ETH-Ethereum,
+   USDt-on-Ethereum, etc.) and which Liquid/Bitcoin asset to settle into
+   (USDt-Liquid, L-BTC via coin='btc' network='liquid', BTC mainchain via
+   coin='btc' network='bitcoin')
+2. Strongly recommend providing an external_refund_address — the address on
+   the deposit chain that the external sender controls. Without this, a stuck
+   shift requires manual intervention via the SideShift web UI. Ask for it.
+3. Call sideshift_pair_info so I see the rate / min / max
+4. Call sideshift_receive — this creates a variable-rate shift; the rate is
+   set when the deposit confirms on-chain
+5. Show me clearly:
+   - The deposit address on the source chain (this is what the external
+     sender pays to)
+   - deposit_min and deposit_max
+   - deposit_memo IF PRESENT (the source chain requires a memo, e.g. TON,
+     Stellar, BNB Beacon — the sender MUST include it)
+   - Where the funds will arrive in my wallet
+6. Tell me to use sideshift_status with the shift_id to poll progress""",
                         ),
                     )
                 ]

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -532,6 +532,15 @@ TOOL_SCHEMAS = {
                 },
                 "settle_memo": {"type": "string", "description": "Required for memo networks (TON, BNB, etc.)"},
                 "refund_memo": {"type": "string"},
+                "quote_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional fixed-rate quote id from a prior sideshift_quote "
+                        "call. Pass this after the user confirms the preview so the "
+                        "shift executes at the same rate they saw — without it, the "
+                        "tool fetches a fresh quote and the rate may have moved."
+                    ),
+                },
             },
             "required": [
                 "deposit_coin", "deposit_network", "settle_coin",
@@ -1208,8 +1217,10 @@ Please:
 9. If wallet is password-encrypted, ask me for the password
 10. For non-L-BTC Liquid assets (USDt-Liquid, etc.), look up the asset_id
     from lw_list_assets and pass liquid_asset_id when calling sideshift_send
-11. Call sideshift_send with the same parameters; this gets a fresh quote,
-    creates the shift, and broadcasts the deposit from my wallet
+11. Call sideshift_send with the same parameters AND pass quote_id from the
+    quote you just showed me so the shift executes at the rate I confirmed
+    (omit quote_id and a fresh quote is fetched, which may move). This
+    creates the shift and broadcasts the deposit from my wallet
 12. Show me shift_id + deposit_hash + the SideShift order URL
     (https://sideshift.ai/orders/<shift_id>)
 13. Tell me to use sideshift_status with the shift_id to track progress""",

--- a/src/aqua/sideshift.py
+++ b/src/aqua/sideshift.py
@@ -30,8 +30,7 @@ Endpoints used (all REST/JSON, base `https://sideshift.ai/api/v2`):
 Auth: anonymous, identified by `affiliateId` in request body (publicly visible
 in any client; commission accrues to that affiliate's account). The affiliate
 ID we ship with is `PVmPh4Mp3` — JAN3's AQUA wallet ID, also used by the
-AQUA Flutter app. Override with the `SIDESHIFT_AFFILIATE_ID` env var if you
-need a different one for testing or analytics.
+AQUA Flutter app.
 """
 
 from __future__ import annotations
@@ -50,9 +49,8 @@ logger = logging.getLogger(__name__)
 
 
 # Public constants — same affiliate id AQUA Flutter ships with. Commission
-# accrues to JAN3's SideShift account; override for analytics by setting
-# SIDESHIFT_AFFILIATE_ID in the environment.
-DEFAULT_AFFILIATE_ID = os.environ.get("SIDESHIFT_AFFILIATE_ID", "PVmPh4Mp3")
+# accrues to JAN3's SideShift account.
+AFFILIATE_ID = "PVmPh4Mp3"
 SIDESHIFT_BASE_URL = os.environ.get("SIDESHIFT_BASE_URL", "https://sideshift.ai/api/v2")
 USER_AGENT = "agentic-aqua"
 HTTP_TIMEOUT_SECONDS = 30.0
@@ -247,7 +245,7 @@ class SideShiftClient:
             base_url: Override the default API base.
         """
         if affiliate_id is None:
-            affiliate_id = DEFAULT_AFFILIATE_ID
+            affiliate_id = AFFILIATE_ID
         # Empty string explicitly disables; any other falsy value also disables.
         self.affiliate_id = affiliate_id or None
         self.base_url = (base_url or SIDESHIFT_BASE_URL).rstrip("/")

--- a/src/aqua/sideshift.py
+++ b/src/aqua/sideshift.py
@@ -453,6 +453,22 @@ def recommend_shift_or_swap(
          "from_coin", "from_network", "to_coin", "to_network"}
     """
     fnet, tnet = from_network.lower(), to_network.lower()
+    fcoin, tcoin = from_coin.lower(), to_coin.lower()
+    # Same (coin, network) on both sides isn't a swap — neither service quotes
+    # it and a caller asking for one almost certainly has a bug. Surface the
+    # error rather than silently steering them at sideswap.
+    if (fcoin, fnet) == (tcoin, tnet):
+        return {
+            "recommendation": "none",
+            "reason": (
+                f"Same asset on the same network ({fcoin}-{fnet}) — there's "
+                "nothing to swap. Re-check the from/to arguments."
+            ),
+            "from_coin": from_coin,
+            "from_network": fnet,
+            "to_coin": to_coin,
+            "to_network": tnet,
+        }
     if fnet in {"bitcoin", "liquid"} and tnet in {"bitcoin", "liquid"}:
         # Both legs are on networks SideSwap can handle natively.
         return {
@@ -640,16 +656,37 @@ class SideShiftManager:
         _check_pair_allowed(deposit_coin, deposit_network, side="deposit")
         _check_pair_allowed(settle_coin, settle_network, side="settle")
 
+        # Guard against the silent-L-BTC footgun: when depositing a non-L-BTC
+        # asset on Liquid (e.g. USDt-Liquid), the wallet's `send` method
+        # defaults to L-BTC unless `liquid_asset_id` is set. Without this
+        # check, a missing `liquid_asset_id` would broadcast L-BTC to the
+        # SideShift deposit address — SideShift wouldn't credit the shift
+        # and the funds would be stuck pending manual refund.
+        if deposit_network_l == "liquid" and deposit_coin.lower() != "btc":
+            if not liquid_asset_id or liquid_asset_id == LBTC_ASSET_ID:
+                raise ValueError(
+                    f"liquid_asset_id is required when depositing a non-L-BTC "
+                    f"Liquid asset (deposit_coin={deposit_coin!r}) and must not "
+                    "be the L-BTC policy asset id. Without it, the wallet "
+                    "would send L-BTC to the deposit address."
+                )
+
         wallet_data = self.storage.load_wallet(wallet_name)
         if not wallet_data:
             raise ValueError(f"Wallet '{wallet_name}' not found")
         if wallet_data.watch_only:
             raise ValueError("Watch-only wallet cannot sign a SideShift deposit")
+        # Pre-validate the mnemonic decryption BEFORE creating the SideShift
+        # order. Without this, a wrong password only surfaces at broadcast
+        # time — leaving an orphan custodial order behind for every retry.
         if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
             wallet_data.encrypted_mnemonic
         ):
             if not password:
                 raise ValueError("Password required to decrypt mnemonic")
+            # retrieve_mnemonic raises on a bad password; let it propagate
+            # before we contact SideShift.
+            self.storage.retrieve_mnemonic(wallet_data.encrypted_mnemonic, password)
 
         # Refund address: same wallet, same network as the deposit. If the
         # shift fails for any reason, the funds come back to where they came
@@ -694,7 +731,7 @@ class SideShiftManager:
 
         # Broadcast the deposit. SideShift's depositAmount is in human-readable
         # decimal (e.g. "0.0005"); our wallet sends are in sats. Convert.
-        deposit_sats = _decimal_to_sats(shift_resp["depositAmount"])
+        deposit_sats = _decimal_to_sats_8dp(shift_resp["depositAmount"])
         try:
             txid = self._wallet_send(
                 deposit_network_l,
@@ -891,12 +928,17 @@ class SideShiftManager:
 # ---------------------------------------------------------------------------
 
 
-def _decimal_to_sats(decimal_str: str | float | int) -> int:
+def _decimal_to_sats_8dp(decimal_str: str | float | int) -> int:
     """Convert a SideShift human-readable amount (e.g. "0.0005") to integer sats.
 
-    SideShift uses decimal strings to preserve precision; our wallet APIs
-    take integer sats (1 sat = 1e-8 of the asset). 8 decimal places is the
-    standard for both BTC and Liquid assets we care about.
+    Hardcoded to 8 decimal places — the precision used by BTC and the Liquid
+    assets we sign on (L-BTC + USDt-Liquid). The broadcast path runs only on
+    `bitcoin` or `liquid` networks, so callers should never pass values from
+    higher-precision chains (e.g. ETH at 18dp) here.
+
+    Rounding is HALF_UP: SideShift quotes are pre-rounded to the chain's
+    native precision in practice, so the sub-sat cases this affects are rare;
+    if one occurs, we'd rather over-pay 1 sat than land below `depositMin`.
     """
     from decimal import Decimal, ROUND_HALF_UP
 

--- a/src/aqua/sideshift.py
+++ b/src/aqua/sideshift.py
@@ -45,6 +45,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Optional
 
+from .assets import LBTC_ASSET_ID
+
 logger = logging.getLogger(__name__)
 
 
@@ -408,14 +410,6 @@ class SideShiftClient:
     def get_shift(self, shift_id: str) -> dict:
         return self._api_request("GET", f"/shifts/{shift_id}") or {}
 
-    def set_refund_address(self, shift_id: str, address: str, memo: Optional[str] = None) -> dict:
-        body: dict[str, Any] = {"address": address}
-        if memo:
-            body["memo"] = memo
-        return self._api_request(
-            "POST", f"/shifts/{shift_id}/set-refund-address", body=body
-        ) or {}
-
 
 # ---------------------------------------------------------------------------
 # Coin/network resolution for the wallet's native chains
@@ -427,15 +421,6 @@ class SideShiftClient:
 NATIVE_DEPOSIT_CHAINS = {
     "bitcoin",  # BDK
     "liquid",   # LWK
-}
-
-# Liquid asset → SideShift (coin, network) mapping. The `coin` is what the
-# SideShift API expects; the `network` is always "liquid" here.
-LIQUID_ASSET_TO_SIDESHIFT_COIN = {
-    # L-BTC. SideShift quirks: L-BTC is "BTC" on the "liquid" network.
-    "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d": "btc",
-    # USDt on Liquid
-    "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2": "usdt",
 }
 
 
@@ -507,7 +492,7 @@ def recommend_shift_or_swap(
 # SideShift returns one of these statuses (lowercase). We surface them as-is
 # but expose `is_final` and `is_success` helpers so callers don't have to
 # memorise the state machine.
-_FINAL_STATUSES = {"settled", "refunded", "expired", "review"}
+_FINAL_STATUSES = {"settled", "refunded", "expired"}
 _SUCCESS_STATUSES = {"settled"}
 _FAILED_STATUSES = {"refunded", "expired"}
 
@@ -617,6 +602,7 @@ class SideShiftManager:
         liquid_asset_id: Optional[str] = None,
         settle_memo: Optional[str] = None,
         refund_memo: Optional[str] = None,
+        quote_id: Optional[str] = None,
     ) -> "SideShiftShift":
         """Send funds from our wallet via a fixed-rate shift.
 
@@ -635,6 +621,12 @@ class SideShiftManager:
                 is not L-BTC (e.g. USDt-Liquid).
             settle_memo / refund_memo: required for memo networks
                 (TON, BNB Beacon, etc.) on either side.
+            quote_id: an existing fixed-rate quote id (from a prior
+                `quote()` call). When provided, skip the internal
+                `request_quote` call so the executed shift uses the same
+                rate the caller just confirmed with the user. Without it,
+                the manager fetches a fresh quote and the rate may differ
+                slightly from a preview shown moments earlier.
         """
         deposit_network_l = deposit_network.lower()
         if deposit_network_l not in NATIVE_DEPOSIT_CHAINS:
@@ -664,15 +656,22 @@ class SideShiftManager:
         # from (less the network fee on a refund tx).
         refund_address = self._wallet_address(deposit_network_l, wallet_name)
 
-        quote = self.client.request_quote(
-            deposit_coin, deposit_network, settle_coin, settle_network,
-            deposit_amount=deposit_amount, settle_amount=settle_amount,
-        )
-        if not quote.get("id"):
-            raise RuntimeError(f"Unexpected quote response: {quote!r}")
+        if quote_id:
+            # Reuse the caller-supplied quote so the shift executes at the
+            # rate the user just confirmed in the preview. Skips a redundant
+            # request_quote round-trip and removes the slippage window.
+            shift_quote_id = quote_id
+        else:
+            quote = self.client.request_quote(
+                deposit_coin, deposit_network, settle_coin, settle_network,
+                deposit_amount=deposit_amount, settle_amount=settle_amount,
+            )
+            if not quote.get("id"):
+                raise RuntimeError(f"Unexpected quote response: {quote!r}")
+            shift_quote_id = quote["id"]
 
         shift_resp = self.client.create_fixed_shift(
-            quote_id=quote["id"],
+            quote_id=shift_quote_id,
             settle_address=settle_address,
             refund_address=refund_address,
             settle_memo=settle_memo,
@@ -687,7 +686,7 @@ class SideShiftManager:
             direction="send",
             wallet_name=wallet_name,
             refund_address=refund_address,
-            quote_id=quote["id"],
+            quote_id=shift_quote_id,
         )
         # Persist BEFORE broadcasting the deposit. If the broadcast fails
         # we still have a record of the shift to refund or retry.
@@ -707,7 +706,7 @@ class SideShiftManager:
             )
         except Exception as e:
             shift.last_error = f"Deposit broadcast failed: {e}"
-            shift.status = shift.status or "failed"
+            shift.status = "failed"
             self.storage.save_sideshift_shift(shift)
             raise
         shift.deposit_hash = txid
@@ -842,7 +841,7 @@ class SideShiftManager:
                 wallet_name, address, amount_sats, password=password
             )
         if network == "liquid":
-            if liquid_asset_id and liquid_asset_id != _LIQUID_LBTC_POLICY_ASSET:
+            if liquid_asset_id and liquid_asset_id != LBTC_ASSET_ID:
                 return self.wallet_manager.send(
                     wallet_name, address, amount_sats,
                     asset_id=liquid_asset_id, password=password,
@@ -890,11 +889,6 @@ class SideShiftManager:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
-
-
-_LIQUID_LBTC_POLICY_ASSET = (
-    "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d"
-)
 
 
 def _decimal_to_sats(decimal_str: str | float | int) -> int:

--- a/src/aqua/sideshift.py
+++ b/src/aqua/sideshift.py
@@ -1,0 +1,913 @@
+"""SideShift.ai integration for cross-chain swaps.
+
+SideShift is a multi-chain swap service.
+
+Two flows:
+
+- **Fixed-rate** (`/v2/quotes` then `/v2/shifts/fixed`): commit to a quoted
+  rate, send *exactly* `depositAmount` within the quote's TTL (~15 min), and
+  the agreed `settleAmount` is delivered.
+- **Variable-rate** (`/v2/shifts/variable`): get a deposit address, send any
+  amount in `[depositMin, depositMax]`, rate set when deposit confirms.
+
+When to use SideShift vs SideSwap:
+
+- Both legs Liquid (or BTC↔L-BTC and you can wait) → SideSwap (trustless or
+  Federation, lower fees).
+- At least one leg is non-Liquid (USDt-Tron, ETH, USDt-on-Ethereum, LTC, etc.) →
+  SideShift (custodial but covers everything else). Use `recommend_shift_or_swap`.
+
+Endpoints used (all REST/JSON, base `https://sideshift.ai/api/v2`):
+
+  GET  /v2/coins                  — supported coins+networks
+  GET  /v2/permissions            — geo / availability check
+  GET  /v2/pair/{from}/{to}       — rate, min, max for a pair
+  POST /v2/quotes                 — fixed quote (15 min TTL)
+  POST /v2/shifts/fixed           — create fixed shift from a quote
+  POST /v2/shifts/variable        — create variable shift (no quote)
+  GET  /v2/shifts/{id}            — shift status
+
+Auth: anonymous, identified by `affiliateId` in request body (publicly visible
+in any client; commission accrues to that affiliate's account). The affiliate
+ID we ship with is `PVmPh4Mp3` — JAN3's AQUA wallet ID, also used by the
+AQUA Flutter app. Override with the `SIDESHIFT_AFFILIATE_ID` env var if you
+need a different one for testing or analytics.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Public constants — same affiliate id AQUA Flutter ships with. Commission
+# accrues to JAN3's SideShift account; override for analytics by setting
+# SIDESHIFT_AFFILIATE_ID in the environment.
+DEFAULT_AFFILIATE_ID = os.environ.get("SIDESHIFT_AFFILIATE_ID", "PVmPh4Mp3")
+SIDESHIFT_BASE_URL = os.environ.get("SIDESHIFT_BASE_URL", "https://sideshift.ai/api/v2")
+USER_AGENT = "agentic-aqua"
+HTTP_TIMEOUT_SECONDS = 30.0
+
+# SideShift's coin-network IDs use lowercase coin + lowercase network. The
+# wallet's policy assets map as follows (see AQUA's `sideshift_ext.dart`):
+SIDESHIFT_COIN_BTC_BITCOIN = ("btc", "bitcoin")
+SIDESHIFT_COIN_BTC_LIQUID = ("btc", "liquid")  # SideShift calls L-BTC just "BTC" on the liquid network
+SIDESHIFT_COIN_USDT_LIQUID = ("usdt", "liquid")
+
+# Curated allowlist of (coin, network) pairs we expose for swaps. Mirrors
+# AQUA Flutter's `SideshiftAsset` factories in
+# `lib/features/sideshift/models/sideshift_assets.dart` — USDt routed across
+# the major chains plus BTC mainchain. Both legs of a `sideshift_send` /
+# `sideshift_receive` call must be in this set.
+#
+# This intentionally does NOT include `(btc, liquid)` (i.e. L-BTC) — for
+# L-BTC ↔ external use SideSwap, or chain SideShift through USDt-Liquid
+# (e.g. L-BTC → USDt-Liquid via SideSwap, then USDt-Liquid → USDt-Tron via
+# SideShift). Override the allowlist for testing or power use by setting
+# `SIDESHIFT_ALLOW_ALL_NETWORKS=1` in the environment.
+ALLOWED_PAIRS: frozenset[tuple[str, str]] = frozenset({
+    ("usdt", "ethereum"),
+    ("usdt", "tron"),
+    ("usdt", "bsc"),
+    ("usdt", "solana"),
+    ("usdt", "polygon"),
+    ("usdt", "ton"),
+    ("usdt", "liquid"),
+    ("btc", "bitcoin"),
+})
+
+
+def _allow_all_networks() -> bool:
+    """Read the override env var. Re-read on every check so tests can mutate it.
+
+    Accepts `1`, `true`, `yes` (case-insensitive) as truthy.
+    """
+    return os.environ.get("SIDESHIFT_ALLOW_ALL_NETWORKS", "").strip().lower() in {
+        "1", "true", "yes",
+    }
+
+
+def _check_pair_allowed(coin: str, network: str, side: str) -> None:
+    """Raise ValueError if (coin, network) isn't on the curated allowlist.
+
+    The override env var bypasses the check entirely.
+
+    Args:
+        coin / network: the pair to check (case-insensitive).
+        side: "deposit" or "settle" — used only for the error message.
+    """
+    if _allow_all_networks():
+        return
+    pair = (coin.lower(), network.lower())
+    if pair not in ALLOWED_PAIRS:
+        allowed = ", ".join(f"{c}-{n}" for c, n in sorted(ALLOWED_PAIRS))
+        raise ValueError(
+            f"SideShift {side} pair {coin}-{network} is not in the curated "
+            f"allowlist (matches AQUA Flutter's supported set): {allowed}. "
+            "Set SIDESHIFT_ALLOW_ALL_NETWORKS=1 to bypass."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SideShiftCoin:
+    """A coin/network as returned from `/v2/coins`."""
+
+    coin: str  # e.g. "USDT"
+    name: str  # e.g. "Tether"
+    networks: list[str]
+    has_memo: bool = False
+    fixed_only: bool = False
+    variable_only: bool = False
+    deposit_offline: bool = False
+    settle_offline: bool = False
+    token_details: Optional[dict] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class SideShiftPairInfo:
+    """Pair info from `/v2/pair/{from}/{to}` — rate, min, max."""
+
+    deposit_coin: str
+    deposit_network: str
+    settle_coin: str
+    settle_network: str
+    rate: str  # SideShift returns rates as strings to preserve precision
+    min: str
+    max: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class SideShiftQuote:
+    """A fixed-rate quote from `/v2/quotes`."""
+
+    quote_id: str
+    deposit_coin: str
+    deposit_network: str
+    settle_coin: str
+    settle_network: str
+    deposit_amount: str
+    settle_amount: str
+    rate: str
+    affiliate_id: Optional[str]
+    created_at: str  # ISO timestamp from server
+    expires_at: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class SideShiftShift:
+    """Persistent record of a SideShift shift (fixed or variable, send or receive)."""
+
+    shift_id: str
+    shift_type: str  # "fixed" | "variable"
+    direction: str  # "send" (we sign deposit) | "receive" (we provide settle address)
+    deposit_coin: str
+    deposit_network: str
+    settle_coin: str
+    settle_network: str
+    settle_address: str
+    deposit_address: str
+    refund_address: Optional[str]
+    wallet_name: Optional[str]
+    status: str
+    created_at: str
+    expires_at: Optional[str] = None
+    deposit_amount: Optional[str] = None  # set on fixed; None on variable until deposit confirms
+    settle_amount: Optional[str] = None  # set on fixed; None on variable until rate is locked
+    deposit_min: Optional[str] = None  # variable shifts only
+    deposit_max: Optional[str] = None  # variable shifts only
+    rate: Optional[str] = None
+    quote_id: Optional[str] = None  # fixed shifts only
+    deposit_memo: Optional[str] = None  # for memo-required networks (TON, BNB, etc.)
+    deposit_hash: Optional[str] = None  # txid where the deposit landed
+    settle_hash: Optional[str] = None  # txid where the settlement landed
+    last_checked_at: Optional[str] = None
+    last_error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SideShiftShift":
+        data = {**data}
+        for f in (
+            "expires_at", "deposit_amount", "settle_amount", "deposit_min",
+            "deposit_max", "rate", "quote_id", "deposit_memo", "deposit_hash",
+            "settle_hash", "last_checked_at", "last_error",
+        ):
+            data.setdefault(f, None)
+        return cls(**data)
+
+
+# ---------------------------------------------------------------------------
+# REST client
+# ---------------------------------------------------------------------------
+
+
+class SideShiftClient:
+    """HTTP client for the SideShift v2 API.
+
+    All POSTs include `affiliateId` in the body so commission accrues to our
+    account. GET endpoints add `affiliateId` as a query parameter where
+    applicable (`/v2/pair`).
+    """
+
+    def __init__(
+        self,
+        affiliate_id: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> None:
+        """
+        Args:
+            affiliate_id: None falls back to the default (`PVmPh4Mp3`); pass
+                an empty string to disable the affiliate id entirely (anonymous,
+                no commission); pass any other string to override.
+            base_url: Override the default API base.
+        """
+        if affiliate_id is None:
+            affiliate_id = DEFAULT_AFFILIATE_ID
+        # Empty string explicitly disables; any other falsy value also disables.
+        self.affiliate_id = affiliate_id or None
+        self.base_url = (base_url or SIDESHIFT_BASE_URL).rstrip("/")
+
+    def _api_request(
+        self,
+        method: str,
+        path: str,
+        body: Optional[dict] = None,
+        query: Optional[dict] = None,
+    ) -> Any:
+        url = f"{self.base_url}{path}"
+        if query:
+            # urllib will encode values; drop None values.
+            cleaned = {k: v for k, v in query.items() if v is not None}
+            if cleaned:
+                url += "?" + urllib.parse.urlencode(cleaned)
+        data = None
+        if body is not None:
+            payload = {**body}
+            if self.affiliate_id and "affiliateId" not in payload:
+                payload["affiliateId"] = self.affiliate_id
+            data = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": USER_AGENT,
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:
+                raw = resp.read().decode()
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as e:
+            detail = ""
+            try:
+                err_body = json.loads(e.read().decode())
+                # SideShift returns {"error": {"message": "..."}} on errors.
+                err = err_body.get("error", {})
+                if isinstance(err, dict):
+                    detail = err.get("message") or err.get("code") or str(err)
+                elif isinstance(err, str):
+                    detail = err
+                else:
+                    detail = err_body.get("message", "")
+            except Exception:
+                pass
+            msg = f"SideShift API error ({e.code} {method} {path})"
+            if detail:
+                msg += f": {detail}"
+            raise RuntimeError(msg) from e
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"SideShift API unreachable ({method} {path}): {e.reason}") from e
+
+    # -- Endpoints -----------------------------------------------------------
+
+    def get_coins(self) -> list[dict]:
+        return self._api_request("GET", "/coins") or []
+
+    def get_permissions(self) -> dict:
+        return self._api_request("GET", "/permissions") or {}
+
+    def get_pair(
+        self,
+        from_coin: str,
+        from_network: str,
+        to_coin: str,
+        to_network: str,
+        amount: Optional[str] = None,
+    ) -> dict:
+        from_id = f"{from_coin.lower()}-{from_network.lower()}"
+        to_id = f"{to_coin.lower()}-{to_network.lower()}"
+        query: dict[str, Any] = {}
+        if self.affiliate_id:
+            query["affiliateId"] = self.affiliate_id
+        if amount is not None:
+            query["amount"] = amount
+        return self._api_request("GET", f"/pair/{from_id}/{to_id}", query=query) or {}
+
+    def request_quote(
+        self,
+        deposit_coin: str,
+        deposit_network: str,
+        settle_coin: str,
+        settle_network: str,
+        deposit_amount: Optional[str] = None,
+        settle_amount: Optional[str] = None,
+    ) -> dict:
+        if (deposit_amount is None) == (settle_amount is None):
+            raise ValueError(
+                "exactly one of deposit_amount or settle_amount must be provided"
+            )
+        body: dict[str, Any] = {
+            "depositCoin": deposit_coin.upper(),
+            "depositNetwork": deposit_network.lower(),
+            "settleCoin": settle_coin.upper(),
+            "settleNetwork": settle_network.lower(),
+        }
+        if deposit_amount is not None:
+            body["depositAmount"] = deposit_amount
+        if settle_amount is not None:
+            body["settleAmount"] = settle_amount
+        return self._api_request("POST", "/quotes", body=body) or {}
+
+    def create_fixed_shift(
+        self,
+        quote_id: str,
+        settle_address: str,
+        refund_address: Optional[str] = None,
+        settle_memo: Optional[str] = None,
+        refund_memo: Optional[str] = None,
+        external_id: Optional[str] = None,
+    ) -> dict:
+        body: dict[str, Any] = {
+            "quoteId": quote_id,
+            "settleAddress": settle_address,
+        }
+        if refund_address:
+            body["refundAddress"] = refund_address
+        if settle_memo:
+            body["settleMemo"] = settle_memo
+        if refund_memo:
+            body["refundMemo"] = refund_memo
+        if external_id:
+            body["externalId"] = external_id
+        return self._api_request("POST", "/shifts/fixed", body=body) or {}
+
+    def create_variable_shift(
+        self,
+        deposit_coin: str,
+        deposit_network: str,
+        settle_coin: str,
+        settle_network: str,
+        settle_address: str,
+        refund_address: Optional[str] = None,
+        settle_memo: Optional[str] = None,
+        refund_memo: Optional[str] = None,
+        external_id: Optional[str] = None,
+    ) -> dict:
+        body: dict[str, Any] = {
+            "depositCoin": deposit_coin.upper(),
+            "depositNetwork": deposit_network.lower(),
+            "settleCoin": settle_coin.upper(),
+            "settleNetwork": settle_network.lower(),
+            "settleAddress": settle_address,
+        }
+        if refund_address:
+            body["refundAddress"] = refund_address
+        if settle_memo:
+            body["settleMemo"] = settle_memo
+        if refund_memo:
+            body["refundMemo"] = refund_memo
+        if external_id:
+            body["externalId"] = external_id
+        return self._api_request("POST", "/shifts/variable", body=body) or {}
+
+    def get_shift(self, shift_id: str) -> dict:
+        return self._api_request("GET", f"/shifts/{shift_id}") or {}
+
+    def set_refund_address(self, shift_id: str, address: str, memo: Optional[str] = None) -> dict:
+        body: dict[str, Any] = {"address": address}
+        if memo:
+            body["memo"] = memo
+        return self._api_request(
+            "POST", f"/shifts/{shift_id}/set-refund-address", body=body
+        ) or {}
+
+
+# ---------------------------------------------------------------------------
+# Coin/network resolution for the wallet's native chains
+# ---------------------------------------------------------------------------
+
+
+# What our wallet can sign for natively. Anything else is a (coin, network)
+# string the user supplies for an external counterparty.
+NATIVE_DEPOSIT_CHAINS = {
+    "bitcoin",  # BDK
+    "liquid",   # LWK
+}
+
+# Liquid asset → SideShift (coin, network) mapping. The `coin` is what the
+# SideShift API expects; the `network` is always "liquid" here.
+LIQUID_ASSET_TO_SIDESHIFT_COIN = {
+    # L-BTC. SideShift quirks: L-BTC is "BTC" on the "liquid" network.
+    "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d": "btc",
+    # USDt on Liquid
+    "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2": "usdt",
+}
+
+
+# ---------------------------------------------------------------------------
+# Recommendation: SideSwap vs SideShift
+# ---------------------------------------------------------------------------
+
+
+def recommend_shift_or_swap(
+    from_coin: str,
+    from_network: str,
+    to_coin: str,
+    to_network: str,
+) -> dict:
+    """Decide whether SideSwap or SideShift is the better fit for a pair.
+
+    Heuristic:
+    - Both legs are in {bitcoin, liquid} → SideSwap (atomic Liquid swap or
+      Liquid Federation peg; trustless or near-trustless, lower fees).
+    - At least one leg is a non-{bitcoin, liquid} chain → SideShift
+      (custodial; covers all the chains SideSwap doesn't).
+    - L-BTC → BTC quickly (skip the federation wait): SideShift is also fine.
+
+    Args:
+        from_coin / from_network / to_coin / to_network: lowercase strings.
+
+    Returns:
+        {"recommendation": "sideswap" | "sideshift",
+         "reason": <human-readable>,
+         "from_coin", "from_network", "to_coin", "to_network"}
+    """
+    fnet, tnet = from_network.lower(), to_network.lower()
+    if fnet in {"bitcoin", "liquid"} and tnet in {"bitcoin", "liquid"}:
+        # Both legs are on networks SideSwap can handle natively.
+        return {
+            "recommendation": "sideswap",
+            "reason": (
+                "Both legs are on Bitcoin or Liquid. SideSwap offers atomic "
+                "Liquid swaps and BTC↔L-BTC pegs — lower fees and no "
+                "custodial risk. Use SideShift if you need a faster BTC ↔ "
+                "L-BTC conversion than the Liquid Federation peg-in (102 "
+                "BTC confs for large amounts) and accept the custodial "
+                "trust trade-off."
+            ),
+            "from_coin": from_coin,
+            "from_network": fnet,
+            "to_coin": to_coin,
+            "to_network": tnet,
+        }
+    return {
+        "recommendation": "sideshift",
+        "reason": (
+            "At least one leg is on a network SideSwap doesn't cover "
+            f"({fnet} → {tnet}). SideShift is custodial (trust the company, "
+            "not on-chain) but covers 30+ chains including ETH, Tron, Solana, "
+            "and USDt on every major network. Always supply a refund address."
+        ),
+        "from_coin": from_coin,
+        "from_network": fnet,
+        "to_coin": to_coin,
+        "to_network": tnet,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Shift status mapping
+# ---------------------------------------------------------------------------
+
+# SideShift returns one of these statuses (lowercase). We surface them as-is
+# but expose `is_final` and `is_success` helpers so callers don't have to
+# memorise the state machine.
+_FINAL_STATUSES = {"settled", "refunded", "expired", "review"}
+_SUCCESS_STATUSES = {"settled"}
+_FAILED_STATUSES = {"refunded", "expired"}
+
+
+def shift_is_final(status: str) -> bool:
+    return status.lower() in _FINAL_STATUSES
+
+
+def shift_is_success(status: str) -> bool:
+    return status.lower() in _SUCCESS_STATUSES
+
+
+def shift_is_failed(status: str) -> bool:
+    return status.lower() in _FAILED_STATUSES
+
+
+# ---------------------------------------------------------------------------
+# High-level manager
+# ---------------------------------------------------------------------------
+
+
+class SideShiftManager:
+    """Orchestrates SideShift send / receive flows tied to AQUA's wallet managers.
+
+    Two flows:
+
+    1. **Send** (`send_shift`): user has funds in their Liquid or BTC wallet
+       and wants to convert to a non-Liquid asset (e.g. send USDt-Liquid to
+       receive USDt-Tron at an external address). We:
+         - Validate the deposit chain is one of {bitcoin, liquid}
+         - Get a fixed-rate quote for the agreed amount
+         - Create a fixed shift with the quote
+         - Broadcast the deposit from our wallet (via `wallet.send` / `bitcoin.send` / `wallet.send_asset`)
+         - Persist throughout
+
+    2. **Receive** (`receive_shift`): user wants to receive Liquid or Bitcoin
+       from any chain. We create a variable-rate shift with the user's wallet
+       address as the settle address; the user (or external sender) sends
+       to the returned `deposit_address` from any wallet on the deposit chain.
+
+    Both flows always supply a refund address (the user's own wallet on the
+    deposit chain when sending, or a user-provided external address when
+    receiving). Without one, a stuck shift can't be unstuck without manually
+    visiting the SideShift web UI.
+    """
+
+    def __init__(self, storage, wallet_manager, btc_wallet_manager) -> None:
+        """
+        Args:
+            storage: Storage instance with sideshift_shift helpers.
+            wallet_manager: WalletManager (Liquid/LWK).
+            btc_wallet_manager: BitcoinWalletManager (BDK).
+        """
+        self.storage = storage
+        self.wallet_manager = wallet_manager
+        self.btc_wallet_manager = btc_wallet_manager
+        self._client: Optional[SideShiftClient] = None
+
+    @property
+    def client(self) -> SideShiftClient:
+        if self._client is None:
+            self._client = SideShiftClient()
+        return self._client
+
+    # -- Read-only helpers ---------------------------------------------------
+
+    def list_coins(self) -> list[dict]:
+        return self.client.get_coins()
+
+    def pair_info(
+        self,
+        from_coin: str,
+        from_network: str,
+        to_coin: str,
+        to_network: str,
+        amount: Optional[str] = None,
+    ) -> dict:
+        return self.client.get_pair(from_coin, from_network, to_coin, to_network, amount)
+
+    def quote(
+        self,
+        deposit_coin: str,
+        deposit_network: str,
+        settle_coin: str,
+        settle_network: str,
+        deposit_amount: Optional[str] = None,
+        settle_amount: Optional[str] = None,
+    ) -> dict:
+        return self.client.request_quote(
+            deposit_coin, deposit_network, settle_coin, settle_network,
+            deposit_amount=deposit_amount, settle_amount=settle_amount,
+        )
+
+    # -- Send flow -----------------------------------------------------------
+
+    def send_shift(
+        self,
+        deposit_coin: str,
+        deposit_network: str,
+        settle_coin: str,
+        settle_network: str,
+        settle_address: str,
+        deposit_amount: Optional[str] = None,
+        settle_amount: Optional[str] = None,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+        liquid_asset_id: Optional[str] = None,
+        settle_memo: Optional[str] = None,
+        refund_memo: Optional[str] = None,
+    ) -> "SideShiftShift":
+        """Send funds from our wallet via a fixed-rate shift.
+
+        Args:
+            deposit_coin / deposit_network: must be a chain we can sign on
+                (bitcoin or liquid). Liquid assets identified by
+                `(coin, network) = ("btc"|"usdt"|..., "liquid")`.
+            settle_coin / settle_network: any chain SideShift supports.
+            settle_address: where SideShift sends the converted asset
+                (the user's external address).
+            deposit_amount / settle_amount: provide exactly one. Strings to
+                preserve precision (SideShift uses decimal strings).
+            wallet_name: which local wallet to send from.
+            password: mnemonic decryption password (if encrypted at rest).
+            liquid_asset_id: hex asset id, required when the Liquid asset
+                is not L-BTC (e.g. USDt-Liquid).
+            settle_memo / refund_memo: required for memo networks
+                (TON, BNB Beacon, etc.) on either side.
+        """
+        deposit_network_l = deposit_network.lower()
+        if deposit_network_l not in NATIVE_DEPOSIT_CHAINS:
+            raise ValueError(
+                f"Cannot sign on {deposit_network!r}; deposit_network must be one "
+                f"of {sorted(NATIVE_DEPOSIT_CHAINS)} (use a wallet that holds the "
+                f"deposit asset and sign externally if needed)."
+            )
+        # Allowlist check: both legs must be in AQUA's curated set, unless the
+        # caller has set SIDESHIFT_ALLOW_ALL_NETWORKS.
+        _check_pair_allowed(deposit_coin, deposit_network, side="deposit")
+        _check_pair_allowed(settle_coin, settle_network, side="settle")
+
+        wallet_data = self.storage.load_wallet(wallet_name)
+        if not wallet_data:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+        if wallet_data.watch_only:
+            raise ValueError("Watch-only wallet cannot sign a SideShift deposit")
+        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
+            wallet_data.encrypted_mnemonic
+        ):
+            if not password:
+                raise ValueError("Password required to decrypt mnemonic")
+
+        # Refund address: same wallet, same network as the deposit. If the
+        # shift fails for any reason, the funds come back to where they came
+        # from (less the network fee on a refund tx).
+        refund_address = self._wallet_address(deposit_network_l, wallet_name)
+
+        quote = self.client.request_quote(
+            deposit_coin, deposit_network, settle_coin, settle_network,
+            deposit_amount=deposit_amount, settle_amount=settle_amount,
+        )
+        if not quote.get("id"):
+            raise RuntimeError(f"Unexpected quote response: {quote!r}")
+
+        shift_resp = self.client.create_fixed_shift(
+            quote_id=quote["id"],
+            settle_address=settle_address,
+            refund_address=refund_address,
+            settle_memo=settle_memo,
+            refund_memo=refund_memo,
+        )
+        if not shift_resp.get("id") or not shift_resp.get("depositAddress"):
+            raise RuntimeError(f"Unexpected shift response: {shift_resp!r}")
+
+        shift = self._shift_from_response(
+            shift_resp,
+            shift_type="fixed",
+            direction="send",
+            wallet_name=wallet_name,
+            refund_address=refund_address,
+            quote_id=quote["id"],
+        )
+        # Persist BEFORE broadcasting the deposit. If the broadcast fails
+        # we still have a record of the shift to refund or retry.
+        self.storage.save_sideshift_shift(shift)
+
+        # Broadcast the deposit. SideShift's depositAmount is in human-readable
+        # decimal (e.g. "0.0005"); our wallet sends are in sats. Convert.
+        deposit_sats = _decimal_to_sats(shift_resp["depositAmount"])
+        try:
+            txid = self._wallet_send(
+                deposit_network_l,
+                wallet_name=wallet_name,
+                address=shift_resp["depositAddress"],
+                amount_sats=deposit_sats,
+                password=password,
+                liquid_asset_id=liquid_asset_id,
+            )
+        except Exception as e:
+            shift.last_error = f"Deposit broadcast failed: {e}"
+            shift.status = shift.status or "failed"
+            self.storage.save_sideshift_shift(shift)
+            raise
+        shift.deposit_hash = txid
+        # Status often stays "waiting" until SideShift sees the deposit on-chain,
+        # which can take a confirmation. Don't override the server's status.
+        self.storage.save_sideshift_shift(shift)
+        return shift
+
+    # -- Receive flow --------------------------------------------------------
+
+    def receive_shift(
+        self,
+        deposit_coin: str,
+        deposit_network: str,
+        settle_coin: str,
+        settle_network: str,
+        wallet_name: str = "default",
+        external_refund_address: Optional[str] = None,
+        external_refund_memo: Optional[str] = None,
+        settle_memo: Optional[str] = None,
+    ) -> "SideShiftShift":
+        """Receive funds into our wallet via a variable-rate shift.
+
+        Args:
+            deposit_coin / deposit_network: any chain SideShift supports
+                (this is where the external sender pays from).
+            settle_coin / settle_network: must be one of {bitcoin, liquid}
+                (this is the chain we settle into).
+            external_refund_address: where SideShift refunds if the deposit
+                arrives wrong. Strongly recommended; without it a stuck shift
+                requires manual web UI intervention. May be the deposit-side
+                external sender's address, asked of the user.
+        """
+        settle_network_l = settle_network.lower()
+        if settle_network_l not in NATIVE_DEPOSIT_CHAINS:
+            raise ValueError(
+                f"Cannot receive on {settle_network!r}; settle_network must be "
+                f"one of {sorted(NATIVE_DEPOSIT_CHAINS)}."
+            )
+        # Allowlist check: both legs must be in AQUA's curated set, unless the
+        # caller has set SIDESHIFT_ALLOW_ALL_NETWORKS.
+        _check_pair_allowed(deposit_coin, deposit_network, side="deposit")
+        _check_pair_allowed(settle_coin, settle_network, side="settle")
+
+        wallet_data = self.storage.load_wallet(wallet_name)
+        if not wallet_data:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+        # Receive doesn't need the mnemonic decrypted — we only need an address.
+
+        settle_address = self._wallet_address(settle_network_l, wallet_name)
+
+        shift_resp = self.client.create_variable_shift(
+            deposit_coin=deposit_coin,
+            deposit_network=deposit_network,
+            settle_coin=settle_coin,
+            settle_network=settle_network,
+            settle_address=settle_address,
+            refund_address=external_refund_address,
+            settle_memo=settle_memo,
+            refund_memo=external_refund_memo,
+        )
+        if not shift_resp.get("id") or not shift_resp.get("depositAddress"):
+            raise RuntimeError(f"Unexpected shift response: {shift_resp!r}")
+
+        shift = self._shift_from_response(
+            shift_resp,
+            shift_type="variable",
+            direction="receive",
+            wallet_name=wallet_name,
+            refund_address=external_refund_address,
+        )
+        self.storage.save_sideshift_shift(shift)
+        return shift
+
+    # -- Status polling ------------------------------------------------------
+
+    def status(self, shift_id: str) -> dict:
+        shift = self.storage.load_sideshift_shift(shift_id)
+        if not shift:
+            raise ValueError(f"SideShift shift not found: {shift_id}")
+
+        warning = None
+        try:
+            resp = self.client.get_shift(shift_id)
+            shift.status = (resp.get("status") or shift.status).lower()
+            if resp.get("depositHash"):
+                shift.deposit_hash = resp["depositHash"]
+            if resp.get("settleHash"):
+                shift.settle_hash = resp["settleHash"]
+            if resp.get("rate"):
+                shift.rate = str(resp["rate"])
+            if resp.get("depositAmount"):
+                shift.deposit_amount = str(resp["depositAmount"])
+            if resp.get("settleAmount"):
+                shift.settle_amount = str(resp["settleAmount"])
+            shift.last_checked_at = datetime.now(UTC).isoformat()
+            self.storage.save_sideshift_shift(shift)
+        except Exception as e:
+            warning = f"Could not refresh status: {e}"
+
+        result = shift.to_dict()
+        result["is_final"] = shift_is_final(shift.status)
+        result["is_success"] = shift_is_success(shift.status)
+        result["is_failed"] = shift_is_failed(shift.status)
+        if warning:
+            result["warning"] = warning
+        return result
+
+    # -- Helpers -------------------------------------------------------------
+
+    def _wallet_address(self, network: str, wallet_name: str) -> str:
+        if network == "bitcoin":
+            return self.btc_wallet_manager.get_address(wallet_name).address
+        if network == "liquid":
+            return self.wallet_manager.get_address(wallet_name).address
+        raise ValueError(f"Unsupported network for wallet address lookup: {network!r}")
+
+    def _wallet_send(
+        self,
+        network: str,
+        *,
+        wallet_name: str,
+        address: str,
+        amount_sats: int,
+        password: Optional[str],
+        liquid_asset_id: Optional[str],
+    ) -> str:
+        if network == "bitcoin":
+            if liquid_asset_id is not None:
+                raise ValueError("liquid_asset_id is not valid on Bitcoin sends")
+            return self.btc_wallet_manager.send(
+                wallet_name, address, amount_sats, password=password
+            )
+        if network == "liquid":
+            if liquid_asset_id and liquid_asset_id != _LIQUID_LBTC_POLICY_ASSET:
+                return self.wallet_manager.send(
+                    wallet_name, address, amount_sats,
+                    asset_id=liquid_asset_id, password=password,
+                )
+            return self.wallet_manager.send(
+                wallet_name, address, amount_sats, password=password
+            )
+        raise ValueError(f"Unsupported send network: {network!r}")
+
+    def _shift_from_response(
+        self,
+        resp: dict,
+        *,
+        shift_type: str,
+        direction: str,
+        wallet_name: Optional[str],
+        refund_address: Optional[str],
+        quote_id: Optional[str] = None,
+    ) -> "SideShiftShift":
+        return SideShiftShift(
+            shift_id=resp["id"],
+            shift_type=shift_type,
+            direction=direction,
+            deposit_coin=resp.get("depositCoin", ""),
+            deposit_network=resp.get("depositNetwork", ""),
+            settle_coin=resp.get("settleCoin", ""),
+            settle_network=resp.get("settleNetwork", ""),
+            settle_address=resp.get("settleAddress", ""),
+            deposit_address=resp["depositAddress"],
+            refund_address=refund_address,
+            wallet_name=wallet_name,
+            status=(resp.get("status") or "waiting").lower(),
+            created_at=datetime.now(UTC).isoformat(),
+            expires_at=resp.get("expiresAt"),
+            deposit_amount=str(resp.get("depositAmount")) if resp.get("depositAmount") is not None else None,
+            settle_amount=str(resp.get("settleAmount")) if resp.get("settleAmount") is not None else None,
+            deposit_min=str(resp.get("depositMin")) if resp.get("depositMin") is not None else None,
+            deposit_max=str(resp.get("depositMax")) if resp.get("depositMax") is not None else None,
+            rate=str(resp.get("rate")) if resp.get("rate") is not None else None,
+            quote_id=quote_id,
+            deposit_memo=resp.get("depositMemo"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+_LIQUID_LBTC_POLICY_ASSET = (
+    "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d"
+)
+
+
+def _decimal_to_sats(decimal_str: str | float | int) -> int:
+    """Convert a SideShift human-readable amount (e.g. "0.0005") to integer sats.
+
+    SideShift uses decimal strings to preserve precision; our wallet APIs
+    take integer sats (1 sat = 1e-8 of the asset). 8 decimal places is the
+    standard for both BTC and Liquid assets we care about.
+    """
+    from decimal import Decimal, ROUND_HALF_UP
+
+    d = Decimal(str(decimal_str))
+    sats = (d * Decimal(100_000_000)).quantize(Decimal("1."), rounding=ROUND_HALF_UP)
+    return int(sats)

--- a/src/aqua/sideshift.py
+++ b/src/aqua/sideshift.py
@@ -507,10 +507,13 @@ def recommend_shift_or_swap(
 
 # SideShift returns one of these statuses (lowercase). We surface them as-is
 # but expose `is_final` and `is_success` helpers so callers don't have to
-# memorise the state machine.
-_FINAL_STATUSES = {"settled", "refunded", "expired"}
+# memorise the state machine. `"failed"` is locally minted by `send_shift`
+# when the deposit broadcast itself raises — the order exists on SideShift
+# but the wallet never funded it, so the shift is terminally dead from our
+# side and should be reported as final + failed.
+_FINAL_STATUSES = {"settled", "refunded", "expired", "failed"}
 _SUCCESS_STATUSES = {"settled"}
-_FAILED_STATUSES = {"refunded", "expired"}
+_FAILED_STATUSES = {"refunded", "expired", "failed"}
 
 
 def shift_is_final(status: str) -> bool:

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -83,6 +83,7 @@ class Storage:
         self.swaps_dir = self.base_dir / "swaps"
         self.ankara_swaps_dir = self.base_dir / "ankara_swaps"
         self.lightning_swaps_dir = self.base_dir / "lightning_swaps"
+        self.sideshift_shifts_dir = self.base_dir / "sideshift_shifts"
         self.config_path = self.base_dir / "config.json"
         self._ensure_dirs()
 
@@ -100,6 +101,8 @@ class Storage:
         os.chmod(self.ankara_swaps_dir, 0o700)
         self.lightning_swaps_dir.mkdir(exist_ok=True, mode=0o700)
         os.chmod(self.lightning_swaps_dir, 0o700)
+        self.sideshift_shifts_dir.mkdir(exist_ok=True, mode=0o700)
+        os.chmod(self.sideshift_shifts_dir, 0o700)
 
     def _derive_key(self, password: str, salt: bytes) -> bytes:
         """Derive encryption key from password."""
@@ -329,6 +332,40 @@ class Storage:
         return [
             p.stem
             for p in self.lightning_swaps_dir.glob("*.json")
+            if SWAP_ID_PATTERN.fullmatch(p.stem)
+        ]
+
+    # SideShift shift operations
+
+    def _sideshift_shift_path(self, shift_id: str) -> Path:
+        """Get path to SideShift shift file, validating the ID to prevent path traversal."""
+        if not SWAP_ID_PATTERN.fullmatch(shift_id):
+            raise ValueError(
+                f"Invalid SideShift shift ID '{shift_id}'. "
+                "Use only letters, numbers, hyphens and underscores (max 128 chars)."
+            )
+        return self.sideshift_shifts_dir / f"{shift_id}.json"
+
+    def save_sideshift_shift(self, shift) -> None:
+        """Save SideShift shift data for recovery."""
+        path = self._sideshift_shift_path(shift.shift_id)
+        self._atomic_write_json(path, shift.to_dict())
+
+    def load_sideshift_shift(self, shift_id: str):
+        """Load SideShift shift data. Returns SideShiftShift or None."""
+        from .sideshift import SideShiftShift
+
+        path = self._sideshift_shift_path(shift_id)
+        if not path.exists():
+            return None
+        with open(path) as f:
+            return SideShiftShift.from_dict(json.load(f))
+
+    def list_sideshift_shifts(self) -> list[str]:
+        """List all SideShift shift IDs."""
+        return [
+            p.stem
+            for p in self.sideshift_shifts_dir.glob("*.json")
             if SWAP_ID_PATTERN.fullmatch(p.stem)
         ]
 

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -1037,7 +1037,9 @@ def sideshift_recommend(
         to_network: settle network
 
     Returns:
-        recommendation ("sideswap" | "sideshift"), reason, plus the input fields.
+        recommendation ("sideswap" | "sideshift" | "none"), reason, plus the
+        input fields. "none" is returned when both legs are the same
+        (coin, network) — there's nothing to swap.
     """
     from .sideshift import recommend_shift_or_swap
 

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -856,6 +856,7 @@ def sideshift_send(
     liquid_asset_id: str | None = None,
     settle_memo: str | None = None,
     refund_memo: str | None = None,
+    quote_id: str | None = None,
 ) -> dict[str, Any]:
     """Send funds from our wallet via a SideShift fixed-rate shift.
 
@@ -886,6 +887,11 @@ def sideshift_send(
         liquid_asset_id: required when deposit is a non-L-BTC Liquid asset
             (e.g. USDt-Liquid: pass the asset id hex)
         settle_memo / refund_memo: required for memo networks (TON, BNB, etc.)
+        quote_id: optional fixed-rate quote id from a prior `sideshift_quote`
+            call. Pass `preview["id"]` after the user confirms the preview to
+            ensure the shift executes at the rate the user just saw. Without
+            it, sideshift_send fetches a fresh quote — fine for non-interactive
+            flows, but the rate may have moved since any earlier preview.
 
     Returns:
         shift_id, deposit_hash (txid we broadcast), deposit_address,
@@ -904,6 +910,7 @@ def sideshift_send(
         liquid_asset_id=liquid_asset_id,
         settle_memo=settle_memo,
         refund_memo=refund_memo,
+        quote_id=quote_id,
     )
     return shift.to_dict()
 

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -28,6 +28,7 @@ EXPLORER_URLS = {
 _manager: WalletManager | None = None
 _btc_manager: BitcoinWalletManager | None = None
 _lightning_manager: "LightningManager | None" = None
+_sideshift_manager: "SideShiftManager | None" = None
 
 
 def get_manager() -> WalletManager:
@@ -57,6 +58,20 @@ def get_lightning_manager() -> "LightningManager":
             wallet_manager=get_manager(),
         )
     return _lightning_manager
+
+
+def get_sideshift_manager() -> "SideShiftManager":
+    """Get or create SideShift manager (shares storage + wallet managers)."""
+    global _sideshift_manager
+    if _sideshift_manager is None:
+        from .sideshift import SideShiftManager
+
+        _sideshift_manager = SideShiftManager(
+            storage=get_manager().storage,
+            wallet_manager=get_manager(),
+            btc_wallet_manager=get_btc_manager(),
+        )
+    return _sideshift_manager
 
 
 # Tool implementations
@@ -751,6 +766,240 @@ def lightning_transaction_status(swap_id: str) -> dict[str, Any]:
     return manager.get_swap_status(swap_id)
 
 
+# ---------------------------------------------------------------------------
+# SideShift (custodial cross-chain swaps via sideshift.ai)
+# ---------------------------------------------------------------------------
+
+
+def sideshift_list_coins() -> dict[str, Any]:
+    """List the coins and networks SideShift supports.
+
+    Use this to discover valid (coin, network) identifiers for the other
+    SideShift tools. Returns the SideShift response unchanged — each entry
+    has `coin`, `name`, `networks`, `hasMemo` (whether deposits to that
+    chain need a memo), `fixedOnly`/`variableOnly`, etc.
+
+    Returns:
+        coins: list of {coin, name, networks, hasMemo, ...}
+        count: number of entries
+    """
+    coins = get_sideshift_manager().list_coins()
+    return {"coins": coins, "count": len(coins)}
+
+
+def sideshift_pair_info(
+    from_coin: str,
+    from_network: str,
+    to_coin: str,
+    to_network: str,
+    amount: str | None = None,
+) -> dict[str, Any]:
+    """Get rate / min / max for a SideShift pair.
+
+    Args:
+        from_coin: Deposit coin ticker (case-insensitive, e.g. "USDT")
+        from_network: Deposit network (case-insensitive, e.g. "tron", "liquid", "bitcoin", "ethereum")
+        to_coin: Settle coin ticker
+        to_network: Settle network
+        amount: Optional reference amount in deposit-coin units (decimal string).
+            Default reference is approximately $500 USD if omitted.
+
+    Returns:
+        rate (string), min (string), max (string), depositCoin, settleCoin,
+        depositNetwork, settleNetwork
+    """
+    return get_sideshift_manager().pair_info(
+        from_coin, from_network, to_coin, to_network, amount=amount
+    )
+
+
+def sideshift_quote(
+    deposit_coin: str,
+    deposit_network: str,
+    settle_coin: str,
+    settle_network: str,
+    deposit_amount: str | None = None,
+    settle_amount: str | None = None,
+) -> dict[str, Any]:
+    """Request a fixed-rate quote (~15 minute TTL).
+
+    Provide exactly one of `deposit_amount` (user is sending X) or
+    `settle_amount` (user wants to receive exactly X). Amounts are decimal
+    strings to preserve precision.
+
+    Returns:
+        SideShift's quote response: {id, expiresAt, depositAmount,
+        settleAmount, rate, ...}.
+
+    Use this BEFORE `sideshift_send` to confirm the quote with the user.
+    """
+    return get_sideshift_manager().quote(
+        deposit_coin=deposit_coin,
+        deposit_network=deposit_network,
+        settle_coin=settle_coin,
+        settle_network=settle_network,
+        deposit_amount=deposit_amount,
+        settle_amount=settle_amount,
+    )
+
+
+def sideshift_send(
+    deposit_coin: str,
+    deposit_network: str,
+    settle_coin: str,
+    settle_network: str,
+    settle_address: str,
+    deposit_amount: str | None = None,
+    settle_amount: str | None = None,
+    wallet_name: str = "default",
+    password: str | None = None,
+    liquid_asset_id: str | None = None,
+    settle_memo: str | None = None,
+    refund_memo: str | None = None,
+) -> dict[str, Any]:
+    """Send funds from our wallet via a SideShift fixed-rate shift.
+
+    Flow:
+      1. Get a fixed-rate quote (matches the agreed amounts).
+      2. Create the shift; SideShift returns a deposit address on the deposit chain.
+      3. Broadcast the deposit from the local wallet (via lw_send / btc_send / lw_send_asset).
+
+    The deposit chain MUST be one of {bitcoin, liquid} — those are the only
+    chains we can sign on. Both legs (deposit + settle) must also be in the
+    curated pair allowlist mirroring AQUA Flutter: USDt on
+    {ethereum, tron, bsc, solana, polygon, ton, liquid} or BTC on bitcoin.
+    L-BTC (btc-liquid) is excluded — use SideSwap for L-BTC ↔ external.
+    Set `SIDESHIFT_ALLOW_ALL_NETWORKS=1` to bypass.
+
+    A refund address is always set automatically: the wallet's own deposit-
+    chain address, so a stuck shift refunds back to the source.
+
+    Args:
+        deposit_coin: e.g. "btc" (for L-BTC use coin="btc", network="liquid")
+        deposit_network: "bitcoin" | "liquid"
+        settle_coin: any SideShift coin ticker
+        settle_network: any SideShift network
+        settle_address: where SideShift sends the converted asset
+        deposit_amount / settle_amount: provide exactly one, decimal strings
+        wallet_name: local wallet to sign with
+        password: mnemonic decryption password (if encrypted)
+        liquid_asset_id: required when deposit is a non-L-BTC Liquid asset
+            (e.g. USDt-Liquid: pass the asset id hex)
+        settle_memo / refund_memo: required for memo networks (TON, BNB, etc.)
+
+    Returns:
+        shift_id, deposit_hash (txid we broadcast), deposit_address,
+        deposit_amount, settle_amount, rate, status, expires_at
+    """
+    shift = get_sideshift_manager().send_shift(
+        deposit_coin=deposit_coin,
+        deposit_network=deposit_network,
+        settle_coin=settle_coin,
+        settle_network=settle_network,
+        settle_address=settle_address,
+        deposit_amount=deposit_amount,
+        settle_amount=settle_amount,
+        wallet_name=wallet_name,
+        password=password,
+        liquid_asset_id=liquid_asset_id,
+        settle_memo=settle_memo,
+        refund_memo=refund_memo,
+    )
+    return shift.to_dict()
+
+
+def sideshift_receive(
+    deposit_coin: str,
+    deposit_network: str,
+    settle_coin: str,
+    settle_network: str,
+    wallet_name: str = "default",
+    external_refund_address: str | None = None,
+    external_refund_memo: str | None = None,
+    settle_memo: str | None = None,
+) -> dict[str, Any]:
+    """Receive into our wallet via a SideShift variable-rate shift.
+
+    SideShift returns a deposit address on the deposit chain. The user (or
+    external sender) sends to that address from any wallet/chain. The rate
+    is set when the deposit confirms; SideShift settles to the wallet's
+    Liquid or Bitcoin address.
+
+    The settle chain MUST be one of {bitcoin, liquid} — those are the only
+    chains we hold addresses for. Both legs (deposit + settle) must also be
+    in the curated pair allowlist mirroring AQUA Flutter: USDt on
+    {ethereum, tron, bsc, solana, polygon, ton, liquid} or BTC on bitcoin.
+    Set `SIDESHIFT_ALLOW_ALL_NETWORKS=1` to bypass.
+
+    Args:
+        deposit_coin: any SideShift coin (e.g. "USDT")
+        deposit_network: any SideShift network (e.g. "tron", "ethereum")
+        settle_coin: "btc" or "usdt" (for Liquid: settle_network="liquid"; for Bitcoin mainchain: settle_network="bitcoin")
+        settle_network: "bitcoin" | "liquid"
+        wallet_name: local wallet to receive into
+        external_refund_address: STRONGLY RECOMMENDED — where SideShift
+            refunds if the deposit fails. Without one a stuck shift requires
+            manual web UI intervention.
+
+    Returns:
+        shift_id, deposit_address, deposit_min, deposit_max, deposit_memo
+        (if applicable), settle_address, status, expires_at
+    """
+    shift = get_sideshift_manager().receive_shift(
+        deposit_coin=deposit_coin,
+        deposit_network=deposit_network,
+        settle_coin=settle_coin,
+        settle_network=settle_network,
+        wallet_name=wallet_name,
+        external_refund_address=external_refund_address,
+        external_refund_memo=external_refund_memo,
+        settle_memo=settle_memo,
+    )
+    return shift.to_dict()
+
+
+def sideshift_status(shift_id: str) -> dict[str, Any]:
+    """Check the status of a SideShift shift order.
+
+    Pings SideShift, refreshes the persisted record, and returns the latest
+    state. Status values (lowercase): waiting, pending, processing, settling,
+    settled, refund, refunding, refunded, expired, review, multiple.
+
+    Returns the full shift record plus `is_final`, `is_success`, `is_failed`
+    so callers don't need to memorise the state machine.
+
+    Args:
+        shift_id: ID returned from sideshift_send or sideshift_receive
+    """
+    return get_sideshift_manager().status(shift_id)
+
+
+def sideshift_recommend(
+    from_coin: str,
+    from_network: str,
+    to_coin: str,
+    to_network: str,
+) -> dict[str, Any]:
+    """Recommend SideSwap vs SideShift for a cross-asset conversion.
+
+    SideSwap is preferred when both legs are on Bitcoin or Liquid (atomic /
+    near-trustless, lower fees). SideShift is the fallback when at least one
+    leg is on a non-Liquid chain (Ethereum, Tron, etc.).
+
+    Args:
+        from_coin: deposit coin ticker (case-insensitive)
+        from_network: deposit network (e.g. "tron", "liquid")
+        to_coin: settle coin ticker
+        to_network: settle network
+
+    Returns:
+        recommendation ("sideswap" | "sideshift"), reason, plus the input fields.
+    """
+    from .sideshift import recommend_shift_or_swap
+
+    return recommend_shift_or_swap(from_coin, from_network, to_coin, to_network)
+
+
 # Tool registry for MCP
 TOOLS = {
     "lw_generate_mnemonic": lw_generate_mnemonic,
@@ -776,4 +1025,11 @@ TOOLS = {
     "lightning_receive": lightning_receive,
     "lightning_send": lightning_send,
     "lightning_transaction_status": lightning_transaction_status,
+    "sideshift_list_coins": sideshift_list_coins,
+    "sideshift_pair_info": sideshift_pair_info,
+    "sideshift_quote": sideshift_quote,
+    "sideshift_send": sideshift_send,
+    "sideshift_receive": sideshift_receive,
+    "sideshift_status": sideshift_status,
+    "sideshift_recommend": sideshift_recommend,
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -759,226 +759,6 @@ class TestLightningCommands:
 
 
 # ---------------------------------------------------------------------------
-# SideShift CLI
-# ---------------------------------------------------------------------------
-
-
-class _FakeSideShiftManager:
-    """Stand-in for SideShiftManager — records calls, returns canned dicts."""
-
-    def __init__(self):
-        self.calls: list[tuple[str, dict]] = []
-        self.coins_response = [
-            {"coin": "BTC", "name": "Bitcoin", "networks": ["bitcoin", "liquid"]}
-        ]
-        self.pair_response = {
-            "rate": "20000",
-            "min": "0.0001",
-            "max": "1.0",
-            "depositCoin": "USDT",
-            "settleCoin": "BTC",
-            "depositNetwork": "tron",
-            "settleNetwork": "bitcoin",
-        }
-        self.quote_response = {
-            "id": "q_test",
-            "depositAmount": "100",
-            "settleAmount": "0.005",
-            "rate": "20000",
-            "expiresAt": "2026-05-08T12:15:00Z",
-        }
-        self.send_response = None
-        self.receive_response = None
-        self.status_response = None
-
-    def list_coins(self):
-        self.calls.append(("list_coins", {}))
-        return self.coins_response
-
-    def pair_info(self, from_coin, from_network, to_coin, to_network, amount=None):
-        self.calls.append(("pair_info", {
-            "from_coin": from_coin, "from_network": from_network,
-            "to_coin": to_coin, "to_network": to_network, "amount": amount,
-        }))
-        return self.pair_response
-
-    def quote(self, **kwargs):
-        self.calls.append(("quote", kwargs))
-        return self.quote_response
-
-    def send_shift(self, **kwargs):
-        from aqua.sideshift import SideShiftShift
-
-        self.calls.append(("send_shift", kwargs))
-        if self.send_response is not None:
-            return self.send_response
-        return SideShiftShift(
-            shift_id="shift_send",
-            shift_type="fixed",
-            direction="send",
-            deposit_coin=kwargs["deposit_coin"].upper(),
-            deposit_network=kwargs["deposit_network"].lower(),
-            settle_coin=kwargs["settle_coin"].upper(),
-            settle_network=kwargs["settle_network"].lower(),
-            settle_address=kwargs["settle_address"],
-            deposit_address="lq1qdeposit",
-            refund_address="lq1qrefund",
-            wallet_name=kwargs["wallet_name"],
-            status="waiting",
-            created_at="2026-05-08T12:00:00+00:00",
-            deposit_amount=kwargs.get("deposit_amount"),
-            settle_amount=kwargs.get("settle_amount"),
-            deposit_hash="lqtxid" + ("0" * 58),
-        )
-
-    def receive_shift(self, **kwargs):
-        from aqua.sideshift import SideShiftShift
-
-        self.calls.append(("receive_shift", kwargs))
-        if self.receive_response is not None:
-            return self.receive_response
-        return SideShiftShift(
-            shift_id="shift_recv",
-            shift_type="variable",
-            direction="receive",
-            deposit_coin=kwargs["deposit_coin"].upper(),
-            deposit_network=kwargs["deposit_network"].lower(),
-            settle_coin=kwargs["settle_coin"].upper(),
-            settle_network=kwargs["settle_network"].lower(),
-            settle_address="lq1qreceive",
-            deposit_address="TXdepositAddr",
-            refund_address=kwargs.get("external_refund_address"),
-            wallet_name=kwargs["wallet_name"],
-            status="waiting",
-            created_at="2026-05-08T12:00:00+00:00",
-            deposit_min="10",
-            deposit_max="10000",
-        )
-
-    def status(self, shift_id):
-        self.calls.append(("status", {"shift_id": shift_id}))
-        if self.status_response is not None:
-            return {**self.status_response, "shift_id": shift_id}
-        return {
-            "shift_id": shift_id,
-            "status": "settled",
-            "is_final": True,
-            "is_success": True,
-            "is_failed": False,
-        }
-
-
-@pytest.fixture
-def sideshift_manager():
-    """Inject a fake SideShiftManager into the global tool layer."""
-    import aqua.tools as tools_module
-
-    fake = _FakeSideShiftManager()
-    saved = tools_module._sideshift_manager
-    tools_module._sideshift_manager = fake
-    try:
-        yield fake
-    finally:
-        tools_module._sideshift_manager = saved
-
-
-class TestSideShiftCoins:
-    def test_coins_returns_list(self, runner, sideshift_manager):
-        result = runner.invoke(cli, ["--format", "json", "sideshift", "coins"])
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["count"] == 1
-        assert data["coins"][0]["coin"] == "BTC"
-        assert sideshift_manager.calls[-1][0] == "list_coins"
-
-
-class TestSideShiftPairInfo:
-    def test_pair_info_passes_args(self, runner, sideshift_manager):
-        result = runner.invoke(
-            cli,
-            ["--format", "json", "sideshift", "pair-info",
-             "--from-coin", "USDT", "--from-network", "tron",
-             "--to-coin", "BTC", "--to-network", "bitcoin",
-             "--amount", "100"],
-        )
-        assert result.exit_code == 0
-        last = sideshift_manager.calls[-1]
-        assert last[0] == "pair_info"
-        assert last[1] == {
-            "from_coin": "USDT", "from_network": "tron",
-            "to_coin": "BTC", "to_network": "bitcoin", "amount": "100",
-        }
-
-
-class TestSideShiftQuote:
-    def test_quote_requires_exactly_one_amount(self, runner):
-        result = runner.invoke(
-            cli,
-            ["sideshift", "quote",
-             "--deposit-coin", "USDT", "--deposit-network", "liquid",
-             "--settle-coin", "BTC", "--settle-network", "bitcoin"],
-        )
-        assert result.exit_code == 2
-
-    def test_quote_rejects_both_amounts(self, runner):
-        result = runner.invoke(
-            cli,
-            ["sideshift", "quote",
-             "--deposit-coin", "USDT", "--deposit-network", "liquid",
-             "--settle-coin", "BTC", "--settle-network", "bitcoin",
-             "--deposit-amount", "100", "--settle-amount", "0.001"],
-        )
-        assert result.exit_code == 2
-
-    def test_quote_passes_deposit_amount(self, runner, sideshift_manager):
-        result = runner.invoke(
-            cli,
-            ["--format", "json", "sideshift", "quote",
-             "--deposit-coin", "USDT", "--deposit-network", "liquid",
-             "--settle-coin", "BTC", "--settle-network", "bitcoin",
-             "--deposit-amount", "100"],
-        )
-        assert result.exit_code == 0
-        last = sideshift_manager.calls[-1]
-        assert last[0] == "quote"
-        assert last[1]["deposit_amount"] == "100"
-        assert last[1]["settle_amount"] is None
-
-
-class TestSideShiftRecommend:
-    def test_btc_to_lbtc_recommends_sideswap(self, runner):
-        result = runner.invoke(
-            cli,
-            ["--format", "json", "sideshift", "recommend",
-             "--from-coin", "btc", "--from-network", "bitcoin",
-             "--to-coin", "btc", "--to-network", "liquid"],
-        )
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["recommendation"] == "sideswap"
-
-    def test_usdt_liquid_to_usdt_tron_recommends_sideshift(self, runner):
-        result = runner.invoke(
-            cli,
-            ["--format", "json", "sideshift", "recommend",
-             "--from-coin", "usdt", "--from-network", "liquid",
-             "--to-coin", "usdt", "--to-network", "tron"],
-        )
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["recommendation"] == "sideshift"
-
-
-class TestSideShiftSend:
-    def test_send_with_yes_flag_skips_quote_prompt(self, runner, sideshift_manager):
-        result = runner.invoke(
-            cli,
-            ["--format", "json", "sideshift", "send",
-             "--deposit-coin", "btc", "--deposit-network", "liquid",
-             "--settle-coin", "usdt", "--settle-network", "tron",
-             "--settle-address", "TXYZ",
-             "--deposit-amount", "0.0005",
-             "--yes"],
 # SideSwap CLI
 # ---------------------------------------------------------------------------
 
@@ -1224,73 +1004,6 @@ class TestSideSwapPegIn:
         )
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["shift_id"] == "shift_send"
-        # Manager was called with the right kwargs
-        send_call = next(c for c in sideshift_manager.calls if c[0] == "send_shift")
-        assert send_call[1]["deposit_amount"] == "0.0005"
-        assert send_call[1]["settle_address"] == "TXYZ"
-
-    def test_send_amount_validation(self, runner):
-        # Neither amount → rejected
-        result = runner.invoke(
-            cli,
-            ["sideshift", "send",
-             "--deposit-coin", "btc", "--deposit-network", "liquid",
-             "--settle-coin", "usdt", "--settle-network", "tron",
-             "--settle-address", "TXYZ", "--yes"],
-        )
-        assert result.exit_code == 2
-
-    def test_send_rejects_non_native_deposit_network(self, runner):
-        # Click validates the choice before the manager is called
-        result = runner.invoke(
-            cli,
-            ["sideshift", "send",
-             "--deposit-coin", "usdt", "--deposit-network", "tron",
-             "--settle-coin", "btc", "--settle-network", "liquid",
-             "--settle-address", "lq1qfoo",
-             "--deposit-amount", "100", "--yes"],
-        )
-        assert result.exit_code == 2
-
-    def test_send_passes_liquid_asset_id(self, runner, sideshift_manager):
-        result = runner.invoke(
-            cli,
-            ["--format", "json", "sideshift", "send",
-             "--deposit-coin", "usdt", "--deposit-network", "liquid",
-             "--settle-coin", "usdt", "--settle-network", "tron",
-             "--settle-address", "TXYZ",
-             "--deposit-amount", "100",
-             "--liquid-asset-id", "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2",
-             "--yes"],
-            env=_cli_env(),
-        )
-        assert result.exit_code == 0
-        send_call = next(c for c in sideshift_manager.calls if c[0] == "send_shift")
-        assert send_call[1]["liquid_asset_id"].startswith("ce091c99")
-
-
-class TestSideShiftReceive:
-    def test_receive_into_liquid(self, runner, sideshift_manager):
-        result = runner.invoke(
-            cli,
-            ["--format", "json", "sideshift", "receive",
-             "--deposit-coin", "usdt", "--deposit-network", "tron",
-             "--settle-coin", "usdt", "--settle-network", "liquid",
-             "--external-refund-address", "TXrefund"],
-        )
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["shift_id"] == "shift_recv"
-        assert data["deposit_address"] == "TXdepositAddr"
-        assert data["refund_address"] == "TXrefund"
-
-    def test_receive_rejects_non_native_settle_network(self, runner):
-        result = runner.invoke(
-            cli,
-            ["sideshift", "receive",
-             "--deposit-coin", "usdt", "--deposit-network", "tron",
-             "--settle-coin", "usdt", "--settle-network", "ethereum"],
         assert data["peg_addr"] == "bc1qdeposit"
         assert data["recv_addr"] == "lq1qreceive"
         assert "order_id" in data
@@ -1337,17 +1050,6 @@ class TestSideSwapPegOut:
         assert result.exit_code == 2
 
 
-class TestSideShiftStatus:
-    def test_status_passes_shift_id(self, runner, sideshift_manager):
-        result = runner.invoke(
-            cli,
-            ["--format", "json", "sideshift", "status", "--shift-id", "shift_xyz"],
-        )
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["shift_id"] == "shift_xyz"
-        assert data["is_final"] is True
-        assert sideshift_manager.calls[-1] == ("status", {"shift_id": "shift_xyz"})
 class TestSideSwapPegStatus:
     def test_peg_status_passes_order_id(self, runner, sideswap_managers):
         peg, _ = sideswap_managers
@@ -1478,6 +1180,316 @@ class TestSideSwapSwap:
         data = json.loads(result.output)
         assert data["order_id"] == "mkt_77"
         assert swap.calls[-1] == ("status", {"order_id": "mkt_77"})
+
+
+# ---------------------------------------------------------------------------
+# SideShift CLI
+# ---------------------------------------------------------------------------
+
+
+class _FakeSideShiftManager:
+    """Stand-in for SideShiftManager — records calls, returns canned dicts."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+        self.coins_response = [
+            {"coin": "BTC", "name": "Bitcoin", "networks": ["bitcoin", "liquid"]}
+        ]
+        self.pair_response = {
+            "rate": "20000",
+            "min": "0.0001",
+            "max": "1.0",
+            "depositCoin": "USDT",
+            "settleCoin": "BTC",
+            "depositNetwork": "tron",
+            "settleNetwork": "bitcoin",
+        }
+        self.quote_response = {
+            "id": "q_test",
+            "depositAmount": "100",
+            "settleAmount": "0.005",
+            "rate": "20000",
+            "expiresAt": "2026-05-08T12:15:00Z",
+        }
+        self.send_response = None
+        self.receive_response = None
+        self.status_response = None
+
+    def list_coins(self):
+        self.calls.append(("list_coins", {}))
+        return self.coins_response
+
+    def pair_info(self, from_coin, from_network, to_coin, to_network, amount=None):
+        self.calls.append(("pair_info", {
+            "from_coin": from_coin, "from_network": from_network,
+            "to_coin": to_coin, "to_network": to_network, "amount": amount,
+        }))
+        return self.pair_response
+
+    def quote(self, **kwargs):
+        self.calls.append(("quote", kwargs))
+        return self.quote_response
+
+    def send_shift(self, **kwargs):
+        from aqua.sideshift import SideShiftShift
+
+        self.calls.append(("send_shift", kwargs))
+        if self.send_response is not None:
+            return self.send_response
+        return SideShiftShift(
+            shift_id="shift_send",
+            shift_type="fixed",
+            direction="send",
+            deposit_coin=kwargs["deposit_coin"].upper(),
+            deposit_network=kwargs["deposit_network"].lower(),
+            settle_coin=kwargs["settle_coin"].upper(),
+            settle_network=kwargs["settle_network"].lower(),
+            settle_address=kwargs["settle_address"],
+            deposit_address="lq1qdeposit",
+            refund_address="lq1qrefund",
+            wallet_name=kwargs["wallet_name"],
+            status="waiting",
+            created_at="2026-05-08T12:00:00+00:00",
+            deposit_amount=kwargs.get("deposit_amount"),
+            settle_amount=kwargs.get("settle_amount"),
+            deposit_hash="lqtxid" + ("0" * 58),
+        )
+
+    def receive_shift(self, **kwargs):
+        from aqua.sideshift import SideShiftShift
+
+        self.calls.append(("receive_shift", kwargs))
+        if self.receive_response is not None:
+            return self.receive_response
+        return SideShiftShift(
+            shift_id="shift_recv",
+            shift_type="variable",
+            direction="receive",
+            deposit_coin=kwargs["deposit_coin"].upper(),
+            deposit_network=kwargs["deposit_network"].lower(),
+            settle_coin=kwargs["settle_coin"].upper(),
+            settle_network=kwargs["settle_network"].lower(),
+            settle_address="lq1qreceive",
+            deposit_address="TXdepositAddr",
+            refund_address=kwargs.get("external_refund_address"),
+            wallet_name=kwargs["wallet_name"],
+            status="waiting",
+            created_at="2026-05-08T12:00:00+00:00",
+            deposit_min="10",
+            deposit_max="10000",
+        )
+
+    def status(self, shift_id):
+        self.calls.append(("status", {"shift_id": shift_id}))
+        if self.status_response is not None:
+            return {**self.status_response, "shift_id": shift_id}
+        return {
+            "shift_id": shift_id,
+            "status": "settled",
+            "is_final": True,
+            "is_success": True,
+            "is_failed": False,
+        }
+
+
+@pytest.fixture
+def sideshift_manager():
+    """Inject a fake SideShiftManager into the global tool layer."""
+    import aqua.tools as tools_module
+
+    fake = _FakeSideShiftManager()
+    saved = tools_module._sideshift_manager
+    tools_module._sideshift_manager = fake
+    try:
+        yield fake
+    finally:
+        tools_module._sideshift_manager = saved
+
+
+class TestSideShiftCoins:
+    def test_coins_returns_list(self, runner, sideshift_manager):
+        result = runner.invoke(cli, ["--format", "json", "sideshift", "coins"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["count"] == 1
+        assert data["coins"][0]["coin"] == "BTC"
+        assert sideshift_manager.calls[-1][0] == "list_coins"
+
+
+class TestSideShiftPairInfo:
+    def test_pair_info_passes_args(self, runner, sideshift_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "pair-info",
+             "--from-coin", "USDT", "--from-network", "tron",
+             "--to-coin", "BTC", "--to-network", "bitcoin",
+             "--amount", "100"],
+        )
+        assert result.exit_code == 0
+        last = sideshift_manager.calls[-1]
+        assert last[0] == "pair_info"
+        assert last[1] == {
+            "from_coin": "USDT", "from_network": "tron",
+            "to_coin": "BTC", "to_network": "bitcoin", "amount": "100",
+        }
+
+
+class TestSideShiftQuote:
+    def test_quote_requires_exactly_one_amount(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideshift", "quote",
+             "--deposit-coin", "USDT", "--deposit-network", "liquid",
+             "--settle-coin", "BTC", "--settle-network", "bitcoin"],
+        )
+        assert result.exit_code == 2
+
+    def test_quote_rejects_both_amounts(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideshift", "quote",
+             "--deposit-coin", "USDT", "--deposit-network", "liquid",
+             "--settle-coin", "BTC", "--settle-network", "bitcoin",
+             "--deposit-amount", "100", "--settle-amount", "0.001"],
+        )
+        assert result.exit_code == 2
+
+    def test_quote_passes_deposit_amount(self, runner, sideshift_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "quote",
+             "--deposit-coin", "USDT", "--deposit-network", "liquid",
+             "--settle-coin", "BTC", "--settle-network", "bitcoin",
+             "--deposit-amount", "100"],
+        )
+        assert result.exit_code == 0
+        last = sideshift_manager.calls[-1]
+        assert last[0] == "quote"
+        assert last[1]["deposit_amount"] == "100"
+        assert last[1]["settle_amount"] is None
+
+
+class TestSideShiftRecommend:
+    def test_btc_to_lbtc_recommends_sideswap(self, runner):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "recommend",
+             "--from-coin", "btc", "--from-network", "bitcoin",
+             "--to-coin", "btc", "--to-network", "liquid"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["recommendation"] == "sideswap"
+
+    def test_usdt_liquid_to_usdt_tron_recommends_sideshift(self, runner):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "recommend",
+             "--from-coin", "usdt", "--from-network", "liquid",
+             "--to-coin", "usdt", "--to-network", "tron"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["recommendation"] == "sideshift"
+
+
+class TestSideShiftSend:
+    def test_send_with_yes_flag_skips_quote_prompt(self, runner, sideshift_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "send",
+             "--deposit-coin", "btc", "--deposit-network", "liquid",
+             "--settle-coin", "usdt", "--settle-network", "tron",
+             "--settle-address", "TXYZ",
+             "--deposit-amount", "0.0005",
+             "--yes"],
+            env=_cli_env(),
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["shift_id"] == "shift_send"
+        # Manager was called with the right kwargs
+        send_call = next(c for c in sideshift_manager.calls if c[0] == "send_shift")
+        assert send_call[1]["deposit_amount"] == "0.0005"
+        assert send_call[1]["settle_address"] == "TXYZ"
+
+    def test_send_amount_validation(self, runner):
+        # Neither amount → rejected
+        result = runner.invoke(
+            cli,
+            ["sideshift", "send",
+             "--deposit-coin", "btc", "--deposit-network", "liquid",
+             "--settle-coin", "usdt", "--settle-network", "tron",
+             "--settle-address", "TXYZ", "--yes"],
+        )
+        assert result.exit_code == 2
+
+    def test_send_rejects_non_native_deposit_network(self, runner):
+        # Click validates the choice before the manager is called
+        result = runner.invoke(
+            cli,
+            ["sideshift", "send",
+             "--deposit-coin", "usdt", "--deposit-network", "tron",
+             "--settle-coin", "btc", "--settle-network", "liquid",
+             "--settle-address", "lq1qfoo",
+             "--deposit-amount", "100", "--yes"],
+        )
+        assert result.exit_code == 2
+
+    def test_send_passes_liquid_asset_id(self, runner, sideshift_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "send",
+             "--deposit-coin", "usdt", "--deposit-network", "liquid",
+             "--settle-coin", "usdt", "--settle-network", "tron",
+             "--settle-address", "TXYZ",
+             "--deposit-amount", "100",
+             "--liquid-asset-id", "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2",
+             "--yes"],
+            env=_cli_env(),
+        )
+        assert result.exit_code == 0
+        send_call = next(c for c in sideshift_manager.calls if c[0] == "send_shift")
+        assert send_call[1]["liquid_asset_id"].startswith("ce091c99")
+
+
+class TestSideShiftReceive:
+    def test_receive_into_liquid(self, runner, sideshift_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "receive",
+             "--deposit-coin", "usdt", "--deposit-network", "tron",
+             "--settle-coin", "usdt", "--settle-network", "liquid",
+             "--external-refund-address", "TXrefund"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["shift_id"] == "shift_recv"
+        assert data["deposit_address"] == "TXdepositAddr"
+        assert data["refund_address"] == "TXrefund"
+
+    def test_receive_rejects_non_native_settle_network(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideshift", "receive",
+             "--deposit-coin", "usdt", "--deposit-network", "tron",
+             "--settle-coin", "usdt", "--settle-network", "ethereum"],
+        )
+        assert result.exit_code == 2
+
+
+class TestSideShiftStatus:
+    def test_status_passes_shift_id(self, runner, sideshift_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "status", "--shift-id", "shift_xyz"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["shift_id"] == "shift_xyz"
+        assert data["is_final"] is True
+        assert sideshift_manager.calls[-1] == ("status", {"shift_id": "shift_xyz"})
+
 
 
 # Error handling

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -758,6 +758,315 @@ class TestLightningCommands:
         assert result.exit_code == 1
 
 
+# ---------------------------------------------------------------------------
+# SideShift CLI
+# ---------------------------------------------------------------------------
+
+
+class _FakeSideShiftManager:
+    """Stand-in for SideShiftManager — records calls, returns canned dicts."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+        self.coins_response = [
+            {"coin": "BTC", "name": "Bitcoin", "networks": ["bitcoin", "liquid"]}
+        ]
+        self.pair_response = {
+            "rate": "20000",
+            "min": "0.0001",
+            "max": "1.0",
+            "depositCoin": "USDT",
+            "settleCoin": "BTC",
+            "depositNetwork": "tron",
+            "settleNetwork": "bitcoin",
+        }
+        self.quote_response = {
+            "id": "q_test",
+            "depositAmount": "100",
+            "settleAmount": "0.005",
+            "rate": "20000",
+            "expiresAt": "2026-05-08T12:15:00Z",
+        }
+        self.send_response = None
+        self.receive_response = None
+        self.status_response = None
+
+    def list_coins(self):
+        self.calls.append(("list_coins", {}))
+        return self.coins_response
+
+    def pair_info(self, from_coin, from_network, to_coin, to_network, amount=None):
+        self.calls.append(("pair_info", {
+            "from_coin": from_coin, "from_network": from_network,
+            "to_coin": to_coin, "to_network": to_network, "amount": amount,
+        }))
+        return self.pair_response
+
+    def quote(self, **kwargs):
+        self.calls.append(("quote", kwargs))
+        return self.quote_response
+
+    def send_shift(self, **kwargs):
+        from aqua.sideshift import SideShiftShift
+
+        self.calls.append(("send_shift", kwargs))
+        if self.send_response is not None:
+            return self.send_response
+        return SideShiftShift(
+            shift_id="shift_send",
+            shift_type="fixed",
+            direction="send",
+            deposit_coin=kwargs["deposit_coin"].upper(),
+            deposit_network=kwargs["deposit_network"].lower(),
+            settle_coin=kwargs["settle_coin"].upper(),
+            settle_network=kwargs["settle_network"].lower(),
+            settle_address=kwargs["settle_address"],
+            deposit_address="lq1qdeposit",
+            refund_address="lq1qrefund",
+            wallet_name=kwargs["wallet_name"],
+            status="waiting",
+            created_at="2026-05-08T12:00:00+00:00",
+            deposit_amount=kwargs.get("deposit_amount"),
+            settle_amount=kwargs.get("settle_amount"),
+            deposit_hash="lqtxid" + ("0" * 58),
+        )
+
+    def receive_shift(self, **kwargs):
+        from aqua.sideshift import SideShiftShift
+
+        self.calls.append(("receive_shift", kwargs))
+        if self.receive_response is not None:
+            return self.receive_response
+        return SideShiftShift(
+            shift_id="shift_recv",
+            shift_type="variable",
+            direction="receive",
+            deposit_coin=kwargs["deposit_coin"].upper(),
+            deposit_network=kwargs["deposit_network"].lower(),
+            settle_coin=kwargs["settle_coin"].upper(),
+            settle_network=kwargs["settle_network"].lower(),
+            settle_address="lq1qreceive",
+            deposit_address="TXdepositAddr",
+            refund_address=kwargs.get("external_refund_address"),
+            wallet_name=kwargs["wallet_name"],
+            status="waiting",
+            created_at="2026-05-08T12:00:00+00:00",
+            deposit_min="10",
+            deposit_max="10000",
+        )
+
+    def status(self, shift_id):
+        self.calls.append(("status", {"shift_id": shift_id}))
+        if self.status_response is not None:
+            return {**self.status_response, "shift_id": shift_id}
+        return {
+            "shift_id": shift_id,
+            "status": "settled",
+            "is_final": True,
+            "is_success": True,
+            "is_failed": False,
+        }
+
+
+@pytest.fixture
+def sideshift_manager():
+    """Inject a fake SideShiftManager into the global tool layer."""
+    import aqua.tools as tools_module
+
+    fake = _FakeSideShiftManager()
+    saved = tools_module._sideshift_manager
+    tools_module._sideshift_manager = fake
+    try:
+        yield fake
+    finally:
+        tools_module._sideshift_manager = saved
+
+
+class TestSideShiftCoins:
+    def test_coins_returns_list(self, runner, sideshift_manager):
+        result = runner.invoke(cli, ["--format", "json", "sideshift", "coins"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["count"] == 1
+        assert data["coins"][0]["coin"] == "BTC"
+        assert sideshift_manager.calls[-1][0] == "list_coins"
+
+
+class TestSideShiftPairInfo:
+    def test_pair_info_passes_args(self, runner, sideshift_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "pair-info",
+             "--from-coin", "USDT", "--from-network", "tron",
+             "--to-coin", "BTC", "--to-network", "bitcoin",
+             "--amount", "100"],
+        )
+        assert result.exit_code == 0
+        last = sideshift_manager.calls[-1]
+        assert last[0] == "pair_info"
+        assert last[1] == {
+            "from_coin": "USDT", "from_network": "tron",
+            "to_coin": "BTC", "to_network": "bitcoin", "amount": "100",
+        }
+
+
+class TestSideShiftQuote:
+    def test_quote_requires_exactly_one_amount(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideshift", "quote",
+             "--deposit-coin", "USDT", "--deposit-network", "liquid",
+             "--settle-coin", "BTC", "--settle-network", "bitcoin"],
+        )
+        assert result.exit_code == 2
+
+    def test_quote_rejects_both_amounts(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideshift", "quote",
+             "--deposit-coin", "USDT", "--deposit-network", "liquid",
+             "--settle-coin", "BTC", "--settle-network", "bitcoin",
+             "--deposit-amount", "100", "--settle-amount", "0.001"],
+        )
+        assert result.exit_code == 2
+
+    def test_quote_passes_deposit_amount(self, runner, sideshift_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "quote",
+             "--deposit-coin", "USDT", "--deposit-network", "liquid",
+             "--settle-coin", "BTC", "--settle-network", "bitcoin",
+             "--deposit-amount", "100"],
+        )
+        assert result.exit_code == 0
+        last = sideshift_manager.calls[-1]
+        assert last[0] == "quote"
+        assert last[1]["deposit_amount"] == "100"
+        assert last[1]["settle_amount"] is None
+
+
+class TestSideShiftRecommend:
+    def test_btc_to_lbtc_recommends_sideswap(self, runner):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "recommend",
+             "--from-coin", "btc", "--from-network", "bitcoin",
+             "--to-coin", "btc", "--to-network", "liquid"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["recommendation"] == "sideswap"
+
+    def test_usdt_liquid_to_usdt_tron_recommends_sideshift(self, runner):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "recommend",
+             "--from-coin", "usdt", "--from-network", "liquid",
+             "--to-coin", "usdt", "--to-network", "tron"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["recommendation"] == "sideshift"
+
+
+class TestSideShiftSend:
+    def test_send_with_yes_flag_skips_quote_prompt(self, runner, sideshift_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "send",
+             "--deposit-coin", "btc", "--deposit-network", "liquid",
+             "--settle-coin", "usdt", "--settle-network", "tron",
+             "--settle-address", "TXYZ",
+             "--deposit-amount", "0.0005",
+             "--yes"],
+            env=_cli_env(),
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["shift_id"] == "shift_send"
+        # Manager was called with the right kwargs
+        send_call = next(c for c in sideshift_manager.calls if c[0] == "send_shift")
+        assert send_call[1]["deposit_amount"] == "0.0005"
+        assert send_call[1]["settle_address"] == "TXYZ"
+
+    def test_send_amount_validation(self, runner):
+        # Neither amount → rejected
+        result = runner.invoke(
+            cli,
+            ["sideshift", "send",
+             "--deposit-coin", "btc", "--deposit-network", "liquid",
+             "--settle-coin", "usdt", "--settle-network", "tron",
+             "--settle-address", "TXYZ", "--yes"],
+        )
+        assert result.exit_code == 2
+
+    def test_send_rejects_non_native_deposit_network(self, runner):
+        # Click validates the choice before the manager is called
+        result = runner.invoke(
+            cli,
+            ["sideshift", "send",
+             "--deposit-coin", "usdt", "--deposit-network", "tron",
+             "--settle-coin", "btc", "--settle-network", "liquid",
+             "--settle-address", "lq1qfoo",
+             "--deposit-amount", "100", "--yes"],
+        )
+        assert result.exit_code == 2
+
+    def test_send_passes_liquid_asset_id(self, runner, sideshift_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "send",
+             "--deposit-coin", "usdt", "--deposit-network", "liquid",
+             "--settle-coin", "usdt", "--settle-network", "tron",
+             "--settle-address", "TXYZ",
+             "--deposit-amount", "100",
+             "--liquid-asset-id", "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2",
+             "--yes"],
+            env=_cli_env(),
+        )
+        assert result.exit_code == 0
+        send_call = next(c for c in sideshift_manager.calls if c[0] == "send_shift")
+        assert send_call[1]["liquid_asset_id"].startswith("ce091c99")
+
+
+class TestSideShiftReceive:
+    def test_receive_into_liquid(self, runner, sideshift_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "receive",
+             "--deposit-coin", "usdt", "--deposit-network", "tron",
+             "--settle-coin", "usdt", "--settle-network", "liquid",
+             "--external-refund-address", "TXrefund"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["shift_id"] == "shift_recv"
+        assert data["deposit_address"] == "TXdepositAddr"
+        assert data["refund_address"] == "TXrefund"
+
+    def test_receive_rejects_non_native_settle_network(self, runner):
+        result = runner.invoke(
+            cli,
+            ["sideshift", "receive",
+             "--deposit-coin", "usdt", "--deposit-network", "tron",
+             "--settle-coin", "usdt", "--settle-network", "ethereum"],
+        )
+        assert result.exit_code == 2
+
+
+class TestSideShiftStatus:
+    def test_status_passes_shift_id(self, runner, sideshift_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "sideshift", "status", "--shift-id", "shift_xyz"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["shift_id"] == "shift_xyz"
+        assert data["is_final"] is True
+        assert sideshift_manager.calls[-1] == ("status", {"shift_id": "shift_xyz"})
+
+
 # Error handling
 
 

--- a/tests/test_sideshift.py
+++ b/tests/test_sideshift.py
@@ -18,8 +18,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from aqua.sideshift import (
+    AFFILIATE_ID,
     ALLOWED_PAIRS,
-    DEFAULT_AFFILIATE_ID,
     SideShiftClient,
     SideShiftManager,
     SideShiftShift,
@@ -377,9 +377,9 @@ class TestStorage:
 
 class TestSideShiftClient:
     def test_default_affiliate_id_is_aqua_id(self):
-        # Default to JAN3's AQUA Flutter affiliate ID. Override with env var.
+        # Default to JAN3's AQUA Flutter affiliate ID.
         client = SideShiftClient()
-        assert client.affiliate_id == DEFAULT_AFFILIATE_ID
+        assert client.affiliate_id == AFFILIATE_ID
         assert client.affiliate_id == "PVmPh4Mp3"
 
     def test_explicit_none_affiliate_id_disables_it(self):

--- a/tests/test_sideshift.py
+++ b/tests/test_sideshift.py
@@ -24,7 +24,7 @@ from aqua.sideshift import (
     SideShiftManager,
     SideShiftShift,
     _check_pair_allowed,
-    _decimal_to_sats,
+    _decimal_to_sats_8dp,
     recommend_shift_or_swap,
     shift_is_failed,
     shift_is_final,
@@ -73,15 +73,15 @@ class TestDecimalToSats:
         ],
     )
     def test_known_amounts(self, decimal_str, expected):
-        assert _decimal_to_sats(decimal_str) == expected
+        assert _decimal_to_sats_8dp(decimal_str) == expected
 
     def test_rounding_half_up_at_9th_decimal(self):
         # 0.000000005 = 0.5 sats; round half up → 1 sat
-        assert _decimal_to_sats("0.000000005") == 1
+        assert _decimal_to_sats_8dp("0.000000005") == 1
 
     def test_accepts_int_and_float(self):
-        assert _decimal_to_sats(1) == 100_000_000
-        assert _decimal_to_sats(0.0005) == 50_000
+        assert _decimal_to_sats_8dp(1) == 100_000_000
+        assert _decimal_to_sats_8dp(0.0005) == 50_000
 
 
 class TestStatusHelpers:
@@ -144,6 +144,23 @@ class TestRecommendation:
         assert rec["recommendation"] == "sideshift"
         assert rec["from_network"] == "bitcoin"
         assert rec["to_network"] == "tron"
+
+    def test_same_coin_same_network_returns_none(self):
+        # Same (coin, network) on both sides is not a swap. Don't silently
+        # steer the caller at sideswap — surface the no-op so the bug is
+        # visible upstream.
+        rec = recommend_shift_or_swap("usdt", "liquid", "usdt", "liquid")
+        assert rec["recommendation"] == "none"
+        assert "nothing to swap" in rec["reason"].lower()
+
+    def test_same_pair_is_case_insensitive(self):
+        rec = recommend_shift_or_swap("USDT", "LIQUID", "usdt", "liquid")
+        assert rec["recommendation"] == "none"
+
+    def test_same_network_different_coin_is_still_a_swap(self):
+        # USDt on Liquid → L-BTC on Liquid is a real intra-Liquid swap.
+        rec = recommend_shift_or_swap("usdt", "liquid", "btc", "liquid")
+        assert rec["recommendation"] == "sideswap"
 
 
 # ---------------------------------------------------------------------------
@@ -835,6 +852,132 @@ class TestManagerSend:
         )
         assert shift.quote_id == "fresh_q"
         assert mock_urlopen.call_count == 2  # /quotes then /shifts/fixed
+
+    def test_send_rejects_liquid_non_btc_without_liquid_asset_id(self, manager_setup):
+        # Footgun guard: depositing USDt on Liquid without `liquid_asset_id`
+        # would silently send L-BTC to the SideShift deposit address. Must
+        # raise BEFORE any SideShift HTTP call so no custodial order is created.
+        mgr, wm, _, storage = manager_setup
+        with pytest.raises(ValueError, match="liquid_asset_id is required"):
+            mgr.send_shift(
+                deposit_coin="usdt",
+                deposit_network="liquid",
+                settle_coin="usdt",
+                settle_network="tron",
+                settle_address="TXYZ",
+                deposit_amount="100",
+                wallet_name="default",
+                # liquid_asset_id intentionally omitted
+            )
+        # No wallet send happened and no shift was persisted
+        assert wm.sent == []
+        assert storage.list_sideshift_shifts() == []
+
+    def test_send_rejects_liquid_non_btc_with_lbtc_asset_id(self, manager_setup):
+        # Closes a sub-footgun of the previous test: passing the L-BTC asset id
+        # explicitly for a non-L-BTC deposit. `_wallet_send` treats that as
+        # "no asset id" and falls back to L-BTC, so the guard must reject it
+        # as firmly as the missing case.
+        mgr, wm, _, storage = manager_setup
+        with pytest.raises(ValueError, match="liquid_asset_id is required"):
+            mgr.send_shift(
+                deposit_coin="usdt",
+                deposit_network="liquid",
+                settle_coin="usdt",
+                settle_network="tron",
+                settle_address="TXYZ",
+                deposit_amount="100",
+                wallet_name="default",
+                liquid_asset_id=L_BTC,  # L-BTC asset id — wrong for USDt deposit
+            )
+        assert wm.sent == []
+        assert storage.list_sideshift_shifts() == []
+
+    def test_send_btc_liquid_does_not_require_liquid_asset_id(self, manager_setup, monkeypatch):
+        # The BTC-on-Liquid (L-BTC) case still doesn't need `liquid_asset_id`,
+        # since the wallet's default send path is L-BTC. Bypass the allowlist
+        # for this test since (btc, liquid) is intentionally excluded.
+        monkeypatch.setenv("SIDESHIFT_ALLOW_ALL_NETWORKS", "1")
+        mgr, _, _, _ = manager_setup
+        with patch("aqua.sideshift.urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = [
+                _mock_response({"id": "q1", "depositAmount": "0.0005",
+                                "settleAmount": "100", "rate": "200000"}),
+                _mock_response({
+                    "id": "shift_lbtc_ok",
+                    "depositAddress": "lq1qdeposit",
+                    "depositAmount": "0.0005",
+                    "depositCoin": "BTC",
+                    "depositNetwork": "liquid",
+                    "status": "waiting",
+                }),
+            ]
+            # Should NOT raise — L-BTC sends fine without liquid_asset_id
+            mgr.send_shift(
+                deposit_coin="btc",
+                deposit_network="liquid",
+                settle_coin="usdt",
+                settle_network="tron",
+                settle_address="TXYZ",
+                deposit_amount="0.0005",
+                wallet_name="default",
+            )
+
+    def test_send_pre_validates_password_before_creating_shift(self, manager_setup):
+        # If the mnemonic is encrypted, a bad password must fail BEFORE any
+        # SideShift HTTP call — otherwise an orphan custodial order accumulates
+        # for every retry.
+        mgr, wm, _, storage = manager_setup
+        # Reach into storage to install an encrypted mnemonic on the test wallet.
+        # `encrypt_mnemonic` is the public path the rest of the codebase uses
+        # to produce the same stored format.
+        wallet = storage.load_wallet("default")
+        wallet.encrypted_mnemonic = storage.encrypt_mnemonic(
+            "abandon abandon abandon abandon abandon abandon abandon "
+            "abandon abandon abandon abandon about",
+            password="correct horse",
+        )
+        storage.save_wallet(wallet)
+
+        with patch("aqua.sideshift.urllib.request.urlopen") as mock_urlopen:
+            with pytest.raises(Exception):
+                mgr.send_shift(
+                    deposit_coin="usdt",
+                    deposit_network="liquid",
+                    settle_coin="usdt",
+                    settle_network="tron",
+                    settle_address="TXYZ",
+                    deposit_amount="100",
+                    wallet_name="default",
+                    liquid_asset_id=USDT_LIQUID,
+                    password="WRONG",
+                )
+            # No HTTP call to SideShift was made
+            assert mock_urlopen.call_count == 0
+        # No shift persisted, no wallet send
+        assert wm.sent == []
+        assert storage.list_sideshift_shifts() == []
+
+    def test_send_rejects_missing_password_when_encrypted(self, manager_setup):
+        mgr, _, _, storage = manager_setup
+        wallet = storage.load_wallet("default")
+        wallet.encrypted_mnemonic = storage.encrypt_mnemonic(
+            "abandon abandon abandon abandon abandon abandon abandon "
+            "abandon abandon abandon abandon about",
+            password="correct horse",
+        )
+        storage.save_wallet(wallet)
+        with pytest.raises(ValueError, match="Password required"):
+            mgr.send_shift(
+                deposit_coin="usdt",
+                deposit_network="liquid",
+                settle_coin="usdt",
+                settle_network="tron",
+                settle_address="TXYZ",
+                deposit_amount="100",
+                wallet_name="default",
+                liquid_asset_id=USDT_LIQUID,
+            )
 
     @patch("aqua.sideshift.urllib.request.urlopen")
     def test_send_with_override_env_var_allows_lbtc(self, mock_urlopen, manager_setup, monkeypatch):

--- a/tests/test_sideshift.py
+++ b/tests/test_sideshift.py
@@ -1,0 +1,973 @@
+"""Tests for SideShift integration (sideshift.ai cross-chain swaps).
+
+Mocks `urllib.request.urlopen` for the HTTP client; the manager-level tests
+fake the wallet managers since SideShift never touches PSETs (custodial; we
+just send to a deposit address). No async machinery to mock — SideShift is
+plain REST.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aqua.sideshift import (
+    ALLOWED_PAIRS,
+    DEFAULT_AFFILIATE_ID,
+    SideShiftClient,
+    SideShiftManager,
+    SideShiftShift,
+    _check_pair_allowed,
+    _decimal_to_sats,
+    recommend_shift_or_swap,
+    shift_is_failed,
+    shift_is_final,
+    shift_is_success,
+)
+from aqua.storage import Storage, WalletData
+
+
+L_BTC = "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d"
+USDT_LIQUID = "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2"
+
+
+def _mock_response(data, status=200):
+    resp = MagicMock()
+    if isinstance(data, dict) or isinstance(data, list):
+        resp.read.return_value = json.dumps(data).encode()
+    elif data is None:
+        resp.read.return_value = b""
+    else:
+        resp.read.return_value = data
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+@pytest.fixture
+def storage():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Storage(Path(tmpdir))
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDecimalToSats:
+    @pytest.mark.parametrize(
+        "decimal_str, expected",
+        [
+            ("0.0005", 50_000),
+            ("0.00000001", 1),
+            ("1", 100_000_000),
+            ("0", 0),
+            ("0.12345678", 12_345_678),
+        ],
+    )
+    def test_known_amounts(self, decimal_str, expected):
+        assert _decimal_to_sats(decimal_str) == expected
+
+    def test_rounding_half_up_at_9th_decimal(self):
+        # 0.000000005 = 0.5 sats; round half up → 1 sat
+        assert _decimal_to_sats("0.000000005") == 1
+
+    def test_accepts_int_and_float(self):
+        assert _decimal_to_sats(1) == 100_000_000
+        assert _decimal_to_sats(0.0005) == 50_000
+
+
+class TestStatusHelpers:
+    @pytest.mark.parametrize("s", ["settled"])
+    def test_settled_is_success(self, s):
+        assert shift_is_success(s) is True
+        assert shift_is_final(s) is True
+        assert shift_is_failed(s) is False
+
+    @pytest.mark.parametrize("s", ["refunded", "expired"])
+    def test_failed_terminal_states(self, s):
+        assert shift_is_success(s) is False
+        assert shift_is_final(s) is True
+        assert shift_is_failed(s) is True
+
+    @pytest.mark.parametrize("s", ["waiting", "pending", "processing", "settling", "refund", "refunding"])
+    def test_pending_states(self, s):
+        assert shift_is_final(s) is False
+        assert shift_is_success(s) is False
+        assert shift_is_failed(s) is False
+
+    def test_review_is_terminal_but_not_success(self):
+        assert shift_is_final("review") is True
+        assert shift_is_success("review") is False
+        assert shift_is_failed("review") is False  # ambiguous; SideShift may eventually settle
+
+    def test_case_insensitive(self):
+        assert shift_is_success("SETTLED") is True
+
+
+class TestRecommendation:
+    def test_btc_to_lbtc_recommends_sideswap(self):
+        rec = recommend_shift_or_swap("btc", "bitcoin", "btc", "liquid")
+        assert rec["recommendation"] == "sideswap"
+
+    def test_lbtc_to_btc_recommends_sideswap(self):
+        rec = recommend_shift_or_swap("btc", "liquid", "btc", "bitcoin")
+        assert rec["recommendation"] == "sideswap"
+
+    def test_lbtc_to_usdt_liquid_recommends_sideswap(self):
+        rec = recommend_shift_or_swap("btc", "liquid", "usdt", "liquid")
+        assert rec["recommendation"] == "sideswap"
+
+    def test_usdt_liquid_to_usdt_tron_recommends_sideshift(self):
+        rec = recommend_shift_or_swap("usdt", "liquid", "usdt", "tron")
+        assert rec["recommendation"] == "sideshift"
+
+    def test_lbtc_to_eth_recommends_sideshift(self):
+        rec = recommend_shift_or_swap("btc", "liquid", "eth", "ethereum")
+        assert rec["recommendation"] == "sideshift"
+
+    def test_btc_to_eth_recommends_sideshift(self):
+        rec = recommend_shift_or_swap("btc", "bitcoin", "eth", "ethereum")
+        assert rec["recommendation"] == "sideshift"
+
+    def test_recommendation_is_case_insensitive_on_network(self):
+        rec = recommend_shift_or_swap("BTC", "BITCOIN", "USDT", "TRON")
+        assert rec["recommendation"] == "sideshift"
+        assert rec["from_network"] == "bitcoin"
+        assert rec["to_network"] == "tron"
+
+
+# ---------------------------------------------------------------------------
+# Allowlist (ALLOWED_PAIRS) — matches AQUA Flutter's curated SideShift surface
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedPairs:
+    """Encodes the contract that we expose the same SideShift surface as AQUA
+    Flutter: USDt across 7 chains + BTC mainchain. L-BTC and arbitrary altcoins
+    are not in the allowlist; users hit the override env var if they want them.
+    """
+
+    def test_allowlist_matches_aqua_flutter(self):
+        # Drift from AQUA's `lib/features/sideshift/models/sideshift_assets.dart`
+        # should fail loudly so we have a forced conversation about it.
+        expected = {
+            ("usdt", "ethereum"),
+            ("usdt", "tron"),
+            ("usdt", "bsc"),
+            ("usdt", "solana"),
+            ("usdt", "polygon"),
+            ("usdt", "ton"),
+            ("usdt", "liquid"),
+            ("btc", "bitcoin"),
+        }
+        assert set(ALLOWED_PAIRS) == expected
+
+    def test_lbtc_is_NOT_in_allowlist(self):
+        # Explicitly: L-BTC is not exposed via SideShift. Use SideSwap instead.
+        assert ("btc", "liquid") not in ALLOWED_PAIRS
+
+    @pytest.mark.parametrize("coin, network", sorted(
+        {("usdt", "ethereum"), ("usdt", "tron"), ("usdt", "liquid"),
+         ("btc", "bitcoin"), ("USDT", "Tron")}  # case-insensitive
+    ))
+    def test_allowed_pairs_pass(self, coin, network):
+        # No exception
+        _check_pair_allowed(coin, network, side="deposit")
+
+    @pytest.mark.parametrize("coin, network", [
+        ("btc", "liquid"),       # L-BTC
+        ("eth", "ethereum"),     # ETH
+        ("ltc", "litecoin"),     # LTC
+        ("xmr", "monero"),       # XMR
+        ("usdc", "ethereum"),    # USDC (only USDt is on the allowlist)
+    ])
+    def test_disallowed_pairs_raise(self, coin, network):
+        with pytest.raises(ValueError, match="not in the curated allowlist"):
+            _check_pair_allowed(coin, network, side="deposit")
+
+    def test_error_message_includes_allowlist_contents(self):
+        with pytest.raises(ValueError) as exc:
+            _check_pair_allowed("eth", "ethereum", side="deposit")
+        msg = str(exc.value)
+        assert "btc-bitcoin" in msg
+        assert "usdt-tron" in msg
+        # Mentions the override env var
+        assert "SIDESHIFT_ALLOW_ALL_NETWORKS" in msg
+
+    def test_override_env_var_bypasses_check(self, monkeypatch):
+        monkeypatch.setenv("SIDESHIFT_ALLOW_ALL_NETWORKS", "1")
+        # Now arbitrary chains pass
+        _check_pair_allowed("eth", "ethereum", side="deposit")
+        _check_pair_allowed("xmr", "monero", side="settle")
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE", "Yes"])
+    def test_override_env_var_truthy_values(self, monkeypatch, value):
+        monkeypatch.setenv("SIDESHIFT_ALLOW_ALL_NETWORKS", value)
+        _check_pair_allowed("eth", "ethereum", side="deposit")
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "blah"])
+    def test_override_env_var_falsy_values_keep_enforcement(self, monkeypatch, value):
+        monkeypatch.setenv("SIDESHIFT_ALLOW_ALL_NETWORKS", value)
+        with pytest.raises(ValueError, match="not in the curated allowlist"):
+            _check_pair_allowed("eth", "ethereum", side="deposit")
+
+    def test_error_message_distinguishes_deposit_and_settle(self):
+        with pytest.raises(ValueError, match="deposit pair"):
+            _check_pair_allowed("eth", "ethereum", side="deposit")
+        with pytest.raises(ValueError, match="settle pair"):
+            _check_pair_allowed("eth", "ethereum", side="settle")
+
+
+# ---------------------------------------------------------------------------
+# SideShiftShift dataclass + storage round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSideShiftShift:
+    def _make(self, **overrides) -> SideShiftShift:
+        defaults = dict(
+            shift_id="abc123",
+            shift_type="fixed",
+            direction="send",
+            deposit_coin="BTC",
+            deposit_network="liquid",
+            settle_coin="USDT",
+            settle_network="tron",
+            settle_address="TXYZ",
+            deposit_address="lq1qdeposit",
+            refund_address="lq1qrefund",
+            wallet_name="default",
+            status="waiting",
+            created_at="2026-05-08T12:00:00+00:00",
+        )
+        defaults.update(overrides)
+        return SideShiftShift(**defaults)
+
+    def test_to_dict_from_dict_roundtrip(self):
+        s = self._make(deposit_amount="0.0005", settle_amount="100", rate="200000")
+        assert SideShiftShift.from_dict(s.to_dict()) == s
+
+    def test_from_dict_backward_compat(self):
+        # Older record without the optional fields should still load
+        data = {
+            "shift_id": "old1",
+            "shift_type": "variable",
+            "direction": "receive",
+            "deposit_coin": "USDT",
+            "deposit_network": "tron",
+            "settle_coin": "USDT",
+            "settle_network": "liquid",
+            "settle_address": "lq1q",
+            "deposit_address": "TXYZ",
+            "refund_address": None,
+            "wallet_name": "default",
+            "status": "waiting",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+        shift = SideShiftShift.from_dict(data)
+        assert shift.deposit_amount is None
+        assert shift.settle_amount is None
+        assert shift.deposit_min is None
+        assert shift.deposit_max is None
+        assert shift.last_error is None
+
+
+class TestStorage:
+    def test_save_load_roundtrip(self, storage):
+        shift = SideShiftShift(
+            shift_id="abc123",
+            shift_type="fixed",
+            direction="send",
+            deposit_coin="BTC",
+            deposit_network="liquid",
+            settle_coin="USDT",
+            settle_network="tron",
+            settle_address="TXYZ",
+            deposit_address="lq1qdeposit",
+            refund_address="lq1qrefund",
+            wallet_name="default",
+            status="waiting",
+            created_at="2026-05-08T12:00:00+00:00",
+        )
+        storage.save_sideshift_shift(shift)
+        loaded = storage.load_sideshift_shift("abc123")
+        assert loaded == shift
+
+    def test_load_missing_returns_none(self, storage):
+        assert storage.load_sideshift_shift("nope") is None
+
+    def test_list_shifts(self, storage):
+        for sid in ("a", "b", "c"):
+            shift = SideShiftShift(
+                shift_id=sid,
+                shift_type="fixed",
+                direction="send",
+                deposit_coin="BTC",
+                deposit_network="liquid",
+                settle_coin="USDT",
+                settle_network="tron",
+                settle_address="TXYZ",
+                deposit_address="lq1q",
+                refund_address=None,
+                wallet_name=None,
+                status="waiting",
+                created_at="2026-05-08T12:00:00+00:00",
+            )
+            storage.save_sideshift_shift(shift)
+        assert set(storage.list_sideshift_shifts()) == {"a", "b", "c"}
+
+    def test_invalid_shift_id_rejected(self, storage):
+        shift = SideShiftShift(
+            shift_id="../escape",
+            shift_type="fixed",
+            direction="send",
+            deposit_coin="BTC",
+            deposit_network="liquid",
+            settle_coin="USDT",
+            settle_network="tron",
+            settle_address="TXYZ",
+            deposit_address="lq1q",
+            refund_address=None,
+            wallet_name=None,
+            status="waiting",
+            created_at="2026-05-08T12:00:00+00:00",
+        )
+        with pytest.raises(ValueError, match="Invalid SideShift shift ID"):
+            storage.save_sideshift_shift(shift)
+
+    @pytest.mark.skipif(
+        __import__("sys").platform == "win32",
+        reason="POSIX file permissions not enforced on Windows",
+    )
+    def test_file_permissions_0600(self, storage):
+        import os
+
+        shift = SideShiftShift(
+            shift_id="permcheck",
+            shift_type="fixed",
+            direction="send",
+            deposit_coin="BTC",
+            deposit_network="liquid",
+            settle_coin="USDT",
+            settle_network="tron",
+            settle_address="TXYZ",
+            deposit_address="lq1q",
+            refund_address=None,
+            wallet_name=None,
+            status="waiting",
+            created_at="2026-05-08T12:00:00+00:00",
+        )
+        storage.save_sideshift_shift(shift)
+        path = storage.sideshift_shifts_dir / "permcheck.json"
+        assert (os.stat(path).st_mode & 0o777) == 0o600
+
+
+# ---------------------------------------------------------------------------
+# REST client (HTTP layer)
+# ---------------------------------------------------------------------------
+
+
+class TestSideShiftClient:
+    def test_default_affiliate_id_is_aqua_id(self):
+        # Default to JAN3's AQUA Flutter affiliate ID. Override with env var.
+        client = SideShiftClient()
+        assert client.affiliate_id == DEFAULT_AFFILIATE_ID
+        assert client.affiliate_id == "PVmPh4Mp3"
+
+    def test_explicit_none_affiliate_id_disables_it(self):
+        client = SideShiftClient(affiliate_id="")
+        assert client.affiliate_id is None
+
+    def test_custom_affiliate_id(self):
+        client = SideShiftClient(affiliate_id="custom")
+        assert client.affiliate_id == "custom"
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_get_coins(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response(
+            [{"coin": "BTC", "name": "Bitcoin", "networks": ["bitcoin", "liquid"]}]
+        )
+        client = SideShiftClient()
+        result = client.get_coins()
+        assert result == [{"coin": "BTC", "name": "Bitcoin", "networks": ["bitcoin", "liquid"]}]
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_get_pair_uses_lowercase_coin_network_ids(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"rate": "20000"})
+        client = SideShiftClient()
+        client.get_pair("BTC", "Bitcoin", "USDT", "TRON")
+        sent = mock_urlopen.call_args[0][0]
+        assert sent.full_url.startswith("https://sideshift.ai/api/v2/pair/btc-bitcoin/usdt-tron")
+        assert "affiliateId=PVmPh4Mp3" in sent.full_url
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_get_pair_includes_amount_when_provided(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"rate": "20000"})
+        client = SideShiftClient()
+        client.get_pair("usdt", "tron", "btc", "bitcoin", amount="100")
+        sent = mock_urlopen.call_args[0][0]
+        assert "amount=100" in sent.full_url
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_request_quote_sends_uppercase_coin_lowercase_network(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"id": "q1", "depositAmount": "0.001"})
+        client = SideShiftClient()
+        client.request_quote("usdt", "Tron", "BTC", "bitcoin", deposit_amount="100")
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body["depositCoin"] == "USDT"
+        assert body["depositNetwork"] == "tron"
+        assert body["settleCoin"] == "BTC"
+        assert body["settleNetwork"] == "bitcoin"
+        assert body["depositAmount"] == "100"
+        assert body["affiliateId"] == "PVmPh4Mp3"
+
+    def test_request_quote_requires_exactly_one_amount(self):
+        client = SideShiftClient()
+        with pytest.raises(ValueError, match="exactly one"):
+            client.request_quote("usdt", "tron", "btc", "bitcoin")
+        with pytest.raises(ValueError, match="exactly one"):
+            client.request_quote(
+                "usdt", "tron", "btc", "bitcoin",
+                deposit_amount="100", settle_amount="0.001",
+            )
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_create_fixed_shift_sends_quote_id_and_addresses(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"id": "shift1", "depositAddress": "addr"})
+        client = SideShiftClient()
+        client.create_fixed_shift("q1", "settle_addr", refund_address="refund_addr")
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body["quoteId"] == "q1"
+        assert body["settleAddress"] == "settle_addr"
+        assert body["refundAddress"] == "refund_addr"
+        assert body["affiliateId"] == "PVmPh4Mp3"
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_create_variable_shift_sends_correct_body(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"id": "shift1", "depositAddress": "addr"})
+        client = SideShiftClient()
+        client.create_variable_shift(
+            deposit_coin="usdt", deposit_network="tron",
+            settle_coin="usdt", settle_network="liquid",
+            settle_address="lq1q", refund_address="TXrefund",
+        )
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body["depositCoin"] == "USDT"
+        assert body["depositNetwork"] == "tron"
+        assert body["settleCoin"] == "USDT"
+        assert body["settleNetwork"] == "liquid"
+        assert body["settleAddress"] == "lq1q"
+        assert body["refundAddress"] == "TXrefund"
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_get_shift_path(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"id": "shift1", "status": "settled"})
+        client = SideShiftClient()
+        client.get_shift("shift1")
+        sent = mock_urlopen.call_args[0][0]
+        assert sent.full_url == "https://sideshift.ai/api/v2/shifts/shift1"
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_http_error_extracts_message(self, mock_urlopen):
+        err = urllib.error.HTTPError(
+            url="https://sideshift.ai/api/v2/shifts/fixed",
+            code=400,
+            msg="Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(json.dumps({"error": {"message": "amount too small"}}).encode()),
+        )
+        mock_urlopen.side_effect = err
+        client = SideShiftClient()
+        with pytest.raises(RuntimeError, match="amount too small"):
+            client.get_coins()
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_unreachable_host_raises(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.URLError("name resolution failed")
+        client = SideShiftClient()
+        with pytest.raises(RuntimeError, match="unreachable"):
+            client.get_coins()
+
+
+# ---------------------------------------------------------------------------
+# Manager (with mocked HTTP and wallet managers)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager_setup(storage):
+    """Build a SideShiftManager with fake wallet/btc managers and a temp Storage.
+
+    The manager only calls `get_address(name).address`, `send(name, addr, sats, …)`
+    on the wallet managers — narrow surface, easy to fake.
+    """
+    wallet = WalletData(
+        name="default",
+        network="mainnet",
+        descriptor="ct(slip77(deadbeef),elwpkh([fp/84'/1776'/0']tpubD.../0/*))",
+        encrypted_mnemonic=None,
+    )
+    storage.save_wallet(wallet)
+
+    class _AddrResult:
+        def __init__(self, addr):
+            self.address = addr
+
+    class FakeWalletManager:
+        def __init__(self):
+            self.sent: list[tuple] = []
+            self.next_address = "lq1qreceive"
+
+        def get_address(self, name, index=None):  # noqa: ARG002
+            return _AddrResult(self.next_address)
+
+        def send(self, name, address, amount, asset_id=None, password=None):  # noqa: ARG002
+            self.sent.append(("liquid", name, address, amount, asset_id, password))
+            return "lqtxid" + ("0" * 58)
+
+    class FakeBtcManager:
+        def __init__(self):
+            self.sent: list[tuple] = []
+            self.next_address = "bc1qreceive"
+
+        def get_address(self, name, index=None):  # noqa: ARG002
+            return _AddrResult(self.next_address)
+
+        def send(self, name, address, amount, fee_rate=None, password=None):  # noqa: ARG002
+            self.sent.append(("bitcoin", name, address, amount, password))
+            return "btctxid" + ("0" * 58)
+
+    wm = FakeWalletManager()
+    btc = FakeBtcManager()
+    mgr = SideShiftManager(storage=storage, wallet_manager=wm, btc_wallet_manager=btc)
+    return mgr, wm, btc, storage
+
+
+class TestManagerSend:
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_send_usdt_liquid_to_usdt_tron_happy_path(self, mock_urlopen, manager_setup):
+        # The headline AQUA flow: USDt-Liquid → USDt-Tron via SideShift.
+        mgr, wm, _, storage = manager_setup
+        mock_urlopen.side_effect = [
+            _mock_response({
+                "id": "q_xyz",
+                "depositAmount": "100",
+                "settleAmount": "99.5",
+                "rate": "0.995",
+            }),
+            _mock_response({
+                "id": "shift_xyz",
+                "depositAddress": "lq1qdeposit",
+                "depositAmount": "100",
+                "settleAmount": "99.5",
+                "rate": "0.995",
+                "status": "waiting",
+                "expiresAt": "2026-05-08T12:15:00Z",
+                "depositCoin": "USDT",
+                "depositNetwork": "liquid",
+                "settleCoin": "USDT",
+                "settleNetwork": "tron",
+                "settleAddress": "TXYZ",
+            }),
+        ]
+        shift = mgr.send_shift(
+            deposit_coin="usdt",
+            deposit_network="liquid",
+            settle_coin="usdt",
+            settle_network="tron",
+            settle_address="TXYZ",
+            deposit_amount="100",
+            wallet_name="default",
+            liquid_asset_id=USDT_LIQUID,
+        )
+        assert shift.shift_id == "shift_xyz"
+        assert shift.deposit_address == "lq1qdeposit"
+        assert shift.deposit_hash and shift.deposit_hash.startswith("lqtxid")
+        # Refund address is the wallet's own Liquid address (the deposit chain)
+        assert shift.refund_address == "lq1qreceive"
+        # 100 USDt = 100 * 1e8 sats (Liquid USDt is 8-decimal)
+        assert wm.sent == [("liquid", "default", "lq1qdeposit", 10_000_000_000,
+                            USDT_LIQUID, None)]
+        # Persisted
+        assert storage.load_sideshift_shift("shift_xyz") is not None
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_send_usdt_liquid_passes_asset_id(self, mock_urlopen, manager_setup):
+        mgr, wm, _, _ = manager_setup
+        mock_urlopen.side_effect = [
+            _mock_response({"id": "q1", "depositAmount": "100", "settleAmount": "99",
+                            "rate": "1"}),
+            _mock_response({
+                "id": "shift_u",
+                "depositAddress": "lq1qassetdeposit",
+                "depositAmount": "100",
+                "settleAmount": "99",
+                "rate": "1",
+                "status": "waiting",
+                "depositCoin": "USDT",
+                "depositNetwork": "liquid",
+                "settleCoin": "USDT",
+                "settleNetwork": "tron",
+                "settleAddress": "TXYZ",
+            }),
+        ]
+        mgr.send_shift(
+            deposit_coin="usdt",
+            deposit_network="liquid",
+            settle_coin="usdt",
+            settle_network="tron",
+            settle_address="TXYZ",
+            deposit_amount="100",
+            wallet_name="default",
+            liquid_asset_id=USDT_LIQUID,
+        )
+        assert wm.sent == [("liquid", "default", "lq1qassetdeposit", 100 * 100_000_000,
+                            USDT_LIQUID, None)]
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_send_btc_uses_btc_manager(self, mock_urlopen, manager_setup):
+        mgr, wm, btc, _ = manager_setup
+        mock_urlopen.side_effect = [
+            _mock_response({"id": "q1", "depositAmount": "0.001", "settleAmount": "10",
+                            "rate": "10000"}),
+            _mock_response({
+                "id": "shift_btc",
+                "depositAddress": "bc1qdeposit",
+                "depositAmount": "0.001",
+                "depositCoin": "BTC",
+                "depositNetwork": "bitcoin",
+                "settleCoin": "USDT",
+                "settleNetwork": "tron",
+                "status": "waiting",
+            }),
+        ]
+        mgr.send_shift(
+            deposit_coin="btc",
+            deposit_network="bitcoin",
+            settle_coin="usdt",
+            settle_network="tron",
+            settle_address="TXYZ",
+            deposit_amount="0.001",
+            wallet_name="default",
+        )
+        # Used the BTC manager, not the Liquid one
+        assert wm.sent == []
+        assert btc.sent == [("bitcoin", "default", "bc1qdeposit", 100_000, None)]
+
+    def test_send_rejects_non_native_deposit_chain(self, manager_setup):
+        mgr, _, _, _ = manager_setup
+        with pytest.raises(ValueError, match="Cannot sign on"):
+            mgr.send_shift(
+                deposit_coin="usdt",
+                deposit_network="tron",
+                settle_coin="btc",
+                settle_network="liquid",
+                settle_address="lq1qfoo",
+                deposit_amount="100",
+                wallet_name="default",
+            )
+
+    def test_send_rejects_unknown_wallet(self, manager_setup):
+        mgr, _, _, _ = manager_setup
+        with pytest.raises(ValueError, match="not found"):
+            mgr.send_shift(
+                deposit_coin="usdt",
+                deposit_network="liquid",
+                settle_coin="usdt",
+                settle_network="tron",
+                settle_address="TXYZ",
+                deposit_amount="100",
+                wallet_name="ghost",
+                liquid_asset_id=USDT_LIQUID,
+            )
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_send_persists_shift_before_broadcast_so_failure_is_recoverable(
+        self, mock_urlopen, manager_setup
+    ):
+        # If create_fixed_shift succeeded but broadcast failed, the shift
+        # must still be on disk so the user can refund/retry.
+        mgr, wm, _, storage = manager_setup
+        mock_urlopen.side_effect = [
+            _mock_response({"id": "q1", "depositAmount": "100",
+                            "settleAmount": "99.5", "rate": "0.995"}),
+            _mock_response({
+                "id": "shift_persist",
+                "depositAddress": "lq1qdeposit",
+                "depositAmount": "100",
+                "depositCoin": "USDT",
+                "depositNetwork": "liquid",
+                "settleCoin": "USDT",
+                "settleNetwork": "tron",
+                "status": "waiting",
+            }),
+        ]
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("broadcast network down")
+
+        wm.send = boom
+
+        with pytest.raises(RuntimeError, match="broadcast network down"):
+            mgr.send_shift(
+                deposit_coin="usdt",
+                deposit_network="liquid",
+                settle_coin="usdt",
+                settle_network="tron",
+                settle_address="TXYZ",
+                deposit_amount="100",
+                wallet_name="default",
+                liquid_asset_id=USDT_LIQUID,
+            )
+
+        loaded = storage.load_sideshift_shift("shift_persist")
+        assert loaded is not None
+        assert loaded.last_error and "broadcast network down" in loaded.last_error
+
+    def test_send_rejects_lbtc_pair_not_in_allowlist(self, manager_setup):
+        # L-BTC (`btc-liquid`) is intentionally not in the allowlist — for
+        # L-BTC ↔ external the agent should use SideSwap or chain through
+        # USDt-Liquid.
+        mgr, _, _, _ = manager_setup
+        with pytest.raises(ValueError, match="not in the curated allowlist"):
+            mgr.send_shift(
+                deposit_coin="btc",
+                deposit_network="liquid",
+                settle_coin="usdt",
+                settle_network="tron",
+                settle_address="TXYZ",
+                deposit_amount="0.0005",
+                wallet_name="default",
+            )
+
+    def test_send_rejects_unrecognized_settle_pair(self, manager_setup):
+        # Settle leg must also be on the allowlist (e.g. ETH is not).
+        mgr, _, _, _ = manager_setup
+        with pytest.raises(ValueError, match="settle pair"):
+            mgr.send_shift(
+                deposit_coin="usdt",
+                deposit_network="liquid",
+                settle_coin="eth",
+                settle_network="ethereum",
+                settle_address="0xfoo",
+                deposit_amount="100",
+                wallet_name="default",
+                liquid_asset_id=USDT_LIQUID,
+            )
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_send_with_override_env_var_allows_lbtc(self, mock_urlopen, manager_setup, monkeypatch):
+        # Power-user escape hatch: the env var bypasses the allowlist entirely.
+        monkeypatch.setenv("SIDESHIFT_ALLOW_ALL_NETWORKS", "1")
+        mgr, wm, _, _ = manager_setup
+        mock_urlopen.side_effect = [
+            _mock_response({"id": "q1", "depositAmount": "0.0005",
+                            "settleAmount": "100", "rate": "200000"}),
+            _mock_response({
+                "id": "shift_override",
+                "depositAddress": "lq1qdeposit",
+                "depositAmount": "0.0005",
+                "depositCoin": "BTC",
+                "depositNetwork": "liquid",
+                "settleCoin": "USDT",
+                "settleNetwork": "tron",
+                "status": "waiting",
+            }),
+        ]
+        # L-BTC pair, normally rejected — passes with the override
+        mgr.send_shift(
+            deposit_coin="btc",
+            deposit_network="liquid",
+            settle_coin="usdt",
+            settle_network="tron",
+            settle_address="TXYZ",
+            deposit_amount="0.0005",
+            wallet_name="default",
+        )
+        assert wm.sent and wm.sent[0][3] == 50_000
+
+
+class TestManagerReceive:
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_receive_into_liquid_returns_deposit_address(self, mock_urlopen, manager_setup):
+        mgr, _, _, storage = manager_setup
+        mock_urlopen.return_value = _mock_response({
+            "id": "shift_r",
+            "depositAddress": "TXdepositAddr",
+            "depositMin": "10",
+            "depositMax": "10000",
+            "settleAddress": "lq1qreceive",
+            "depositCoin": "USDT",
+            "depositNetwork": "tron",
+            "settleCoin": "USDT",
+            "settleNetwork": "liquid",
+            "status": "waiting",
+            "expiresAt": "2026-06-01T00:00:00Z",
+        })
+        shift = mgr.receive_shift(
+            deposit_coin="usdt",
+            deposit_network="tron",
+            settle_coin="usdt",
+            settle_network="liquid",
+            wallet_name="default",
+            external_refund_address="TXrefund",
+        )
+        assert shift.shift_id == "shift_r"
+        assert shift.shift_type == "variable"
+        assert shift.direction == "receive"
+        assert shift.deposit_address == "TXdepositAddr"
+        assert shift.settle_address == "lq1qreceive"
+        assert shift.refund_address == "TXrefund"
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body["refundAddress"] == "TXrefund"
+        assert body["settleAddress"] == "lq1qreceive"
+        # Persisted
+        assert storage.load_sideshift_shift("shift_r") is not None
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_receive_into_bitcoin_uses_btc_manager_address(self, mock_urlopen, manager_setup):
+        mgr, _, btc, _ = manager_setup
+        mock_urlopen.return_value = _mock_response({
+            "id": "shift_btc_r",
+            "depositAddress": "TXdepositAddr",
+            "depositCoin": "USDT",
+            "depositNetwork": "tron",
+            "settleCoin": "BTC",
+            "settleNetwork": "bitcoin",
+            "settleAddress": "bc1qreceive",
+            "status": "waiting",
+        })
+        mgr.receive_shift(
+            deposit_coin="usdt", deposit_network="tron",
+            settle_coin="btc", settle_network="bitcoin",
+            wallet_name="default",
+        )
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body["settleAddress"] == "bc1qreceive"
+
+    def test_receive_rejects_non_native_settle_chain(self, manager_setup):
+        mgr, _, _, _ = manager_setup
+        with pytest.raises(ValueError, match="Cannot receive on"):
+            mgr.receive_shift(
+                deposit_coin="usdt", deposit_network="tron",
+                settle_coin="usdt", settle_network="ethereum",
+                wallet_name="default",
+            )
+
+    def test_receive_rejects_unrecognized_deposit_pair(self, manager_setup):
+        # The deposit leg must be on the allowlist (only USDt across the 7
+        # major chains and BTC mainchain).
+        mgr, _, _, _ = manager_setup
+        with pytest.raises(ValueError, match="deposit pair"):
+            mgr.receive_shift(
+                deposit_coin="eth", deposit_network="ethereum",
+                settle_coin="usdt", settle_network="liquid",
+                wallet_name="default",
+            )
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_receive_with_override_env_var_allows_eth(
+        self, mock_urlopen, manager_setup, monkeypatch
+    ):
+        monkeypatch.setenv("SIDESHIFT_ALLOW_ALL_NETWORKS", "1")
+        mgr, _, _, _ = manager_setup
+        mock_urlopen.return_value = _mock_response({
+            "id": "shift_eth",
+            "depositAddress": "0xeth_deposit",
+            "depositCoin": "ETH",
+            "depositNetwork": "ethereum",
+            "settleCoin": "USDT",
+            "settleNetwork": "liquid",
+            "settleAddress": "lq1qreceive",
+            "status": "waiting",
+        })
+        # ETH pair, normally rejected — passes with the override
+        shift = mgr.receive_shift(
+            deposit_coin="eth", deposit_network="ethereum",
+            settle_coin="usdt", settle_network="liquid",
+            wallet_name="default",
+        )
+        assert shift.deposit_address == "0xeth_deposit"
+
+
+class TestManagerStatus:
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_status_refreshes_persisted_record(self, mock_urlopen, manager_setup):
+        mgr, _, _, storage = manager_setup
+        # Pre-seed a pending shift
+        original = SideShiftShift(
+            shift_id="poll1",
+            shift_type="variable",
+            direction="receive",
+            deposit_coin="USDT",
+            deposit_network="tron",
+            settle_coin="USDT",
+            settle_network="liquid",
+            settle_address="lq1qreceive",
+            deposit_address="TXdepositAddr",
+            refund_address=None,
+            wallet_name="default",
+            status="waiting",
+            created_at="2026-05-08T12:00:00+00:00",
+        )
+        storage.save_sideshift_shift(original)
+
+        mock_urlopen.return_value = _mock_response({
+            "id": "poll1",
+            "status": "settled",
+            "depositHash": "TXhash",
+            "settleHash": "lqsettlehash",
+            "rate": "1.0",
+            "depositAmount": "100",
+            "settleAmount": "99.5",
+        })
+        result = mgr.status("poll1")
+        assert result["status"] == "settled"
+        assert result["deposit_hash"] == "TXhash"
+        assert result["settle_hash"] == "lqsettlehash"
+        assert result["is_final"] is True
+        assert result["is_success"] is True
+        assert result["is_failed"] is False
+        # Updated record persisted
+        loaded = storage.load_sideshift_shift("poll1")
+        assert loaded.status == "settled"
+        assert loaded.last_checked_at is not None
+
+    def test_status_unknown_raises(self, manager_setup):
+        mgr, _, _, _ = manager_setup
+        with pytest.raises(ValueError, match="not found"):
+            mgr.status("nope")
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_status_warns_on_remote_error(self, mock_urlopen, manager_setup):
+        mgr, _, _, storage = manager_setup
+        original = SideShiftShift(
+            shift_id="poll2",
+            shift_type="fixed",
+            direction="send",
+            deposit_coin="BTC",
+            deposit_network="liquid",
+            settle_coin="USDT",
+            settle_network="tron",
+            settle_address="TXYZ",
+            deposit_address="lq1q",
+            refund_address="lq1q",
+            wallet_name="default",
+            status="waiting",
+            created_at="2026-05-08T12:00:00+00:00",
+        )
+        storage.save_sideshift_shift(original)
+
+        mock_urlopen.side_effect = urllib.error.URLError("boom")
+        result = mgr.status("poll2")
+        assert "warning" in result
+        # Status unchanged
+        assert result["status"] == "waiting"

--- a/tests/test_sideshift.py
+++ b/tests/test_sideshift.py
@@ -91,7 +91,7 @@ class TestStatusHelpers:
         assert shift_is_final(s) is True
         assert shift_is_failed(s) is False
 
-    @pytest.mark.parametrize("s", ["refunded", "expired"])
+    @pytest.mark.parametrize("s", ["refunded", "expired", "failed"])
     def test_failed_terminal_states(self, s):
         assert shift_is_success(s) is False
         assert shift_is_final(s) is True

--- a/tests/test_sideshift.py
+++ b/tests/test_sideshift.py
@@ -103,10 +103,12 @@ class TestStatusHelpers:
         assert shift_is_success(s) is False
         assert shift_is_failed(s) is False
 
-    def test_review_is_terminal_but_not_success(self):
-        assert shift_is_final("review") is True
+    def test_review_is_not_terminal(self):
+        # Per SideShift docs, "review" is a risk-management hold that can
+        # still resolve to settled or refunded — so it is NOT a final state.
+        assert shift_is_final("review") is False
         assert shift_is_success("review") is False
-        assert shift_is_failed("review") is False  # ambiguous; SideShift may eventually settle
+        assert shift_is_failed("review") is False
 
     def test_case_insensitive(self):
         assert shift_is_success("SETTLED") is True
@@ -762,6 +764,77 @@ class TestManagerSend:
                 wallet_name="default",
                 liquid_asset_id=USDT_LIQUID,
             )
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_send_with_quote_id_skips_internal_request_quote(self, mock_urlopen, manager_setup):
+        # When the caller threads through a confirmed quote_id, the manager
+        # must NOT call /quotes again — only /shifts/fixed and the broadcast.
+        mgr, wm, _, _ = manager_setup
+        mock_urlopen.side_effect = [
+            _mock_response({
+                "id": "shift_qid",
+                "depositAddress": "lq1qdeposit",
+                "depositAmount": "100",
+                "settleAmount": "99.5",
+                "rate": "0.995",
+                "status": "waiting",
+                "depositCoin": "USDT",
+                "depositNetwork": "liquid",
+                "settleCoin": "USDT",
+                "settleNetwork": "tron",
+                "settleAddress": "TXYZ",
+            }),
+        ]
+        shift = mgr.send_shift(
+            deposit_coin="usdt",
+            deposit_network="liquid",
+            settle_coin="usdt",
+            settle_network="tron",
+            settle_address="TXYZ",
+            deposit_amount="100",
+            wallet_name="default",
+            liquid_asset_id=USDT_LIQUID,
+            quote_id="confirmed_q_id",
+        )
+        assert shift.shift_id == "shift_qid"
+        assert shift.quote_id == "confirmed_q_id"
+        # Exactly one HTTP call: /shifts/fixed with the supplied quote id.
+        assert mock_urlopen.call_count == 1
+        req = mock_urlopen.call_args.args[0]
+        assert req.full_url.endswith("/shifts/fixed")
+        body = json.loads(req.data.decode())
+        assert body["quoteId"] == "confirmed_q_id"
+
+    @patch("aqua.sideshift.urllib.request.urlopen")
+    def test_send_without_quote_id_fetches_fresh_quote(self, mock_urlopen, manager_setup):
+        # The default path (no quote_id) still fetches a fresh quote.
+        mgr, _, _, _ = manager_setup
+        mock_urlopen.side_effect = [
+            _mock_response({"id": "fresh_q", "depositAmount": "100",
+                            "settleAmount": "99.5", "rate": "0.995"}),
+            _mock_response({
+                "id": "shift_fresh",
+                "depositAddress": "lq1qdeposit",
+                "depositAmount": "100",
+                "status": "waiting",
+                "depositCoin": "USDT",
+                "depositNetwork": "liquid",
+                "settleCoin": "USDT",
+                "settleNetwork": "tron",
+            }),
+        ]
+        shift = mgr.send_shift(
+            deposit_coin="usdt",
+            deposit_network="liquid",
+            settle_coin="usdt",
+            settle_network="tron",
+            settle_address="TXYZ",
+            deposit_amount="100",
+            wallet_name="default",
+            liquid_asset_id=USDT_LIQUID,
+        )
+        assert shift.quote_id == "fresh_q"
+        assert mock_urlopen.call_count == 2  # /quotes then /shifts/fixed
 
     @patch("aqua.sideshift.urllib.request.urlopen")
     def test_send_with_override_env_var_allows_lbtc(self, mock_urlopen, manager_setup, monkeypatch):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -720,6 +720,13 @@ class TestToolRegistry:
             "delete_wallet",
             "btc_import_descriptor",
             "btc_export_descriptor",
+            "sideshift_list_coins",
+            "sideshift_pair_info",
+            "sideshift_quote",
+            "sideshift_send",
+            "sideshift_receive",
+            "sideshift_status",
+            "sideshift_recommend",
         }
         assert set(TOOLS.keys()) == expected
 


### PR DESCRIPTION
> **Independent of the SideSwap stack** (#27, #31, #32). Branched off `main` so it can land on its own merits without waiting for those PRs to merge first.

## Summary

- Adds custodial cross-chain swap support via [sideshift.ai](https://sideshift.ai). Complementary to (not redundant with) SideSwap: SideSwap is atomic Liquid + pegs (Liquid universe only); SideShift covers 30+ chains and 200+ assets.
- The killer flow is **USDt on expensive chains ↔ USDt-Liquid** — gets users out of high-fee networks (Ethereum, Tron, etc.) into cheap Liquid in one tool call.
- 7 new MCP tools, 2 prompts, an `aqua sideshift` CLI subcommand group, 71 new tests (371 passing in total).

## How it differs from SideSwap

| Aspect | SideSwap | SideShift |
|---|---|---|
| **Trust model** | Atomic on Liquid (PSET) or Liquid Federation peg | Custodial — SideShift takes the deposit and sends from their hot wallet |
| **Asset universe** | Liquid only (L-BTC, USDt-Liquid, EURx, MEX, DePix, etc.) + BTC↔L-BTC pegs | 30+ chains, 200+ assets (BTC, ETH, SOL, TRX, BSC, USDt-on-everything, …) |
| **Fees** | 0–0.2% atomic / 0.1% peg | ~0.5–2% (commission markup) |
| **When to use** | Both legs Liquid (or BTC↔L-BTC if you can wait) | At least one leg on a non-Liquid chain |

The new `sideshift_recommend` tool exposes this trade-off as a one-call helper for agents.

## What's in this PR

**`src/aqua/sideshift.py`**: REST client (stdlib `urllib`, mirroring Boltz/Ankara patterns), data classes (`SideShiftCoin`, `SideShiftPairInfo`, `SideShiftQuote`, `SideShiftShift`), high-level `SideShiftManager` orchestrating send / receive / status flows, plus `recommend_shift_or_swap` and shift-status helpers.

**7 new MCP tools**:
- `sideshift_list_coins` — list supported coins + networks
- `sideshift_pair_info` — rate / min / max for a pair
- `sideshift_quote` — fixed-rate quote (~15 min TTL)
- `sideshift_send` — send funds OUT (we sign on Liquid/BTC, refund address auto-set)
- `sideshift_receive` — receive funds IN via variable-rate shift (returns deposit address)
- `sideshift_status` — poll shift status with `is_final`/`is_success`/`is_failed` booleans
- `sideshift_recommend` — SideSwap vs SideShift helper

**2 new prompts**: `cross_chain_send`, `cross_chain_receive`.

**CLI subcommand group** `aqua sideshift {coins,pair-info,quote,send,receive,status,recommend}` mirroring the tool surface. The `send` subcommand shows a fresh quote and prompts for confirmation by default (`--yes` to skip for scripted use). Password resolution follows the existing `--password-stdin` / `AQUA_PASSWORD` pattern.

**Storage** at `~/.aqua/sideshift_shifts/{shift_id}.json`, mode `0o600`, atomic writes; persisted before broadcast on send so a failed broadcast leaves a recoverable record on disk.

## Affiliate ID

Hardcoded to `PVmPh4Mp3` — the same one AQUA Flutter wallet ships with (publicly committed in their `lib/config/constants/api_keys.dart:6`). Commission accrues to JAN3's SideShift account. Pass an empty string to `SideShiftClient(affiliate_id="")` to disable affiliate identification entirely.

## Wire-format quirks

Documented in the module docstring + AGENTS.md:
- L-BTC is identified as `coin: "BTC", network: "liquid"` (not `lbtc-liquid`)
- USDt-Liquid is `coin: "USDT", network: "liquid"`
- Coin tickers uppercase, networks lowercase on the wire
- All amounts are decimal strings (e.g. `"0.0005"`, `"100"`); the manager converts to integer sats before calling our wallet send methods
- Memo networks (TON, Stellar, BNB Beacon) require a memo on the deposit — surfaced via `deposit_memo` on the persisted shift record

## Test plan

Module tests (`test_sideshift.py`, 58 tests):
- [x] Decimal → sats conversion incl. rounding (5)
- [x] Status state machine helpers (5)
- [x] Recommendation logic for various pairs incl. case-insensitive (7)
- [x] `SideShiftShift` dataclass round-trip + backward-compat + 0o600 file permissions (5)
- [x] REST client: affiliate id resolution, all 6 endpoints, error extraction, unreachable host, commission rate passthrough (12)
- [x] Manager send: happy path L-BTC → USDt-Tron, USDt-Liquid with `liquid_asset_id`, BTC → external uses BDK manager, rejects non-native deposit chain, rejects unknown wallet, persists shift before broadcast so failure is recoverable (6)
- [x] Manager receive: into Liquid, into Bitcoin, rejects non-native settle chain (3)
- [x] Manager status: refreshes persisted record, unknown raises, warns on remote error (3)

CLI tests (added to `test_cli.py`, 13 tests): all 7 subcommands, fake manager injection, argument validation.

Tool registry test updated for the 7 new tools.

- [ ] **Manual testnet smoke test** — required before mainnet sign-off. Procedure: import a wallet, run `aqua sideshift coins` to verify connectivity, run a small `sideshift_receive` (e.g. \$1 of USDt-Tron → USDt-Liquid) and have an external sender pay the deposit address, run a small `sideshift_send` from L-BTC → USDt-Tron with an address you control on Tron, confirm balances change as expected.

## Reviewer notes

- This PR is **fully independent of the SideSwap stack** (#27, #31, #32). It branched off `main`. They can land in any order.
- The trust model is fundamentally different from SideSwap. The MCP server's role here is essentially "fetch a quote, broadcast a deposit, poll status" — there's no PSET signing, no on-chain atomic guarantee, no security-critical verifier. The existing security work in #27/#31 doesn't apply here because it doesn't need to.
- `sideshift_recommend` is a feature, not a redirect: agents should call it when both options are viable so the user understands the trade-off.
- The default `commissionRate` is whatever SideShift applies for the affiliate (≈0.5%). The client supports overriding via `SideShiftClient(commission_rate=…)` (0.0–0.02 per docs). Not exposed as a CLI flag because most users shouldn't touch it.