### PR TITLE
Add Changelly USDt cross-chain swap integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,9 @@ AI Assistant ←→ MCP Server (Python) ←→ LWK (Liquid) ──→ Electrum/E
 
 No local server required. Liquid uses Electrum/Esplora; Bitcoin uses Esplora only. All via Blockstream's public infrastructure.
 
-## Tools (22 total)
+## Tools (27 total)
 
-Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`.
+Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`; Changelly cross-chain USDt tools are `changelly_*`.
 
 ### Wallet Management
 
@@ -74,6 +74,22 @@ Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified 
 | `lightning_send` | Pay a Lightning invoice using L-BTC via Boltz submarine swap. Fees: ~0.1% + miner fees. Limits: 100 – 25,000,000 sats | `invoice`: BOLT11 string (lnbc... or lntb...), `wallet_name`: optional, `password`: optional |
 | `lightning_transaction_status` | Check status of a Lightning swap (send or receive). For receive: auto-claims L-BTC when settled. For send: retrieves preimage when claimed. | `swap_id`: string |
 
+### Changelly (USDt Cross-Chain Swaps via AQUA's Ankara Proxy)
+
+Changelly is a cross-chain swap service routed through AQUA's Ankara backend proxy (`https://ankara.aquabtc.com/api/v1/changelly`). Use it for **USDt-Liquid ↔ USDt on the 6 supported external chains**: Ethereum, Tron, BSC, Solana, Polygon, TON. For BTC, L-BTC, or non-USDt swaps, use SideSwap or SideShift instead.
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `changelly_list_currencies` | List Changelly's supported currencies (read-only; allowlist not enforced) | (none) |
+| `changelly_quote` | Fixed-rate quote for a USDt-Liquid ↔ USDt-on-X swap. Use BEFORE `changelly_send`. | `external_network` (ethereum/tron/bsc/solana/polygon/ton), `direction` (send/receive), exactly one of `amount_from` / `amount_to` (decimal strings) |
+| `changelly_send` | Send USDt-Liquid OUT to USDt on an external chain. Gets quote, creates fixed order, broadcasts deposit from Liquid wallet. Refund address auto-set to wallet's own Liquid address. | `external_network`, `settle_address`, `amount_from`, `wallet_name`: optional, `password`: optional |
+| `changelly_receive` | Receive USDt-Liquid IN via variable-rate swap. Returns deposit address on the source chain for the external sender. STRONGLY recommend `external_refund_address`. | `external_network`, `wallet_name`: optional, `external_refund_address`: optional but recommended, `amount_from`: optional reference for quote preview |
+| `changelly_status` | Check status of a swap order (returns `is_final`, `is_success`, `is_failed`) | `order_id`: string |
+
+> ⚠️ **Changelly trust model**: Custodial. They take the USDt-Liquid deposit (or USDt on the external chain) and send the converted asset from their hot wallet. Refund address is auto-set on send (wallet's own Liquid address). On receives, strongly encourage the user to provide an external refund address — without one, a stuck order requires manual intervention via Changelly's web UI.
+
+> ⚠️ **Curated allowlist**: Mirrors AQUA Flutter's `ChangellyAssetIds` in `lib/features/changelly/models/changelly_models.dart`. Only USDt is supported. Set `CHANGELLY_ALLOW_ALL_PAIRS=1` to bypass for testing or power use.
+
 ## Resources (3 total)
 
 MCP resources provide static documentation to AI assistants.
@@ -84,7 +100,7 @@ MCP resources provide static documentation to AI assistants.
 | `aqua://docs/networks` | Network Reference | Bitcoin and Liquid network details, address formats, explorers, common assets |
 | `aqua://docs/security` | Security Best Practices | Password usage, at-rest encryption, backup, watch-only wallets, recovery |
 
-## Prompts (14 total)
+## Prompts (16 total)
 
 MCP prompts provide pre-built conversation starters for common workflows.
 
@@ -104,6 +120,8 @@ MCP prompts provide pre-built conversation starters for common workflows.
 | `export_descriptor` | Export descriptor for watch-only wallet | `wallet_name`: optional |
 | `delete_wallet` | Safely delete a wallet with balance check and seed backup reminder | `wallet_name`: required |
 | `pay_lightning` | Pay a Lightning invoice using Liquid Bitcoin | `wallet_name`: optional |
+| `usdt_cross_chain_send` | Send USDt-Liquid out to USDt on another chain via Changelly (e.g. USDt-Liquid → USDt-Tron). Walks through quote, confirmation, and broadcast. | `wallet_name`: optional |
+| `usdt_cross_chain_receive` | Receive USDt-Liquid from USDt on another chain via Changelly. Returns deposit address for the external sender. | `wallet_name`: optional |
 
 ## Data Storage
 
@@ -120,6 +138,8 @@ Wallet data stored in `~/.aqua/`:
 │   └── {swap_id}.json   # Contains swap details + preimage when settled
 ├── lightning_swaps/     # Unified Lightning swap data (send & receive)
 │   └── {swap_id}.json   # Contains swap details + status + optional preimage
+├── changelly_swaps/     # Changelly cross-chain USDt swap orders
+│   └── {order_id}.json  # Contains direction, type, addresses, status, txid
 └── cache/
     └── <wallet_name>/
         └── btc/
@@ -283,6 +303,40 @@ Ankara backend (`test.aquabtc.com`) provides Lightning → L-BTC swaps (receive 
 
 **Amount Limits**: 100 – 25,000,000 sats (no authentication required)
 
+## Changelly Integration
+
+Changelly is reached via AQUA's Ankara backend proxy at `https://ankara.aquabtc.com/api/v1/changelly`. AQUA's backend handles the Changelly partner API secret server-side, so this MCP server doesn't need its own credentials.
+
+**API**: REST/JSON. No authentication required from this side.
+
+**Configurable via environment variable**: `CHANGELLY_BASE_URL` overrides the default base for testing or local development. `CHANGELLY_ALLOW_ALL_PAIRS=1` bypasses the curated pair allowlist.
+
+**Endpoints used (proxied through AQUA's backend)**:
+- `GET /currencies` — list of supported currencies
+- `POST /pairs` — available pairs
+- `POST /get-fix-rate-for-amount` — fixed-rate quote
+- `POST /quote` — variable-rate quote (used for receive flow's reference preview)
+- `POST /create-fix-transaction` — create a fixed-rate order from a quote
+- `POST /create-transaction` — create a variable-rate order
+- `GET /status/{orderId}` — poll order status
+
+**Asset id conventions** (Changelly's own format, distinct from SideShift's):
+- `lusdt` — USDt on Liquid
+- `usdt20` — USDt on Ethereum (ERC-20)
+- `usdtrx` — USDt on Tron (TRC-20)
+- `usdtbsc` — USDt on BSC
+- `usdtsol` — USDt on Solana
+- `usdtpolygon` — USDt on Polygon
+- `usdton` — USDt on TON
+
+**Curated pair allowlist** (`ALLOWED_PAIRS` in `src/aqua/changelly.py`): one leg must be `lusdt`, the other must be one of the 6 external USDt variants. 6 chains × 2 directions = 12 ordered pairs. Mirrors AQUA Flutter's `ChangellyAssetIds` set; drift is detected by `tests/test_changelly.py::TestAllowedPairs::test_allowlist_matches_aqua_flutter`.
+
+**Status state machine** (lowercase): `new` → `waiting` → `confirming` → `exchanging` → `sending` → `finished` (success). Failure terminals: `failed`, `refunded`, `expired`, `overdue`. Manual review: `hold` (terminal but ambiguous). Helpers `swap_is_final` / `swap_is_success` / `swap_is_failed` abstract over the grouping.
+
+**Trust model**: Custodial. Changelly takes the deposit and sends the converted asset from their hot wallet via AQUA's backend. Refund address is set automatically on send (the wallet's own Liquid address) and strongly recommended on receive (must be supplied by the caller; otherwise a stuck order needs manual web UI intervention).
+
+**Why both Changelly and SideShift?** Both are USDt cross-chain swap services and cover roughly the same chains. They're redundant on supported pairs by design. Agents can pick whichever has better rates at quote time, or fall back to the other if one is degraded or unavailable.
+
 ## Bitcoin Implementation Details
 
 ### BDK Constants
@@ -394,14 +448,21 @@ agentic-aqua/
 │   └── aqua/
 │       ├── __init__.py
 │       ├── server.py   # MCP server entry point (tools, resources, prompts)
-│       ├── tools.py    # Tool implementations (lw_*, btc_*, unified_*, lightning_*)
+│       ├── tools.py    # Tool implementations (lw_*, btc_*, unified_*, lightning_*, changelly_*)
 │       ├── wallet.py   # Liquid wallet (LWK)
 │       ├── bitcoin.py  # Bitcoin wallet (BDK)
 │       ├── lightning.py # Lightning abstraction layer (unified send/receive manager)
 │       ├── boltz.py    # Boltz Exchange integration (submarine swaps, send)
 │       ├── ankara.py   # Ankara backend integration (Lightning receive)
+│       ├── changelly.py # Changelly USDt cross-chain swap integration (via Ankara proxy)
 │       ├── assets.py   # Asset registry
-│       └── storage.py  # Persistence layer (encryption, config, wallet data)
+│       ├── storage.py  # Persistence layer (encryption, config, wallet data)
+│       └── cli/
+│           ├── main.py / commands.py
+│           ├── liquid.py / btc.py / lightning.py
+│           ├── changelly.py # `aqua changelly …` (USDt cross-chain swap commands)
+│           ├── wallet.py / serve.py
+│           ├── output.py / password.py
 └── tests/
     ├── test_tools.py
     ├── test_lightning.py
@@ -409,6 +470,8 @@ agentic-aqua/
     ├── test_bitcoin.py
     ├── test_boltz.py
     ├── test_ankara.py
+    ├── test_changelly.py
+    ├── test_cli.py
     └── test_server.py
 ```
 

--- a/src/aqua/changelly.py
+++ b/src/aqua/changelly.py
@@ -145,7 +145,7 @@ _ADDRESS_PATTERNS: dict[str, re.Pattern[str]] = {
     "ethereum": re.compile(r"^0x[0-9a-fA-F]{40}$"),
     "bsc":      re.compile(r"^0x[0-9a-fA-F]{40}$"),
     "polygon":  re.compile(r"^0x[0-9a-fA-F]{40}$"),
-    "solana":   re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$"),
+    "solana":   re.compile(r"^[1-9A-HJ-NP-Za-km-z]{43,44}$"),
     "ton":      re.compile(r"^[EU][Qq][0-9A-Za-z_\-]{46}$"),
 }
 
@@ -158,8 +158,21 @@ def _validate_settle_address(network: str, address: str) -> None:
     """
     if not address or not address.strip():
         raise ValueError("settle_address cannot be empty")
-    pattern = _ADDRESS_PATTERNS.get(network.lower())
-    if pattern and not pattern.match(address):
+    norm = network.lower()
+    pattern = _ADDRESS_PATTERNS.get(norm)
+    if pattern is None:
+        # Drift guard: if someone adds a network to NETWORK_TO_USDT_ID
+        # without a matching pattern here, address validation silently
+        # becomes a no-op. Refuse rather than ship a footgun.
+        # "liquid" is intentionally absent — Liquid addresses are produced
+        # by the local wallet, not user-pasted.
+        if norm in NETWORK_TO_USDT_ID and norm != "liquid":
+            raise RuntimeError(
+                f"_ADDRESS_PATTERNS is missing an entry for supported network "
+                f"{norm!r}. Add the pattern alongside NETWORK_TO_USDT_ID."
+            )
+        return
+    if not pattern.match(address):
         raise ValueError(
             f"settle_address {address!r} doesn't look like a valid {network} address. "
             f"Double-check the address and network before sending."
@@ -609,6 +622,16 @@ class ChangellyManager:
         # human-readable decimals; our wallet expects integer sats. USDt-Liquid
         # uses 8 decimal places (same as L-BTC).
         deposit_sats = _decimal_to_sats(order.get("amountExpectedFrom") or amount_from)
+        # Defence in depth: refuse to sign a zero/negative-value send even if
+        # the Changelly response (or upstream wrapper) passed validation. The
+        # tool-layer wrapper checks amount_from, but the manager is also
+        # callable directly (tests, future callers) so re-check here.
+        if deposit_sats <= 0:
+            msg = f"Changelly returned non-positive deposit amount: {deposit_sats}"
+            swap.last_error = msg
+            swap.status = "failed"
+            self.storage.save_changelly_swap(swap)
+            raise RuntimeError(msg)
         try:
             txid = self.wallet_manager.send(
                 wallet_name,
@@ -649,6 +672,11 @@ class ChangellyManager:
         from_asset = network_to_asset_id(external_network)
         to_asset = LIQUID_USDT_ID
         _check_pair_allowed(from_asset, to_asset)
+        # Validate the user-supplied refund address against the source-chain
+        # format before we ship it to Changelly. Pasting a Liquid address as a
+        # Tron refund is exactly the footgun the docstring warns about.
+        if external_refund_address:
+            _validate_settle_address(external_network, external_refund_address)
 
         wallet_data = self.storage.load_wallet(wallet_name)
         if not wallet_data:

--- a/src/aqua/changelly.py
+++ b/src/aqua/changelly.py
@@ -43,11 +43,15 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import urllib.error
 import urllib.request
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from datetime import UTC, datetime
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Optional
+
+from .assets import lookup_asset_by_ticker
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +135,34 @@ def _check_pair_allowed(from_id: str, to_id: str) -> None:
             f"allowlist. One leg must be {LIQUID_USDT_ID!r} (USDt-Liquid); "
             f"the other must be one of: {allowed}. Set "
             f"CHANGELLY_ALLOW_ALL_PAIRS=1 to bypass."
+        )
+
+
+# Per-network address format patterns. Used to catch wrong-network addresses
+# before Changelly accepts the order (which could result in lost funds).
+_ADDRESS_PATTERNS: dict[str, re.Pattern[str]] = {
+    "tron":     re.compile(r"^T[1-9A-HJ-NP-Za-km-z]{33}$"),
+    "ethereum": re.compile(r"^0x[0-9a-fA-F]{40}$"),
+    "bsc":      re.compile(r"^0x[0-9a-fA-F]{40}$"),
+    "polygon":  re.compile(r"^0x[0-9a-fA-F]{40}$"),
+    "solana":   re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$"),
+    "ton":      re.compile(r"^[EU][Qq][0-9A-Za-z_\-]{46}$"),
+}
+
+
+def _validate_settle_address(network: str, address: str) -> None:
+    """Raise ValueError if `address` doesn't match the expected format for `network`.
+
+    Prevents sending to a wrong-network address — Changelly may accept it and
+    the funds would be unrecoverable.
+    """
+    if not address or not address.strip():
+        raise ValueError("settle_address cannot be empty")
+    pattern = _ADDRESS_PATTERNS.get(network.lower())
+    if pattern and not pattern.match(address):
+        raise ValueError(
+            f"settle_address {address!r} doesn't look like a valid {network} address. "
+            f"Double-check the address and network before sending."
         )
 
 
@@ -396,8 +428,11 @@ class ChangellyClient:
         if isinstance(resp, str):
             return resp
         if isinstance(resp, dict):
-            return resp.get("status") or resp.get("result") or "unknown"
-        return "unknown"
+            status = resp.get("status") or resp.get("result")
+            if not status:
+                raise RuntimeError(f"Changelly status response missing status/result field: {resp!r}")
+            return status
+        raise RuntimeError(f"Unexpected Changelly status response type {type(resp).__name__}: {resp!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -433,10 +468,8 @@ def changelly_track_url(order_id: str) -> str:
 
 
 # Liquid USDt asset id (hex) — what `WalletManager.send` expects when sending
-# a non-L-BTC Liquid asset.
-LIQUID_USDT_HEX = (
-    "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2"
-)
+# a non-L-BTC Liquid asset. Sourced from the canonical MAINNET_ASSETS registry.
+LIQUID_USDT_HEX = lookup_asset_by_ticker("USDt").asset_id  # type: ignore[union-attr]
 
 
 class ChangellyManager:
@@ -498,6 +531,7 @@ class ChangellyManager:
         settle_address: str,
         wallet_name: str = "default",
         password: Optional[str] = None,
+        rate_id: Optional[str] = None,
     ) -> "ChangellySwap":
         """Send USDt-Liquid out via a Changelly fixed-rate order.
 
@@ -507,14 +541,18 @@ class ChangellyManager:
             settle_address: external chain address to receive at.
             wallet_name: local Liquid wallet to sign with.
             password: mnemonic decryption password (if encrypted at rest).
+            rate_id: rate id from a prior changelly_quote call. If provided,
+                skips the internal quote fetch and uses this rate directly,
+                preventing rate drift between quote and execution.
 
         Returns a persisted `ChangellySwap` with the broadcast `deposit_hash`
         and Changelly's order id.
         """
         from_asset = LIQUID_USDT_ID
         to_asset = network_to_asset_id(external_network)
-        # Validate the agreed pair before any HTTP work.
+        # Validate the agreed pair and destination address before any HTTP work.
         _check_pair_allowed(from_asset, to_asset)
+        _validate_settle_address(external_network, settle_address)
 
         wallet_data = self.storage.load_wallet(wallet_name)
         if not wallet_data:
@@ -530,15 +568,17 @@ class ChangellyManager:
         # Refund address: wallet's own Liquid address (USDt-Liquid is on Liquid).
         refund_address = self.wallet_manager.get_address(wallet_name).address
 
-        # Step 1 — fixed-rate quote
-        quote = self.client.get_fix_rate_for_amount(
-            from_asset=from_asset,
-            to_asset=to_asset,
-            amount_from=amount_from,
-        )
-        rate_id = quote.get("id") or quote.get("rateId")
-        if not rate_id:
-            raise RuntimeError(f"Unexpected Changelly quote response: {quote!r}")
+        # Step 1 — fixed-rate quote (skip if caller supplies a rate_id from a
+        # prior changelly_quote call to avoid rate drift between preview and send)
+        if rate_id is None:
+            quote = self.client.get_fix_rate_for_amount(
+                from_asset=from_asset,
+                to_asset=to_asset,
+                amount_from=amount_from,
+            )
+            rate_id = quote.get("id") or quote.get("rateId")
+            if not rate_id:
+                raise RuntimeError(f"Unexpected Changelly quote response: {quote!r}")
 
         # Step 2 — create fixed order
         order = self.client.create_fixed_transaction(
@@ -593,7 +633,7 @@ class ChangellyManager:
         external_network: str,
         wallet_name: str = "default",
         external_refund_address: Optional[str] = None,
-        amount_from: Optional[str] = None,
+        amount_from: str = "",
     ) -> "ChangellySwap":
         """Receive USDt-Liquid via a Changelly variable-rate order.
 
@@ -603,8 +643,8 @@ class ChangellyManager:
             external_refund_address: STRONGLY RECOMMENDED — sender's address
                 on the source chain. Without it, a stuck order requires
                 manual intervention via the Changelly web UI.
-            amount_from: optional reference amount. Variable orders accept any
-                amount; this is just for the quote preview.
+            amount_from: amount the external sender will deposit (decimal string,
+                e.g. "50"). Required by the Ankara backend serializer.
         """
         from_asset = network_to_asset_id(external_network)
         to_asset = LIQUID_USDT_ID
@@ -705,8 +745,6 @@ def _decimal_to_sats(decimal_str: str | float | int) -> int:
 
     USDt-Liquid uses 8 decimal places — same conversion as L-BTC sats.
     """
-    from decimal import Decimal, ROUND_HALF_UP
-
     d = Decimal(str(decimal_str))
     sats = (d * Decimal(100_000_000)).quantize(Decimal("1."), rounding=ROUND_HALF_UP)
     return int(sats)

--- a/src/aqua/changelly.py
+++ b/src/aqua/changelly.py
@@ -1,0 +1,712 @@
+"""Changelly integration for USDt cross-chain swaps via AQUA's backend proxy.
+
+Talks to Changelly through AQUA's Ankara proxy at
+`https://ankara.aquabtc.com/api/v1/changelly` so we don't have to manage a
+Changelly API secret on the user's machine.
+
+Scope (mirrors what AQUA Flutter exposes through Changelly): **USDt-Liquid
+↔ USDt on the same 6 external chains we allow in SideShift** (Ethereum, Tron,
+BSC, Solana, Polygon, TON). One leg of every swap MUST be `lusdt` (USDt-Liquid);
+the other MUST be one of those 6 external USDt variants. L-BTC, BTC, and
+arbitrary altcoins are intentionally excluded — for those use SideSwap or
+SideShift. The override env var `CHANGELLY_ALLOW_ALL_PAIRS=1` bypasses the
+allowlist for testing or power use.
+
+Endpoints used (REST/JSON, base `https://ankara.aquabtc.com/api/v1/changelly`):
+
+  GET  /currencies                 — list of supported currencies
+  POST /pairs                      — available pairs (filterable by from/to)
+  POST /get-fix-rate-for-amount    — fixed-rate quote (commit to a rate)
+  POST /quote                      — variable-rate quote
+  POST /create-fix-transaction     — create a fixed order from a quote
+  POST /create-transaction         — create a variable order
+  GET  /status/{orderId}           — poll order status
+
+Asset id conventions (Changelly's own format, distinct from SideShift's):
+
+  lusdt        — USDt on Liquid
+  usdt20       — USDt on Ethereum (ERC-20)
+  usdtrx       — USDt on Tron (TRC-20)
+  usdtbsc      — USDt on BSC
+  usdtsol      — USDt on Solana
+  usdtpolygon  — USDt on Polygon
+  usdton       — USDt on TON
+
+Status state machine (lowercase): `new`, `waiting`, `confirming`, `exchanging`,
+`sending`, `finished` (success), `failed`, `refunded`, `hold`, `overdue`,
+`expired`. Helpers `swap_is_final`, `swap_is_success`, `swap_is_failed`
+abstract over the terminal-state grouping.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Endpoint configuration — defaults to AQUA's Ankara proxy. Override for
+# testing or local development by setting CHANGELLY_BASE_URL.
+CHANGELLY_BASE_URL = os.environ.get(
+    "CHANGELLY_BASE_URL", "https://ankara.aquabtc.com/api/v1/changelly"
+)
+USER_AGENT = "agentic-aqua"
+HTTP_TIMEOUT_SECONDS = 30.0
+
+
+# ---------------------------------------------------------------------------
+# Asset identifiers + curated allowlist
+# ---------------------------------------------------------------------------
+
+# Changelly's identifier for USDt on the Liquid Network. One leg of every
+# swap we support is this one.
+LIQUID_USDT_ID = "lusdt"
+
+# The 6 external USDt variants we expose. Mirrors the non-Liquid USDt subset
+# of SideShift's allowlist (ethereum, tron, bsc, solana, polygon, ton).
+EXTERNAL_USDT_IDS = frozenset({
+    "usdt20",      # Ethereum (ERC-20)
+    "usdtrx",      # Tron (TRC-20)
+    "usdtbsc",     # BSC
+    "usdtsol",     # Solana
+    "usdtpolygon", # Polygon
+    "usdton",      # TON
+})
+
+# Curated pair allowlist: one leg must be lusdt, the other must be in
+# EXTERNAL_USDT_IDS. Mirrors AQUA Flutter's `ChangellyAssetIds` set in
+# `lib/features/changelly/models/changelly_models.dart` (intersected with
+# our SideShift allowlist for consistency between the two integrations).
+ALLOWED_PAIRS: frozenset[tuple[str, str]] = frozenset(
+    [(LIQUID_USDT_ID, ext) for ext in EXTERNAL_USDT_IDS]
+    + [(ext, LIQUID_USDT_ID) for ext in EXTERNAL_USDT_IDS]
+)
+
+# User-facing network-name → Changelly asset_id mapping. Used by the MCP
+# tools / CLI so users say "tron" rather than "usdtrx" — same vocabulary as
+# the SideShift surface.
+NETWORK_TO_USDT_ID = {
+    "liquid": "lusdt",
+    "ethereum": "usdt20",
+    "tron": "usdtrx",
+    "bsc": "usdtbsc",
+    "solana": "usdtsol",
+    "polygon": "usdtpolygon",
+    "ton": "usdton",
+}
+USDT_ID_TO_NETWORK = {v: k for k, v in NETWORK_TO_USDT_ID.items()}
+
+
+def _allow_all_pairs() -> bool:
+    """Read the override env var. Re-read on every check so tests can mutate it.
+
+    Accepts `1`, `true`, `yes` (case-insensitive) as truthy.
+    """
+    return os.environ.get("CHANGELLY_ALLOW_ALL_PAIRS", "").strip().lower() in {
+        "1", "true", "yes",
+    }
+
+
+def _check_pair_allowed(from_id: str, to_id: str) -> None:
+    """Raise ValueError if the (from, to) pair isn't on the allowlist.
+
+    Both legs combined must form a curated pair: exactly one leg is `lusdt`,
+    the other is one of the 6 external USDt variants. The override env var
+    bypasses the check entirely.
+    """
+    if _allow_all_pairs():
+        return
+    pair = (from_id.lower(), to_id.lower())
+    if pair not in ALLOWED_PAIRS:
+        allowed = ", ".join(sorted(EXTERNAL_USDT_IDS))
+        raise ValueError(
+            f"Changelly pair ({from_id} → {to_id}) is not in the curated "
+            f"allowlist. One leg must be {LIQUID_USDT_ID!r} (USDt-Liquid); "
+            f"the other must be one of: {allowed}. Set "
+            f"CHANGELLY_ALLOW_ALL_PAIRS=1 to bypass."
+        )
+
+
+def network_to_asset_id(network: str) -> str:
+    """Translate a user-facing network name to Changelly's asset id.
+
+    Args:
+        network: Lowercase network name (e.g. "tron", "liquid", "ethereum").
+
+    Returns:
+        The Changelly asset id (e.g. "usdtrx", "lusdt", "usdt20").
+
+    Raises:
+        ValueError if the network is not a USDt-supporting network we recognise.
+    """
+    norm = network.lower()
+    if norm not in NETWORK_TO_USDT_ID:
+        allowed = ", ".join(sorted(NETWORK_TO_USDT_ID))
+        raise ValueError(
+            f"Unknown network for Changelly USDt swap: {network!r}. "
+            f"Supported: {allowed}."
+        )
+    return NETWORK_TO_USDT_ID[norm]
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ChangellyQuote:
+    """A fixed-rate quote from `/get-fix-rate-for-amount`.
+
+    Note: amounts are decimal strings (e.g. "100.0") to preserve precision.
+    `expired_at` is a Unix-epoch seconds timestamp.
+    """
+
+    quote_id: str
+    from_asset: str
+    to_asset: str
+    amount_from: str
+    amount_to: str
+    network_fee: str
+    min_from: str
+    max_from: str
+    expired_at: int
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class ChangellySwap:
+    """Persistent record of a Changelly cross-chain swap (send or receive)."""
+
+    order_id: str
+    swap_type: str  # "fixed" | "variable"
+    direction: str  # "send" (we sign deposit) | "receive" (we provide settle address)
+    from_asset: str  # Changelly asset id (e.g. "lusdt", "usdtrx")
+    to_asset: str
+    settle_address: str  # `payoutAddress` in Changelly terms
+    deposit_address: str  # `payinAddress` in Changelly terms
+    refund_address: Optional[str]
+    wallet_name: Optional[str]
+    status: str
+    created_at: str
+    expires_at: Optional[str] = None  # ISO timestamp; from `payTill` for fixed orders
+    amount_from: Optional[str] = None
+    amount_to: Optional[str] = None
+    network_fee: Optional[str] = None
+    quote_id: Optional[str] = None  # fixed orders only
+    deposit_hash: Optional[str] = None  # txid we broadcast (send flow)
+    track_url: Optional[str] = None
+    last_checked_at: Optional[str] = None
+    last_error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ChangellySwap":
+        data = {**data}
+        for f in (
+            "expires_at", "amount_from", "amount_to", "network_fee", "quote_id",
+            "deposit_hash", "track_url", "last_checked_at", "last_error",
+        ):
+            data.setdefault(f, None)
+        return cls(**data)
+
+
+# ---------------------------------------------------------------------------
+# REST client
+# ---------------------------------------------------------------------------
+
+
+class ChangellyClient:
+    """HTTP client for AQUA's Changelly proxy.
+
+    No auth required — AQUA's backend handles the Changelly API secret. We
+    just speak JSON.
+    """
+
+    def __init__(self, base_url: Optional[str] = None) -> None:
+        self.base_url = (base_url or CHANGELLY_BASE_URL).rstrip("/")
+
+    def _api_request(self, method: str, path: str, body: Optional[dict] = None) -> Any:
+        url = f"{self.base_url}{path}"
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": USER_AGENT,
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:
+                raw = resp.read().decode()
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as e:
+            detail = ""
+            try:
+                err_body = json.loads(e.read().decode())
+                if isinstance(err_body, dict):
+                    detail = (
+                        err_body.get("error")
+                        or err_body.get("message")
+                        or str(err_body)
+                    )
+            except Exception:
+                pass
+            msg = f"Changelly API error ({e.code} {method} {path})"
+            if detail:
+                msg += f": {detail}"
+            raise RuntimeError(msg) from e
+        except urllib.error.URLError as e:
+            raise RuntimeError(
+                f"Changelly API unreachable ({method} {path}): {e.reason}"
+            ) from e
+
+    # -- Endpoints -----------------------------------------------------------
+
+    def get_currencies(self) -> list[str]:
+        """List supported currencies. Returns Changelly asset ids (e.g. "lusdt", "btc")."""
+        resp = self._api_request("GET", "/currencies")
+        if isinstance(resp, dict):
+            return resp.get("result", []) or []
+        return resp or []
+
+    def get_pairs(
+        self,
+        from_asset: Optional[str] = None,
+        to_asset: Optional[str] = None,
+    ) -> list[dict]:
+        """Fetch available pairs. Optionally filter by from / to asset id.
+
+        Returns a list of `{from, to}` dicts.
+        """
+        body: dict[str, Any] = {}
+        if from_asset:
+            body["from"] = from_asset.lower()
+        if to_asset:
+            body["to"] = to_asset.lower()
+        resp = self._api_request("POST", "/pairs", body=body)
+        return resp or []
+
+    def get_fix_rate_for_amount(
+        self,
+        from_asset: str,
+        to_asset: str,
+        amount_from: Optional[str] = None,
+        amount_to: Optional[str] = None,
+    ) -> dict:
+        """Fixed-rate quote (~5-30 minute TTL). Returns `{id, result, expiredAt, ...}`.
+
+        Provide exactly one of `amount_from` or `amount_to`. Amounts are
+        decimal strings to preserve precision.
+        """
+        if (amount_from is None) == (amount_to is None):
+            raise ValueError("exactly one of amount_from or amount_to must be provided")
+        body: dict[str, Any] = {
+            "from": from_asset.lower(),
+            "to": to_asset.lower(),
+        }
+        if amount_from is not None:
+            body["amountFrom"] = amount_from
+        if amount_to is not None:
+            body["amountTo"] = amount_to
+        return self._api_request("POST", "/get-fix-rate-for-amount", body=body) or {}
+
+    def get_variable_quote(
+        self,
+        from_asset: str,
+        to_asset: str,
+        amount_from: str,
+    ) -> dict:
+        """Variable-rate quote. Returns the first quote from the response list."""
+        body = {
+            "from": from_asset.lower(),
+            "to": to_asset.lower(),
+            "amountFrom": amount_from,
+        }
+        resp = self._api_request("POST", "/quote", body=body)
+        if isinstance(resp, list):
+            if not resp:
+                raise RuntimeError("Changelly /quote returned no quotes")
+            return resp[0]
+        return resp or {}
+
+    def create_fixed_transaction(
+        self,
+        from_asset: str,
+        to_asset: str,
+        rate_id: str,
+        address: str,
+        refund_address: str,
+        amount_from: Optional[str] = None,
+        amount_to: Optional[str] = None,
+    ) -> dict:
+        """Create a fixed-rate order. Returns full order incl. `payinAddress`, `payTill`."""
+        body: dict[str, Any] = {
+            "from": from_asset.lower(),
+            "to": to_asset.lower(),
+            "rateId": rate_id,
+            "address": address,
+            "refundAddress": refund_address,
+        }
+        if amount_from is not None:
+            body["amountFrom"] = amount_from
+        if amount_to is not None:
+            body["amountTo"] = amount_to
+        return self._api_request("POST", "/create-fix-transaction", body=body) or {}
+
+    def create_variable_transaction(
+        self,
+        from_asset: str,
+        to_asset: str,
+        address: str,
+        refund_address: Optional[str] = None,
+        amount_from: Optional[str] = None,
+        amount_to: Optional[str] = None,
+    ) -> dict:
+        """Create a variable-rate order. Returns full order incl. `payinAddress`."""
+        body: dict[str, Any] = {
+            "from": from_asset.lower(),
+            "to": to_asset.lower(),
+            "address": address,
+        }
+        if refund_address:
+            body["refundAddress"] = refund_address
+        if amount_from is not None:
+            body["amountFrom"] = amount_from
+        if amount_to is not None:
+            body["amountTo"] = amount_to
+        return self._api_request("POST", "/create-transaction", body=body) or {}
+
+    def get_status(self, order_id: str) -> str:
+        """Poll order status. Returns the bare status string (e.g. 'finished')."""
+        resp = self._api_request("GET", f"/status/{order_id}")
+        if isinstance(resp, str):
+            return resp
+        if isinstance(resp, dict):
+            return resp.get("status") or resp.get("result") or "unknown"
+        return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Status helpers
+# ---------------------------------------------------------------------------
+
+# Lowercase status strings per Changelly's `ChangellyOrderStatus` enum.
+_FINAL_STATUSES = {"finished", "failed", "refunded", "expired", "overdue", "hold"}
+_SUCCESS_STATUSES = {"finished"}
+_FAILED_STATUSES = {"failed", "refunded", "expired", "overdue"}
+
+
+def swap_is_final(status: str) -> bool:
+    return status.lower() in _FINAL_STATUSES
+
+
+def swap_is_success(status: str) -> bool:
+    return status.lower() in _SUCCESS_STATUSES
+
+
+def swap_is_failed(status: str) -> bool:
+    return status.lower() in _FAILED_STATUSES
+
+
+def changelly_track_url(order_id: str) -> str:
+    """Public Changelly tracking URL for the given order id."""
+    return f"https://changelly.com/track/{order_id}"
+
+
+# ---------------------------------------------------------------------------
+# High-level manager
+# ---------------------------------------------------------------------------
+
+
+# Liquid USDt asset id (hex) — what `WalletManager.send` expects when sending
+# a non-L-BTC Liquid asset.
+LIQUID_USDT_HEX = (
+    "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2"
+)
+
+
+class ChangellyManager:
+    """Orchestrates Changelly send / receive flows tied to AQUA's wallet manager.
+
+    Two flows mirror SideShift:
+
+    1. **Send** (`send_swap`): user holds USDt-Liquid and wants USDt on
+       another chain. We get a fixed-rate quote, create a fixed order, and
+       broadcast the deposit from the Liquid wallet.
+
+    2. **Receive** (`receive_swap`): user wants USDt-Liquid in. We create
+       a variable-rate order with the wallet's Liquid address as the settle
+       target; the external sender pays the returned deposit address from
+       any USDt-supporting chain.
+
+    Both flows always set a refund address (the wallet's own Liquid address
+    on send; user-supplied external address on receive — strongly
+    recommended). Without one, a stuck order requires manual intervention
+    via the Changelly web UI.
+    """
+
+    def __init__(self, storage, wallet_manager) -> None:
+        self.storage = storage
+        self.wallet_manager = wallet_manager
+        self._client: Optional[ChangellyClient] = None
+
+    @property
+    def client(self) -> ChangellyClient:
+        if self._client is None:
+            self._client = ChangellyClient()
+        return self._client
+
+    # -- Read-only helpers ---------------------------------------------------
+
+    def list_currencies(self) -> list[str]:
+        return self.client.get_currencies()
+
+    def fixed_quote(
+        self,
+        from_asset: str,
+        to_asset: str,
+        amount_from: Optional[str] = None,
+        amount_to: Optional[str] = None,
+    ) -> dict:
+        # Allowlist-check the pair even on quote so we fail fast in the UI.
+        _check_pair_allowed(from_asset, to_asset)
+        return self.client.get_fix_rate_for_amount(
+            from_asset, to_asset,
+            amount_from=amount_from, amount_to=amount_to,
+        )
+
+    # -- Send flow (USDt-Liquid → USDt-on-external-chain) --------------------
+
+    def send_swap(
+        self,
+        external_network: str,
+        amount_from: str,
+        settle_address: str,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+    ) -> "ChangellySwap":
+        """Send USDt-Liquid out via a Changelly fixed-rate order.
+
+        Args:
+            external_network: target USDt network (e.g. "tron", "ethereum").
+            amount_from: USDt-Liquid to send (decimal string, e.g. "100").
+            settle_address: external chain address to receive at.
+            wallet_name: local Liquid wallet to sign with.
+            password: mnemonic decryption password (if encrypted at rest).
+
+        Returns a persisted `ChangellySwap` with the broadcast `deposit_hash`
+        and Changelly's order id.
+        """
+        from_asset = LIQUID_USDT_ID
+        to_asset = network_to_asset_id(external_network)
+        # Validate the agreed pair before any HTTP work.
+        _check_pair_allowed(from_asset, to_asset)
+
+        wallet_data = self.storage.load_wallet(wallet_name)
+        if not wallet_data:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+        if wallet_data.watch_only:
+            raise ValueError("Watch-only wallet cannot sign a Changelly deposit")
+        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
+            wallet_data.encrypted_mnemonic
+        ):
+            if not password:
+                raise ValueError("Password required to decrypt mnemonic")
+
+        # Refund address: wallet's own Liquid address (USDt-Liquid is on Liquid).
+        refund_address = self.wallet_manager.get_address(wallet_name).address
+
+        # Step 1 — fixed-rate quote
+        quote = self.client.get_fix_rate_for_amount(
+            from_asset=from_asset,
+            to_asset=to_asset,
+            amount_from=amount_from,
+        )
+        rate_id = quote.get("id") or quote.get("rateId")
+        if not rate_id:
+            raise RuntimeError(f"Unexpected Changelly quote response: {quote!r}")
+
+        # Step 2 — create fixed order
+        order = self.client.create_fixed_transaction(
+            from_asset=from_asset,
+            to_asset=to_asset,
+            rate_id=rate_id,
+            address=settle_address,
+            refund_address=refund_address,
+            amount_from=amount_from,
+        )
+        order_id = order.get("id")
+        deposit_address = order.get("payinAddress")
+        if not order_id or not deposit_address:
+            raise RuntimeError(f"Unexpected Changelly order response: {order!r}")
+
+        swap = self._swap_from_response(
+            order,
+            swap_type="fixed",
+            direction="send",
+            wallet_name=wallet_name,
+            refund_address=refund_address,
+            quote_id=rate_id,
+        )
+        # Persist BEFORE broadcasting so a crash mid-broadcast is recoverable.
+        self.storage.save_changelly_swap(swap)
+
+        # Step 3 — broadcast the USDt-Liquid deposit. Changelly amounts are
+        # human-readable decimals; our wallet expects integer sats. USDt-Liquid
+        # uses 8 decimal places (same as L-BTC).
+        deposit_sats = _decimal_to_sats(order.get("amountExpectedFrom") or amount_from)
+        try:
+            txid = self.wallet_manager.send(
+                wallet_name,
+                deposit_address,
+                deposit_sats,
+                asset_id=LIQUID_USDT_HEX,
+                password=password,
+            )
+        except Exception as e:
+            swap.last_error = f"Deposit broadcast failed: {e}"
+            swap.status = swap.status or "failed"
+            self.storage.save_changelly_swap(swap)
+            raise
+        swap.deposit_hash = txid
+        self.storage.save_changelly_swap(swap)
+        return swap
+
+    # -- Receive flow (USDt-on-external → USDt-Liquid) -----------------------
+
+    def receive_swap(
+        self,
+        external_network: str,
+        wallet_name: str = "default",
+        external_refund_address: Optional[str] = None,
+        amount_from: Optional[str] = None,
+    ) -> "ChangellySwap":
+        """Receive USDt-Liquid via a Changelly variable-rate order.
+
+        Args:
+            external_network: source USDt network the external sender pays from.
+            wallet_name: local Liquid wallet to receive into.
+            external_refund_address: STRONGLY RECOMMENDED — sender's address
+                on the source chain. Without it, a stuck order requires
+                manual intervention via the Changelly web UI.
+            amount_from: optional reference amount. Variable orders accept any
+                amount; this is just for the quote preview.
+        """
+        from_asset = network_to_asset_id(external_network)
+        to_asset = LIQUID_USDT_ID
+        _check_pair_allowed(from_asset, to_asset)
+
+        wallet_data = self.storage.load_wallet(wallet_name)
+        if not wallet_data:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+
+        settle_address = self.wallet_manager.get_address(wallet_name).address
+
+        order = self.client.create_variable_transaction(
+            from_asset=from_asset,
+            to_asset=to_asset,
+            address=settle_address,
+            refund_address=external_refund_address,
+            amount_from=amount_from,
+        )
+        order_id = order.get("id")
+        deposit_address = order.get("payinAddress")
+        if not order_id or not deposit_address:
+            raise RuntimeError(f"Unexpected Changelly order response: {order!r}")
+
+        swap = self._swap_from_response(
+            order,
+            swap_type="variable",
+            direction="receive",
+            wallet_name=wallet_name,
+            refund_address=external_refund_address,
+        )
+        self.storage.save_changelly_swap(swap)
+        return swap
+
+    # -- Status polling ------------------------------------------------------
+
+    def status(self, order_id: str) -> dict:
+        swap = self.storage.load_changelly_swap(order_id)
+        if not swap:
+            raise ValueError(f"Changelly swap not found: {order_id}")
+
+        warning = None
+        try:
+            new_status = self.client.get_status(order_id)
+            swap.status = (new_status or swap.status).lower()
+            swap.last_checked_at = datetime.now(UTC).isoformat()
+            self.storage.save_changelly_swap(swap)
+        except Exception as e:
+            warning = f"Could not refresh status: {e}"
+
+        result = swap.to_dict()
+        result["is_final"] = swap_is_final(swap.status)
+        result["is_success"] = swap_is_success(swap.status)
+        result["is_failed"] = swap_is_failed(swap.status)
+        if warning:
+            result["warning"] = warning
+        return result
+
+    # -- Helpers -------------------------------------------------------------
+
+    def _swap_from_response(
+        self,
+        resp: dict,
+        *,
+        swap_type: str,
+        direction: str,
+        wallet_name: Optional[str],
+        refund_address: Optional[str],
+        quote_id: Optional[str] = None,
+    ) -> "ChangellySwap":
+        return ChangellySwap(
+            order_id=resp["id"],
+            swap_type=swap_type,
+            direction=direction,
+            from_asset=resp.get("currencyFrom", ""),
+            to_asset=resp.get("currencyTo", ""),
+            settle_address=resp.get("payoutAddress", ""),
+            deposit_address=resp["payinAddress"],
+            refund_address=refund_address,
+            wallet_name=wallet_name,
+            status=(resp.get("status") or "new").lower(),
+            created_at=datetime.now(UTC).isoformat(),
+            expires_at=resp.get("payTill"),
+            amount_from=resp.get("amountExpectedFrom"),
+            amount_to=resp.get("amountExpectedTo"),
+            network_fee=resp.get("networkFee"),
+            quote_id=quote_id,
+            track_url=resp.get("trackUrl") or changelly_track_url(resp["id"]),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _decimal_to_sats(decimal_str: str | float | int) -> int:
+    """Convert a Changelly human-readable amount (e.g. "100.0") to integer sats.
+
+    USDt-Liquid uses 8 decimal places — same conversion as L-BTC sats.
+    """
+    from decimal import Decimal, ROUND_HALF_UP
+
+    d = Decimal(str(decimal_str))
+    sats = (d * Decimal(100_000_000)).quantize(Decimal("1."), rounding=ROUND_HALF_UP)
+    return int(sats)

--- a/src/aqua/cli/changelly.py
+++ b/src/aqua/cli/changelly.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import logging
+
 import click
+
+logger = logging.getLogger(__name__)
 
 from ..tools import (
     changelly_list_currencies,
@@ -100,6 +104,7 @@ def send(ctx, external_network, settle_address, amount_from, wallet_name,
     from the local wallet. A refund address is set automatically (the
     wallet's own Liquid address).
     """
+    rate_id = None
     if not skip_confirm:
         click.echo("Fetching Changelly quote…", err=True)
         try:
@@ -110,6 +115,7 @@ def send(ctx, external_network, settle_address, amount_from, wallet_name,
             )
         except Exception as e:
             raise click.UsageError(f"Could not fetch quote: {e}") from e
+        rate_id = preview.get("id")
         click.echo(
             f"Send: {preview.get('amountFrom')} USDt-Liquid\n"
             f"Recv: {preview.get('amountTo')} USDt on {external_network} "
@@ -133,6 +139,7 @@ def send(ctx, external_network, settle_address, amount_from, wallet_name,
                 "amount_from": amount_from,
                 "wallet_name": wallet_name,
                 "password": password,
+                "rate_id": rate_id,
             },
         ),
     )
@@ -149,8 +156,8 @@ def send(ctx, external_network, settle_address, amount_from, wallet_name,
     help="Source-chain refund address (STRONGLY RECOMMENDED).",
 )
 @click.option(
-    "--amount-from", default=None,
-    help="Optional reference amount for the quote preview.",
+    "--amount-from", required=True,
+    help="Amount the external sender will deposit (decimal string, e.g. '50').",
 )
 @click.pass_obj
 def receive(ctx, external_network, wallet_name, external_refund_address, amount_from):
@@ -161,6 +168,12 @@ def receive(ctx, external_network, wallet_name, external_refund_address, amount_
     `--external-refund-address`, a stuck order requires manual intervention
     via Changelly's web UI.
     """
+    if external_refund_address is None or not str(external_refund_address).strip():
+        logger.warning(
+            "Changelly receive: no --external-refund-address. Omitting it may leave "
+            "orders stuck and require manual intervention via Changelly's web UI; "
+            "use --external-refund-address with a source-chain refund address when possible."
+        )
     run_tool(
         ctx,
         lambda: changelly_receive(

--- a/src/aqua/cli/changelly.py
+++ b/src/aqua/cli/changelly.py
@@ -1,0 +1,180 @@
+"""Changelly CLI — USDt cross-chain swaps via AQUA's Ankara proxy."""
+
+from __future__ import annotations
+
+import click
+
+from ..tools import (
+    changelly_list_currencies,
+    changelly_quote,
+    changelly_receive,
+    changelly_send,
+    changelly_status,
+)
+from .output import run_tool
+from .password import handle_password_retry, resolve_secret
+
+
+_EXTERNAL_NETWORK = click.Choice([
+    "ethereum", "tron", "bsc", "solana", "polygon", "ton",
+])
+_DIRECTION = click.Choice(["send", "receive"])
+_PASSWORD_HELP = (
+    "Read wallet password from stdin (piped) or prompt interactively. "
+    "Without this flag, falls back to the AQUA_PASSWORD environment variable, "
+    "then to no password."
+)
+
+
+@click.group()
+def changelly():
+    """Changelly — USDt cross-chain swaps (Liquid ↔ ETH/Tron/BSC/Solana/Polygon/TON).
+
+    Routed through AQUA's Ankara backend proxy. For Liquid-only swaps
+    (e.g. L-BTC ↔ USDt-Liquid) prefer `aqua sideswap` (atomic on Liquid).
+
+    Scope: USDt-Liquid ↔ USDt on the 6 supported external chains. For BTC,
+    L-BTC, or non-USDt swaps, use `aqua sideswap` or `aqua sideshift`.
+    """
+
+
+@changelly.command("currencies")
+@click.pass_obj
+def currencies(ctx):
+    """List currencies Changelly supports (read-only; for discovery)."""
+    run_tool(ctx, lambda: changelly_list_currencies())
+
+
+@changelly.command("quote")
+@click.option(
+    "--external-network", required=True, type=_EXTERNAL_NETWORK,
+    help="USDt network on the non-Liquid side.",
+)
+@click.option(
+    "--direction", type=_DIRECTION, default="send", show_default=True,
+    help="'send' = deposit USDt-Liquid; 'receive' = deposit USDt on external chain.",
+)
+@click.option("--amount-from", default=None, help="Deposit-side amount (decimal string).")
+@click.option("--amount-to", default=None, help="Settle-side amount (decimal string).")
+@click.pass_obj
+def quote(ctx, external_network, direction, amount_from, amount_to):
+    """Get a fixed-rate quote for a USDt-Liquid ↔ USDt-on-X swap."""
+    if (amount_from is None) == (amount_to is None):
+        raise click.UsageError("Provide exactly one of --amount-from or --amount-to.")
+    run_tool(
+        ctx,
+        lambda: changelly_quote(
+            external_network=external_network,
+            direction=direction,
+            amount_from=amount_from,
+            amount_to=amount_to,
+        ),
+    )
+
+
+@changelly.command("send")
+@click.option(
+    "--external-network", required=True, type=_EXTERNAL_NETWORK,
+    help="Target USDt network (USDt arrives here).",
+)
+@click.option("--settle-address", required=True, help="External chain address to receive at.")
+@click.option(
+    "--amount-from", required=True,
+    help="USDt-Liquid to send (decimal string, e.g. '100').",
+)
+@click.option("--wallet-name", default="default", show_default=True)
+@click.option(
+    "--yes", "-y", "skip_confirm", is_flag=True, default=False,
+    help="Skip the interactive quote-confirmation prompt.",
+)
+@click.option(
+    "--password-stdin", "password_stdin", is_flag=True, default=False,
+    help=_PASSWORD_HELP,
+)
+@click.pass_obj
+def send(ctx, external_network, settle_address, amount_from, wallet_name,
+         skip_confirm, password_stdin):
+    """Send USDt-Liquid out to USDt on another chain (fixed-rate).
+
+    Gets a quote, creates the order, and broadcasts the USDt-Liquid deposit
+    from the local wallet. A refund address is set automatically (the
+    wallet's own Liquid address).
+    """
+    if not skip_confirm:
+        click.echo("Fetching Changelly quote…", err=True)
+        try:
+            preview = changelly_quote(
+                external_network=external_network,
+                direction="send",
+                amount_from=amount_from,
+            )
+        except Exception as e:
+            raise click.UsageError(f"Could not fetch quote: {e}") from e
+        click.echo(
+            f"Send: {preview.get('amountFrom')} USDt-Liquid\n"
+            f"Recv: {preview.get('amountTo')} USDt on {external_network} "
+            f"at {settle_address}\n"
+            f"Network fee: {preview.get('networkFee')}\n"
+            f"Quote expires (epoch): {preview.get('expiredAt')}",
+            err=True,
+        )
+        click.confirm("Proceed with this swap?", abort=True, err=True)
+
+    password = resolve_secret(
+        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
+    )
+    run_tool(
+        ctx,
+        lambda: handle_password_retry(
+            changelly_send,
+            {
+                "external_network": external_network,
+                "settle_address": settle_address,
+                "amount_from": amount_from,
+                "wallet_name": wallet_name,
+                "password": password,
+            },
+        ),
+    )
+
+
+@changelly.command("receive")
+@click.option(
+    "--external-network", required=True, type=_EXTERNAL_NETWORK,
+    help="Source USDt network (external sender pays from here).",
+)
+@click.option("--wallet-name", default="default", show_default=True)
+@click.option(
+    "--external-refund-address", default=None,
+    help="Source-chain refund address (STRONGLY RECOMMENDED).",
+)
+@click.option(
+    "--amount-from", default=None,
+    help="Optional reference amount for the quote preview.",
+)
+@click.pass_obj
+def receive(ctx, external_network, wallet_name, external_refund_address, amount_from):
+    """Create a variable-rate Changelly order to receive USDt-Liquid.
+
+    Returns a deposit address on the source chain. The external sender pays
+    to it from any USDt-supporting wallet on that network. Without an
+    `--external-refund-address`, a stuck order requires manual intervention
+    via Changelly's web UI.
+    """
+    run_tool(
+        ctx,
+        lambda: changelly_receive(
+            external_network=external_network,
+            wallet_name=wallet_name,
+            external_refund_address=external_refund_address,
+            amount_from=amount_from,
+        ),
+    )
+
+
+@changelly.command("status")
+@click.option("--order-id", required=True, help="ID returned from `aqua changelly send` or `… receive`.")
+@click.pass_obj
+def status(ctx, order_id):
+    """Check the status of a Changelly swap order."""
+    run_tool(ctx, lambda: changelly_status(order_id))

--- a/src/aqua/cli/commands.py
+++ b/src/aqua/cli/commands.py
@@ -9,6 +9,7 @@ from .output import run_tool
 def register_commands(cli):
     """Register all subcommand groups and top-level commands on the root CLI group."""
     from .btc import btc
+    from .changelly import changelly
     from .lightning import lightning
     from .liquid import liquid
     from .serve import serve
@@ -18,6 +19,7 @@ def register_commands(cli):
     cli.add_command(liquid)
     cli.add_command(btc)
     cli.add_command(lightning)
+    cli.add_command(changelly)
     cli.add_command(serve)
     cli.add_command(balance)
 

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1822,8 +1822,10 @@ Please:
 2. STRONGLY recommend providing an external_refund_address — the source
    chain address the external sender controls. Without it, a stuck order
    requires manual web UI intervention. Ask for it.
-3. Optional: ask if the user knows the rough amount; if yes, pass it as
-   amount_from for a better rate preview
+3. Ask the user for the deposit amount in source-chain USDt (decimal string,
+   e.g. "50"). This is REQUIRED — the Ankara backend serialiser rejects
+   the request without it — and the changelly_receive tool will refuse an
+   empty value. Pass it as amount_from.
 4. Call changelly_receive — this creates a variable-rate order
 5. Show me clearly:
    - The deposit address on the source chain (this is what the external

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -453,6 +453,107 @@ TOOL_SCHEMAS = {
             "required": ["swap_id"],
         },
     },
+    "changelly_list_currencies": {
+        "description": (
+            "List the currencies Changelly supports (Changelly's own asset id format). "
+            "Useful for discovery; the agentic-aqua surface only enables the curated "
+            "USDt-Liquid ↔ USDt-on-{ethereum,tron,bsc,solana,polygon,ton} pairs for "
+            "actual swaps."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    "changelly_quote": {
+        "description": (
+            "Get a fixed-rate Changelly quote for a USDt-Liquid ↔ USDt-on-X swap. "
+            "Provide exactly one of deposit_amount or settle_amount as a decimal string. "
+            "Use BEFORE changelly_send to confirm the price with the user."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "external_network": {
+                    "type": "string",
+                    "enum": ["ethereum", "tron", "bsc", "solana", "polygon", "ton"],
+                    "description": "USDt network on the non-Liquid side",
+                },
+                "direction": {
+                    "type": "string",
+                    "enum": ["send", "receive"],
+                    "default": "send",
+                    "description": "'send' = deposit USDt-Liquid; 'receive' = deposit USDt on external chain",
+                },
+                "amount_from": {"type": "string", "description": "Deposit-side amount (decimal string)"},
+                "amount_to": {"type": "string", "description": "Settle-side amount (decimal string)"},
+            },
+            "required": ["external_network"],
+        },
+    },
+    "changelly_send": {
+        "description": (
+            "Send USDt-Liquid out via a Changelly fixed-rate swap. Gets a quote, "
+            "creates the order, and broadcasts the deposit from the local wallet. "
+            "Refund address is set automatically (the wallet's own Liquid address). "
+            "ALWAYS call changelly_quote first and confirm the price with the user."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "external_network": {
+                    "type": "string",
+                    "enum": ["ethereum", "tron", "bsc", "solana", "polygon", "ton"],
+                    "description": "Target USDt network",
+                },
+                "settle_address": {"type": "string", "description": "External chain address to receive USDt at"},
+                "amount_from": {"type": "string", "description": "USDt-Liquid to send (decimal string, e.g. '100')"},
+                "wallet_name": {"type": "string", "default": "default"},
+                "password": {"type": "string", "description": "Password to decrypt mnemonic (if encrypted at rest)"},
+            },
+            "required": ["external_network", "settle_address", "amount_from"],
+        },
+    },
+    "changelly_receive": {
+        "description": (
+            "Receive USDt-Liquid via a Changelly variable-rate swap. Returns a "
+            "deposit address on the source chain — the external sender pays to it. "
+            "Settles to the wallet's Liquid address as USDt-Liquid. STRONGLY RECOMMEND "
+            "passing external_refund_address."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "external_network": {
+                    "type": "string",
+                    "enum": ["ethereum", "tron", "bsc", "solana", "polygon", "ton"],
+                    "description": "Source USDt network the external sender pays from",
+                },
+                "wallet_name": {"type": "string", "default": "default"},
+                "external_refund_address": {
+                    "type": "string",
+                    "description": "Source-chain refund address (strongly recommended)",
+                },
+                "amount_from": {
+                    "type": "string",
+                    "description": "Optional reference amount for the quote preview",
+                },
+            },
+            "required": ["external_network"],
+        },
+    },
+    "changelly_status": {
+        "description": (
+            "Check the status of a Changelly swap order. Returns is_final / "
+            "is_success / is_failed booleans. State machine: new → waiting → "
+            "confirming → exchanging → sending → finished. Failure: failed, "
+            "refunded, expired, overdue."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "order_id": {"type": "string", "description": "ID from changelly_send or changelly_receive"},
+            },
+            "required": ["order_id"],
+        },
+    },
 }
 
 
@@ -519,6 +620,28 @@ LIGHTNING:
 - Use lightning_send to pay a BOLT11 invoice using L-BTC (submarine swap via Boltz)
   Fees: ~0.1% + miner fees, Limits: 100 - 25,000,000 Sats
 - Use lightning_transaction_status to check status of any Lightning swap (send or receive)
+
+CHANGELLY (custodial USDt cross-chain swaps via AQUA's Ankara proxy):
+- Use changelly_send when the user wants to send USDt-Liquid OUT to USDt on
+  another chain (Ethereum, Tron, BSC, Solana, Polygon, TON).
+- Use changelly_receive when the user wants to receive USDt-Liquid IN from
+  USDt on another chain. Returns a deposit address on the source chain.
+- ALWAYS call changelly_quote first for sends so the user can confirm the
+  rate before signing. Quotes are fixed-rate with a short TTL.
+- ALWAYS encourage providing external_refund_address on receives — without
+  it, a stuck order requires manual intervention via Changelly's web UI.
+- Use changelly_status to poll an order; the response includes is_final /
+  is_success / is_failed booleans.
+- TRUST MODEL: Changelly is custodial — they take the deposit and send the
+  converted asset from their hot wallet. Different from SideSwap (atomic on
+  Liquid) and Lightning (Boltz submarine, atomic). Communicate the trade-off.
+- SCOPE: USDt-Liquid ↔ USDt on the 6 supported chains only. For BTC ↔ X,
+  L-BTC ↔ X, or anything non-USDt, use SideSwap or SideShift instead.
+- SideSwap vs Changelly vs SideShift for similar flows:
+  - L-BTC ↔ USDt-Liquid: SideSwap (atomic, lower fees)
+  - USDt-Liquid ↔ USDt-Tron / USDt-Ethereum / etc.: Changelly OR SideShift
+    (both custodial; Changelly proxies through AQUA backend; SideShift uses
+    a public affiliate ID). Pick whichever is configured / has better rates.
 
 WATCH-ONLY WALLETS:
 - For a Bitcoin-only watch wallet: btc_import_descriptor (BIP84 wpkh xpub).
@@ -647,6 +770,29 @@ WALLET DELETION:
             Prompt(
                 name="pay_lightning",
                 description="Pay a Lightning invoice using Liquid Bitcoin (via Boltz submarine swap)",
+                arguments=[
+                    PromptArgument(name="wallet_name", description="Wallet name", required=False),
+                ],
+            ),
+            # Changelly (cross-chain USDt swaps)
+            Prompt(
+                name="usdt_cross_chain_send",
+                description=(
+                    "Send USDt-Liquid out to USDt on another chain via Changelly "
+                    "(e.g. USDt-Liquid → USDt-Tron). Walks through quote, "
+                    "confirmation, and broadcast."
+                ),
+                arguments=[
+                    PromptArgument(name="wallet_name", description="Wallet name", required=False),
+                ],
+            ),
+            Prompt(
+                name="usdt_cross_chain_receive",
+                description=(
+                    "Receive USDt-Liquid from USDt on another chain via Changelly "
+                    "(e.g. USDt-Tron → USDt-Liquid). Returns a deposit address for "
+                    "the external sender."
+                ),
                 arguments=[
                     PromptArgument(name="wallet_name", description="Wallet name", required=False),
                 ],
@@ -981,6 +1127,76 @@ Please:
    - Preimage (proof of payment)
    - Explorer link for lockup transaction
 8. If swap fails, explain that L-BTC is locked until timeout and can be refunded""",
+                        ),
+                    )
+                ]
+            )
+
+        elif name == "usdt_cross_chain_send":
+            return GetPromptResult(
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(
+                            type="text",
+                            text=f"""I want to send USDt-Liquid out to USDt on another chain via Changelly, from wallet '{wallet_name}'.
+
+Changelly is a custodial cross-chain swap service routed through AQUA's
+Ankara backend. They take the USDt-Liquid deposit and send USDt on the
+target chain from their hot wallet. Trust model: trust the company, not
+on-chain — make sure I understand this trade-off.
+
+Please:
+1. Show my Liquid balance (lw_balance) so I can see how much USDt-Liquid I have
+2. Ask me which target USDt chain (ethereum, tron, bsc, solana, polygon, ton)
+3. Ask me for:
+   - The destination address on that chain
+   - The amount of USDt-Liquid to send (decimal, e.g. "100")
+4. Call changelly_quote with direction='send' to show the rate, network fee,
+   and exact amount the recipient will get
+5. Show me a clear summary BEFORE proceeding:
+   - Send: X USDt on Liquid
+   - Receive: Y USDt on [chain] at [destination address]
+   - Network fee + Changelly fee
+6. Ask for explicit confirmation
+7. If wallet is password-encrypted, ask for the password
+8. Call changelly_send — this gets a fresh quote, creates the order, and
+   broadcasts the deposit from my Liquid wallet
+9. Show me order_id + deposit_hash + the Changelly tracking URL
+10. Tell me to use changelly_status to track progress""",
+                        ),
+                    )
+                ]
+            )
+
+        elif name == "usdt_cross_chain_receive":
+            return GetPromptResult(
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(
+                            type="text",
+                            text=f"""I want to receive USDt-Liquid in my '{wallet_name}' wallet by having someone send USDt from another chain via Changelly.
+
+Changelly is a custodial cross-chain swap service. They take the deposit
+on the source chain from the external sender and send USDt-Liquid to my
+Liquid address from their hot wallet. Trust model: trust the company.
+
+Please:
+1. Ask me which source USDt chain the external sender will pay from
+   (ethereum, tron, bsc, solana, polygon, ton)
+2. STRONGLY recommend providing an external_refund_address — the source
+   chain address the external sender controls. Without it, a stuck order
+   requires manual web UI intervention. Ask for it.
+3. Optional: ask if the user knows the rough amount; if yes, pass it as
+   amount_from for a better rate preview
+4. Call changelly_receive — this creates a variable-rate order
+5. Show me clearly:
+   - The deposit address on the source chain (this is what the external
+     sender pays to)
+   - The Changelly tracking URL
+   - Where the funds will arrive in my wallet (USDt-Liquid)
+6. Tell me to use changelly_status with the order_id to poll progress""",
                         ),
                     )
                 ]

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -507,6 +507,7 @@ TOOL_SCHEMAS = {
                 "amount_from": {"type": "string", "description": "USDt-Liquid to send (decimal string, e.g. '100')"},
                 "wallet_name": {"type": "string", "default": "default"},
                 "password": {"type": "string", "description": "Password to decrypt mnemonic (if encrypted at rest)"},
+                "rate_id": {"type": "string", "description": "Rate id from a prior changelly_quote call — pass this to lock the previewed rate and avoid drift"},
             },
             "required": ["external_network", "settle_address", "amount_from"],
         },
@@ -533,10 +534,10 @@ TOOL_SCHEMAS = {
                 },
                 "amount_from": {
                     "type": "string",
-                    "description": "Optional reference amount for the quote preview",
+                    "description": "Amount the external sender will deposit (decimal string, e.g. '50')",
                 },
             },
-            "required": ["external_network"],
+            "required": ["external_network", "amount_from"],
         },
     },
     "changelly_status": {

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -83,6 +83,7 @@ class Storage:
         self.swaps_dir = self.base_dir / "swaps"
         self.ankara_swaps_dir = self.base_dir / "ankara_swaps"
         self.lightning_swaps_dir = self.base_dir / "lightning_swaps"
+        self.changelly_swaps_dir = self.base_dir / "changelly_swaps"
         self.config_path = self.base_dir / "config.json"
         self._ensure_dirs()
 
@@ -100,6 +101,8 @@ class Storage:
         os.chmod(self.ankara_swaps_dir, 0o700)
         self.lightning_swaps_dir.mkdir(exist_ok=True, mode=0o700)
         os.chmod(self.lightning_swaps_dir, 0o700)
+        self.changelly_swaps_dir.mkdir(exist_ok=True, mode=0o700)
+        os.chmod(self.changelly_swaps_dir, 0o700)
 
     def _derive_key(self, password: str, salt: bytes) -> bytes:
         """Derive encryption key from password."""
@@ -329,6 +332,40 @@ class Storage:
         return [
             p.stem
             for p in self.lightning_swaps_dir.glob("*.json")
+            if SWAP_ID_PATTERN.fullmatch(p.stem)
+        ]
+
+    # Changelly swap operations
+
+    def _changelly_swap_path(self, order_id: str) -> Path:
+        """Get path to Changelly swap file, validating the ID to prevent path traversal."""
+        if not SWAP_ID_PATTERN.fullmatch(order_id):
+            raise ValueError(
+                f"Invalid Changelly order ID '{order_id}'. "
+                "Use only letters, numbers, hyphens and underscores (max 128 chars)."
+            )
+        return self.changelly_swaps_dir / f"{order_id}.json"
+
+    def save_changelly_swap(self, swap) -> None:
+        """Save Changelly swap data for recovery."""
+        path = self._changelly_swap_path(swap.order_id)
+        self._atomic_write_json(path, swap.to_dict())
+
+    def load_changelly_swap(self, order_id: str):
+        """Load Changelly swap data. Returns ChangellySwap or None."""
+        from .changelly import ChangellySwap
+
+        path = self._changelly_swap_path(order_id)
+        if not path.exists():
+            return None
+        with open(path) as f:
+            return ChangellySwap.from_dict(json.load(f))
+
+    def list_changelly_swaps(self) -> list[str]:
+        """List all Changelly swap order IDs."""
+        return [
+            p.stem
+            for p in self.changelly_swaps_dir.glob("*.json")
             if SWAP_ID_PATTERN.fullmatch(p.stem)
         ]
 

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -28,6 +28,7 @@ EXPLORER_URLS = {
 _manager: WalletManager | None = None
 _btc_manager: BitcoinWalletManager | None = None
 _lightning_manager: "LightningManager | None" = None
+_changelly_manager: "ChangellyManager | None" = None
 
 
 def get_manager() -> WalletManager:
@@ -57,6 +58,19 @@ def get_lightning_manager() -> "LightningManager":
             wallet_manager=get_manager(),
         )
     return _lightning_manager
+
+
+def get_changelly_manager() -> "ChangellyManager":
+    """Get or create Changelly manager (shares storage + wallet manager)."""
+    global _changelly_manager
+    if _changelly_manager is None:
+        from .changelly import ChangellyManager
+
+        _changelly_manager = ChangellyManager(
+            storage=get_manager().storage,
+            wallet_manager=get_manager(),
+        )
+    return _changelly_manager
 
 
 # Tool implementations
@@ -751,6 +765,154 @@ def lightning_transaction_status(swap_id: str) -> dict[str, Any]:
     return manager.get_swap_status(swap_id)
 
 
+# ---------------------------------------------------------------------------
+# Changelly (USDt cross-chain swaps via AQUA's Ankara proxy)
+# ---------------------------------------------------------------------------
+
+
+def changelly_list_currencies() -> dict[str, Any]:
+    """List the currencies Changelly supports (Changelly's own asset id format).
+
+    Useful for discovery; the agentic-aqua surface only enables the curated
+    USDt-Liquid ↔ USDt-on-{ethereum,tron,bsc,solana,polygon,ton} pairs for
+    actual swaps, but the read-only currency list is unrestricted.
+
+    Returns:
+        currencies: list of asset id strings
+        count: number of entries
+    """
+    currencies = get_changelly_manager().list_currencies()
+    return {"currencies": currencies, "count": len(currencies)}
+
+
+def changelly_quote(
+    external_network: str,
+    direction: str = "send",
+    amount_from: str | None = None,
+    amount_to: str | None = None,
+) -> dict[str, Any]:
+    """Get a fixed-rate Changelly quote for a USDt-Liquid ↔ USDt-on-X swap.
+
+    Provide exactly one of `amount_from` or `amount_to` (decimal strings).
+    Direction implies which leg is the deposit:
+      - "send": deposit USDt-Liquid, receive USDt on `external_network`
+      - "receive": deposit USDt on `external_network`, receive USDt-Liquid
+
+    Args:
+        external_network: USDt network (one of: ethereum, tron, bsc, solana,
+            polygon, ton).
+        direction: "send" or "receive". Default: "send".
+        amount_from: amount the deposit side sends (decimal string).
+        amount_to: amount the settle side receives (decimal string).
+
+    Returns:
+        Changelly's quote response: {id, result, amountFrom, amountTo,
+        networkFee, min, max, expiredAt, ...}
+    """
+    from .changelly import LIQUID_USDT_ID, network_to_asset_id
+
+    ext = network_to_asset_id(external_network)
+    if direction == "send":
+        from_asset, to_asset = LIQUID_USDT_ID, ext
+    elif direction == "receive":
+        from_asset, to_asset = ext, LIQUID_USDT_ID
+    else:
+        raise ValueError("direction must be 'send' or 'receive'")
+    return get_changelly_manager().fixed_quote(
+        from_asset, to_asset, amount_from=amount_from, amount_to=amount_to,
+    )
+
+
+def changelly_send(
+    external_network: str,
+    settle_address: str,
+    amount_from: str,
+    wallet_name: str = "default",
+    password: str | None = None,
+) -> dict[str, Any]:
+    """Send USDt-Liquid out via a Changelly fixed-rate swap.
+
+    Flow:
+      1. Get a fixed-rate quote for `amount_from` USDt-Liquid → USDt-on-network.
+      2. Create the fixed order; Changelly returns a Liquid deposit address.
+      3. Broadcast the USDt-Liquid deposit from the local wallet.
+
+    A refund address is set automatically — the wallet's own Liquid address,
+    so a stuck order refunds back to source.
+
+    Args:
+        external_network: target USDt network (ethereum, tron, bsc, solana,
+            polygon, ton).
+        settle_address: external chain address where the user receives.
+        amount_from: USDt-Liquid to send (decimal string, e.g. "100").
+        wallet_name: Liquid wallet to sign with.
+        password: mnemonic decryption password (if encrypted at rest).
+
+    Returns:
+        order_id, deposit_hash (txid we broadcast), deposit_address,
+        amount_from, amount_to, status, expires_at, track_url
+    """
+    swap = get_changelly_manager().send_swap(
+        external_network=external_network,
+        amount_from=amount_from,
+        settle_address=settle_address,
+        wallet_name=wallet_name,
+        password=password,
+    )
+    return swap.to_dict()
+
+
+def changelly_receive(
+    external_network: str,
+    wallet_name: str = "default",
+    external_refund_address: str | None = None,
+    amount_from: str | None = None,
+) -> dict[str, Any]:
+    """Receive USDt-Liquid via a Changelly variable-rate swap.
+
+    Returns a deposit address on `external_network`. The external sender
+    pays to it from any USDt-supporting wallet on that network; rate is set
+    when the deposit confirms; Changelly settles to the wallet's Liquid
+    address as USDt-Liquid.
+
+    Args:
+        external_network: source USDt network (ethereum, tron, bsc, solana,
+            polygon, ton).
+        wallet_name: Liquid wallet to receive into.
+        external_refund_address: STRONGLY RECOMMENDED — the deposit-chain
+            address to refund to if the order fails. Without one a stuck
+            order requires manual web UI intervention.
+        amount_from: optional reference amount for the quote preview only;
+            variable orders accept any amount in [min, max].
+
+    Returns:
+        order_id, deposit_address, settle_address, amount_from (if provided),
+        status, track_url
+    """
+    swap = get_changelly_manager().receive_swap(
+        external_network=external_network,
+        wallet_name=wallet_name,
+        external_refund_address=external_refund_address,
+        amount_from=amount_from,
+    )
+    return swap.to_dict()
+
+
+def changelly_status(order_id: str) -> dict[str, Any]:
+    """Check the status of a Changelly swap order.
+
+    Returns the persisted record plus is_final / is_success / is_failed
+    booleans so callers don't have to memorise the state machine. The
+    Changelly state machine: new → waiting → confirming → exchanging →
+    sending → finished (success). Failure terminals: failed, refunded,
+    expired, overdue.
+
+    Args:
+        order_id: ID returned from changelly_send or changelly_receive.
+    """
+    return get_changelly_manager().status(order_id)
+
+
 # Tool registry for MCP
 TOOLS = {
     "lw_generate_mnemonic": lw_generate_mnemonic,
@@ -776,4 +938,9 @@ TOOLS = {
     "lightning_receive": lightning_receive,
     "lightning_send": lightning_send,
     "lightning_transaction_status": lightning_transaction_status,
+    "changelly_list_currencies": changelly_list_currencies,
+    "changelly_quote": changelly_quote,
+    "changelly_send": changelly_send,
+    "changelly_receive": changelly_receive,
+    "changelly_status": changelly_status,
 }

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -5,6 +5,7 @@ import logging
 import re
 import urllib.error
 import urllib.request
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from .assets import MAINNET_ASSETS, TESTNET_ASSETS, resolve_asset_name
@@ -330,6 +331,21 @@ def _parse_tx_input(tx_input: str) -> tuple[str, str]:
     raise ValueError(
         f"Invalid input: expected a 64-char hex txid or a Blockstream URL, got: {tx_input}"
     )
+
+
+def _validate_positive_decimal_string(value: str, field_name: str) -> None:
+    """Ensure value strips to a valid Decimal > 0 (for Changelly decimal amounts)."""
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{field_name} must be a non-empty decimal string")
+    try:
+        amount = Decimal(stripped)
+    except InvalidOperation:
+        raise ValueError(
+            f"{field_name} must be a valid decimal string, got {value!r}"
+        ) from None
+    if amount <= 0:
+        raise ValueError(f"{field_name} must be positive")
 
 
 def lw_tx_status(tx: str) -> dict[str, Any]:
@@ -809,6 +825,10 @@ def changelly_quote(
         Changelly's quote response: {id, result, amountFrom, amountTo,
         networkFee, min, max, expiredAt, ...}
     """
+    if (amount_from is None) == (amount_to is None):
+        raise ValueError(
+            "Provide exactly one of amount_from or amount_to — not both, not neither."
+        )
     from .changelly import LIQUID_USDT_ID, network_to_asset_id
 
     ext = network_to_asset_id(external_network)
@@ -829,11 +849,13 @@ def changelly_send(
     amount_from: str,
     wallet_name: str = "default",
     password: str | None = None,
+    rate_id: str | None = None,
 ) -> dict[str, Any]:
     """Send USDt-Liquid out via a Changelly fixed-rate swap.
 
     Flow:
-      1. Get a fixed-rate quote for `amount_from` USDt-Liquid → USDt-on-network.
+      1. Get a fixed-rate quote for `amount_from` USDt-Liquid → USDt-on-network
+         (skipped if `rate_id` supplied from a prior changelly_quote call).
       2. Create the fixed order; Changelly returns a Liquid deposit address.
       3. Broadcast the USDt-Liquid deposit from the local wallet.
 
@@ -847,17 +869,23 @@ def changelly_send(
         amount_from: USDt-Liquid to send (decimal string, e.g. "100").
         wallet_name: Liquid wallet to sign with.
         password: mnemonic decryption password (if encrypted at rest).
+        rate_id: rate id from a prior changelly_quote call. Pass this to lock
+            the previewed rate and avoid drift between quote and execution.
 
     Returns:
         order_id, deposit_hash (txid we broadcast), deposit_address,
         amount_from, amount_to, status, expires_at, track_url
     """
+    _validate_positive_decimal_string(amount_from, "amount_from")
+    if not settle_address or not settle_address.strip():
+        raise ValueError("settle_address cannot be empty")
     swap = get_changelly_manager().send_swap(
         external_network=external_network,
         amount_from=amount_from,
         settle_address=settle_address,
         wallet_name=wallet_name,
         password=password,
+        rate_id=rate_id,
     )
     return swap.to_dict()
 
@@ -866,7 +894,7 @@ def changelly_receive(
     external_network: str,
     wallet_name: str = "default",
     external_refund_address: str | None = None,
-    amount_from: str | None = None,
+    amount_from: str = "",
 ) -> dict[str, Any]:
     """Receive USDt-Liquid via a Changelly variable-rate swap.
 
@@ -882,13 +910,13 @@ def changelly_receive(
         external_refund_address: STRONGLY RECOMMENDED — the deposit-chain
             address to refund to if the order fails. Without one a stuck
             order requires manual web UI intervention.
-        amount_from: optional reference amount for the quote preview only;
-            variable orders accept any amount in [min, max].
+        amount_from: amount the external sender will deposit (decimal string,
+            e.g. "50"). Required by the Ankara backend serializer.
 
     Returns:
-        order_id, deposit_address, settle_address, amount_from (if provided),
-        status, track_url
+        order_id, deposit_address, settle_address, amount_from, status, track_url
     """
+    _validate_positive_decimal_string(amount_from, "amount_from")
     swap = get_changelly_manager().receive_swap(
         external_network=external_network,
         wallet_name=wallet_name,

--- a/tests/test_changelly.py
+++ b/tests/test_changelly.py
@@ -215,7 +215,7 @@ class TestValidateSettleAddress:
         ("ethereum", "0xAbCdEf1234567890abcdef1234567890abCdEf12"),  # 0x + 40 hex = 42
         ("bsc",      "0xAbCdEf1234567890abcdef1234567890abCdEf12"),
         ("polygon",  "0xAbCdEf1234567890abcdef1234567890abCdEf12"),
-        ("solana",   "So11111111111111111111111111111111"),      # 34 base58
+        ("solana",   "So11111111111111111111111111111111111111112"),  # 44-char wrapped SOL mint
         ("ton",      "EQ" + "D" * 46),                          # EQ + 46 base64url = 48
         ("ton",      "UQ" + "D" * 46),                          # UQ + 46 base64url = 48
     ])
@@ -646,19 +646,19 @@ class TestManagerReceive:
         swap = mgr.receive_swap(
             external_network="tron",
             wallet_name="default",
-            external_refund_address="TXrefund",
+            external_refund_address=_TRON_ADDR,
             amount_from="50",
         )
         assert swap.order_id == "ord_recv"
         assert swap.swap_type == "variable"
         assert swap.direction == "receive"
         assert swap.deposit_address == "TXdepositAddr"
-        assert swap.refund_address == "TXrefund"
+        assert swap.refund_address == _TRON_ADDR
         body = json.loads(mock_urlopen.call_args[0][0].data.decode())
         assert body["from"] == "usdtrx"
         assert body["to"] == "lusdt"
         assert body["address"] == "lq1qreceive"
-        assert body["refundAddress"] == "TXrefund"
+        assert body["refundAddress"] == _TRON_ADDR
         loaded = storage.load_changelly_swap("ord_recv")
         assert loaded is not None
 
@@ -666,6 +666,68 @@ class TestManagerReceive:
         mgr, _, _ = manager_setup
         with pytest.raises(ValueError, match="Unknown network"):
             mgr.receive_swap(external_network="avalanche", wallet_name="default", amount_from="50")
+
+    def test_receive_rejects_wrong_format_external_refund_address(self, manager_setup):
+        # A Liquid-style refund address for a Tron deposit would result in a
+        # stuck order if Changelly accepts it. Reject before the API call.
+        mgr, _, _ = manager_setup
+        with pytest.raises(ValueError, match="valid tron"):
+            mgr.receive_swap(
+                external_network="tron",
+                wallet_name="default",
+                external_refund_address="lq1qbogusrefund",
+                amount_from="50",
+            )
+
+
+class TestManagerSendDepositSatsGuard:
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_send_rejects_zero_deposit_sats(self, mock_urlopen, manager_setup):
+        # Defence in depth: even if Changelly returns "0" as amountExpectedFrom
+        # the manager must refuse to sign a zero-value send. We force the path
+        # by skipping the quote call (rate_id supplied) and returning an order
+        # with amountExpectedFrom == "0".
+        mgr, _, storage = manager_setup
+        mock_urlopen.return_value = _mock_response({
+            "id": "order_zero",
+            "payinAddress": "lq1qdeposit",
+            "amountExpectedFrom": "0",
+            "currencyFrom": "lusdt",
+            "currencyTo": "usdtrx",
+            "status": "new",
+        })
+        with pytest.raises(RuntimeError, match="non-positive deposit amount"):
+            mgr.send_swap(
+                external_network="tron",
+                amount_from="100",
+                settle_address=_TRON_ADDR,
+                wallet_name="default",
+                rate_id="prefetched",
+            )
+        # Swap must still be persisted with last_error so the user can
+        # diagnose what happened.
+        loaded = storage.load_changelly_swap("order_zero")
+        assert loaded is not None
+        assert loaded.status == "failed"
+        assert loaded.last_error and "non-positive" in loaded.last_error
+
+
+class TestValidateSettleAddressDriftGuard:
+    def test_missing_pattern_for_supported_network_raises(self, monkeypatch):
+        # If a future contributor adds a network to NETWORK_TO_USDT_ID without
+        # a matching pattern in _ADDRESS_PATTERNS, validation must refuse to
+        # silently no-op.
+        from aqua import changelly as changelly_mod
+
+        monkeypatch.setitem(changelly_mod.NETWORK_TO_USDT_ID, "newchain", "usdtnew")
+        with pytest.raises(RuntimeError, match="_ADDRESS_PATTERNS is missing"):
+            _validate_settle_address("newchain", "some_address_123")
+
+    def test_truly_unknown_network_still_passes_through(self):
+        # Networks not on the supported list (e.g. user typo) are not the
+        # contributor-drift case; preserve the lenient no-op so we don't
+        # block on unknown user input upstream of the asset-id lookup.
+        _validate_settle_address("zzz_not_a_real_chain", "some_address_123")
 
 
 class TestManagerStatus:

--- a/tests/test_changelly.py
+++ b/tests/test_changelly.py
@@ -28,6 +28,7 @@ from aqua.changelly import (
     ChangellySwap,
     _check_pair_allowed,
     _decimal_to_sats,
+    _validate_settle_address,
     changelly_track_url,
     network_to_asset_id,
     swap_is_failed,
@@ -201,6 +202,42 @@ class TestAllowedPairs:
         monkeypatch.setenv("CHANGELLY_ALLOW_ALL_PAIRS", value)
         with pytest.raises(ValueError, match="not in the curated allowlist"):
             _check_pair_allowed("btc", "lusdt")
+
+
+# ---------------------------------------------------------------------------
+# settle_address validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSettleAddress:
+    @pytest.mark.parametrize("network, address", [
+        ("tron",     "T" + "X" * 33),                           # T + 33 base58 = 34
+        ("ethereum", "0xAbCdEf1234567890abcdef1234567890abCdEf12"),  # 0x + 40 hex = 42
+        ("bsc",      "0xAbCdEf1234567890abcdef1234567890abCdEf12"),
+        ("polygon",  "0xAbCdEf1234567890abcdef1234567890abCdEf12"),
+        ("solana",   "So11111111111111111111111111111111"),      # 34 base58
+        ("ton",      "EQ" + "D" * 46),                          # EQ + 46 base64url = 48
+        ("ton",      "UQ" + "D" * 46),                          # UQ + 46 base64url = 48
+    ])
+    def test_valid_addresses_pass(self, network, address):
+        _validate_settle_address(network, address)
+
+    @pytest.mark.parametrize("network, address, match", [
+        ("tron",     "",                    "empty"),
+        ("tron",     "   ",                 "empty"),
+        ("tron",     "0xAbCd1234",          "valid tron"),  # Ethereum addr on Tron
+        ("ethereum", "TXYZabc123456789012", "valid ethereum"),  # Tron addr on ETH
+        ("ethereum", "0xShort",            "valid ethereum"),
+        ("solana",   "0x1234",             "valid solana"),
+        ("ton",      "0x1234",             "valid ton"),
+    ])
+    def test_invalid_addresses_raise(self, network, address, match):
+        with pytest.raises(ValueError, match=match):
+            _validate_settle_address(network, address)
+
+    def test_unknown_network_passes_through(self):
+        # No pattern for unknown network → no crash, just no validation.
+        _validate_settle_address("unknownchain", "some_address_123")
 
 
 # ---------------------------------------------------------------------------
@@ -480,6 +517,9 @@ def manager_setup(storage):
     return mgr, wm, storage
 
 
+_TRON_ADDR = "T" + "X" * 33  # valid 34-char Tron address for tests
+
+
 class TestManagerSend:
     @patch("aqua.changelly.urllib.request.urlopen")
     def test_send_lusdt_to_usdt_tron_happy_path(self, mock_urlopen, manager_setup):
@@ -516,7 +556,7 @@ class TestManagerSend:
         swap = mgr.send_swap(
             external_network="tron",
             amount_from="100",
-            settle_address="TXrecv",
+            settle_address=_TRON_ADDR,
             wallet_name="default",
         )
         assert swap.order_id == "order_xyz"
@@ -547,7 +587,7 @@ class TestManagerSend:
             mgr.send_swap(
                 external_network="tron",
                 amount_from="100",
-                settle_address="TX",
+                settle_address=_TRON_ADDR,
                 wallet_name="ghost",
             )
 
@@ -578,7 +618,7 @@ class TestManagerSend:
             mgr.send_swap(
                 external_network="tron",
                 amount_from="100",
-                settle_address="TX",
+                settle_address=_TRON_ADDR,
                 wallet_name="default",
             )
         loaded = storage.load_changelly_swap("order_persist")
@@ -607,6 +647,7 @@ class TestManagerReceive:
             external_network="tron",
             wallet_name="default",
             external_refund_address="TXrefund",
+            amount_from="50",
         )
         assert swap.order_id == "ord_recv"
         assert swap.swap_type == "variable"
@@ -624,7 +665,7 @@ class TestManagerReceive:
     def test_receive_rejects_unknown_external_network(self, manager_setup):
         mgr, _, _ = manager_setup
         with pytest.raises(ValueError, match="Unknown network"):
-            mgr.receive_swap(external_network="avalanche", wallet_name="default")
+            mgr.receive_swap(external_network="avalanche", wallet_name="default", amount_from="50")
 
 
 class TestManagerStatus:

--- a/tests/test_changelly.py
+++ b/tests/test_changelly.py
@@ -1,0 +1,673 @@
+"""Tests for Changelly cross-chain swap integration.
+
+Mocks `urllib.request.urlopen` for the HTTP client; the manager-level tests
+fake the wallet manager since Changelly never touches PSETs (custodial; we
+just send to a deposit address).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aqua.changelly import (
+    ALLOWED_PAIRS,
+    CHANGELLY_BASE_URL,
+    EXTERNAL_USDT_IDS,
+    LIQUID_USDT_HEX,
+    LIQUID_USDT_ID,
+    NETWORK_TO_USDT_ID,
+    ChangellyClient,
+    ChangellyManager,
+    ChangellySwap,
+    _check_pair_allowed,
+    _decimal_to_sats,
+    changelly_track_url,
+    network_to_asset_id,
+    swap_is_failed,
+    swap_is_final,
+    swap_is_success,
+)
+from aqua.storage import Storage, WalletData
+
+
+def _mock_response(data, status=200):
+    resp = MagicMock()
+    if isinstance(data, (dict, list)):
+        resp.read.return_value = json.dumps(data).encode()
+    elif isinstance(data, str):
+        # Status endpoint returns a bare string
+        resp.read.return_value = json.dumps(data).encode()
+    elif data is None:
+        resp.read.return_value = b""
+    else:
+        resp.read.return_value = data
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+@pytest.fixture
+def storage():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Storage(Path(tmpdir))
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDecimalToSats:
+    @pytest.mark.parametrize("decimal_str, expected", [
+        ("100", 10_000_000_000),  # 100 USDt-Liquid (8-decimal)
+        ("0.0005", 50_000),
+        ("0.00000001", 1),
+        ("0", 0),
+    ])
+    def test_known_amounts(self, decimal_str, expected):
+        assert _decimal_to_sats(decimal_str) == expected
+
+
+class TestStatusHelpers:
+    @pytest.mark.parametrize("s", ["finished"])
+    def test_finished_is_success(self, s):
+        assert swap_is_success(s) is True
+        assert swap_is_final(s) is True
+        assert swap_is_failed(s) is False
+
+    @pytest.mark.parametrize("s", ["failed", "refunded", "expired", "overdue"])
+    def test_failed_terminal_states(self, s):
+        assert swap_is_success(s) is False
+        assert swap_is_final(s) is True
+        assert swap_is_failed(s) is True
+
+    @pytest.mark.parametrize("s", ["new", "waiting", "confirming", "exchanging", "sending"])
+    def test_pending_states(self, s):
+        assert swap_is_final(s) is False
+        assert swap_is_success(s) is False
+        assert swap_is_failed(s) is False
+
+    def test_hold_is_terminal_but_not_success_or_failed(self):
+        # "hold" means under manual review — terminal-ish but ambiguous
+        assert swap_is_final("hold") is True
+        assert swap_is_success("hold") is False
+        assert swap_is_failed("hold") is False
+
+    def test_case_insensitive(self):
+        assert swap_is_success("FINISHED") is True
+
+    def test_track_url(self):
+        assert changelly_track_url("abc123") == "https://changelly.com/track/abc123"
+
+
+class TestNetworkToAssetId:
+    @pytest.mark.parametrize("network, expected", [
+        ("liquid", "lusdt"),
+        ("ethereum", "usdt20"),
+        ("tron", "usdtrx"),
+        ("bsc", "usdtbsc"),
+        ("solana", "usdtsol"),
+        ("polygon", "usdtpolygon"),
+        ("ton", "usdton"),
+        ("TRON", "usdtrx"),  # case-insensitive
+    ])
+    def test_known_networks(self, network, expected):
+        assert network_to_asset_id(network) == expected
+
+    def test_unknown_network_raises(self):
+        with pytest.raises(ValueError, match="Unknown network"):
+            network_to_asset_id("avalanche")
+
+    def test_error_message_lists_supported(self):
+        with pytest.raises(ValueError) as exc:
+            network_to_asset_id("doge")
+        assert "tron" in str(exc.value)
+        assert "ethereum" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Allowlist (ALLOWED_PAIRS) — matches AQUA Flutter's curated Changelly set
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedPairs:
+    def test_allowlist_matches_aqua_flutter(self):
+        # Drift from AQUA's `ChangellyAssetIds` set in
+        # `lib/features/changelly/models/changelly_models.dart` should fail
+        # loudly so we have a forced conversation about it.
+        expected_external = {"usdt20", "usdtrx", "usdtbsc", "usdtsol", "usdtpolygon", "usdton"}
+        assert set(EXTERNAL_USDT_IDS) == expected_external
+        # 6 chains × 2 directions = 12 ordered pairs
+        assert len(ALLOWED_PAIRS) == 12
+
+    def test_btc_lbtc_usdc_etc_NOT_in_allowlist(self):
+        # Explicitly: only USDt, only the 6 external chains, only paired
+        # with USDt-Liquid.
+        assert ("btc", "lusdt") not in ALLOWED_PAIRS
+        assert ("lbtc", "usdtrx") not in ALLOWED_PAIRS
+        assert ("usdc", "lusdt") not in ALLOWED_PAIRS
+        # Same external chain ↔ same external chain not allowed (must touch Liquid)
+        assert ("usdtrx", "usdt20") not in ALLOWED_PAIRS
+
+    @pytest.mark.parametrize("from_id, to_id", [
+        ("lusdt", "usdt20"),
+        ("lusdt", "usdtrx"),
+        ("usdt20", "lusdt"),
+        ("usdtrx", "lusdt"),
+        ("LUSDT", "USDT20"),  # case-insensitive
+    ])
+    def test_allowed_pairs_pass(self, from_id, to_id):
+        _check_pair_allowed(from_id, to_id)
+
+    @pytest.mark.parametrize("from_id, to_id", [
+        ("btc", "lusdt"),       # BTC not allowed
+        ("lbtc", "usdtrx"),     # L-BTC not allowed
+        ("usdc", "lusdt"),      # USDC not allowed
+        ("usdtrx", "usdt20"),   # external-to-external not allowed
+        ("lusdt", "lusdt"),     # same on both sides
+    ])
+    def test_disallowed_pairs_raise(self, from_id, to_id):
+        with pytest.raises(ValueError, match="not in the curated allowlist"):
+            _check_pair_allowed(from_id, to_id)
+
+    def test_error_message_includes_helpful_info(self):
+        with pytest.raises(ValueError) as exc:
+            _check_pair_allowed("btc", "lusdt")
+        msg = str(exc.value)
+        assert "lusdt" in msg
+        assert "usdt20" in msg or "usdtrx" in msg
+        assert "CHANGELLY_ALLOW_ALL_PAIRS" in msg
+
+    def test_override_env_var_bypasses_check(self, monkeypatch):
+        monkeypatch.setenv("CHANGELLY_ALLOW_ALL_PAIRS", "1")
+        # Now arbitrary pairs pass
+        _check_pair_allowed("btc", "lusdt")
+        _check_pair_allowed("usdtrx", "usdt20")
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE", "Yes"])
+    def test_override_env_var_truthy_values(self, monkeypatch, value):
+        monkeypatch.setenv("CHANGELLY_ALLOW_ALL_PAIRS", value)
+        _check_pair_allowed("btc", "lusdt")
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "blah"])
+    def test_override_env_var_falsy_values_keep_enforcement(self, monkeypatch, value):
+        monkeypatch.setenv("CHANGELLY_ALLOW_ALL_PAIRS", value)
+        with pytest.raises(ValueError, match="not in the curated allowlist"):
+            _check_pair_allowed("btc", "lusdt")
+
+
+# ---------------------------------------------------------------------------
+# ChangellySwap dataclass + storage round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestChangellySwap:
+    def _make(self, **overrides) -> ChangellySwap:
+        defaults = dict(
+            order_id="abc123",
+            swap_type="fixed",
+            direction="send",
+            from_asset="lusdt",
+            to_asset="usdtrx",
+            settle_address="TXrecv",
+            deposit_address="lq1qdeposit",
+            refund_address="lq1qrefund",
+            wallet_name="default",
+            status="new",
+            created_at="2026-05-08T12:00:00+00:00",
+        )
+        defaults.update(overrides)
+        return ChangellySwap(**defaults)
+
+    def test_roundtrip(self):
+        s = self._make(amount_from="100", amount_to="99.5",
+                       deposit_hash="lqtxid" * 8, track_url="https://changelly.com/track/abc123")
+        assert ChangellySwap.from_dict(s.to_dict()) == s
+
+    def test_from_dict_backward_compat(self):
+        data = {
+            "order_id": "old1",
+            "swap_type": "variable",
+            "direction": "receive",
+            "from_asset": "usdtrx",
+            "to_asset": "lusdt",
+            "settle_address": "lq1q",
+            "deposit_address": "TXY",
+            "refund_address": None,
+            "wallet_name": "default",
+            "status": "new",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+        swap = ChangellySwap.from_dict(data)
+        assert swap.amount_from is None
+        assert swap.deposit_hash is None
+        assert swap.last_error is None
+
+
+class TestStorage:
+    def test_save_load_roundtrip(self, storage):
+        swap = ChangellySwap(
+            order_id="abc123",
+            swap_type="fixed",
+            direction="send",
+            from_asset="lusdt",
+            to_asset="usdtrx",
+            settle_address="TXrecv",
+            deposit_address="lq1qdeposit",
+            refund_address="lq1qrefund",
+            wallet_name="default",
+            status="new",
+            created_at="2026-05-08T12:00:00+00:00",
+        )
+        storage.save_changelly_swap(swap)
+        loaded = storage.load_changelly_swap("abc123")
+        assert loaded == swap
+
+    def test_load_missing_returns_none(self, storage):
+        assert storage.load_changelly_swap("nope") is None
+
+    def test_invalid_order_id_rejected(self, storage):
+        swap = ChangellySwap(
+            order_id="../escape",
+            swap_type="fixed",
+            direction="send",
+            from_asset="lusdt",
+            to_asset="usdtrx",
+            settle_address="TX",
+            deposit_address="lq1q",
+            refund_address=None,
+            wallet_name=None,
+            status="new",
+            created_at="2026-05-08T12:00:00+00:00",
+        )
+        with pytest.raises(ValueError, match="Invalid Changelly order ID"):
+            storage.save_changelly_swap(swap)
+
+    def test_list_swaps(self, storage):
+        for sid in ("a", "b", "c"):
+            storage.save_changelly_swap(ChangellySwap(
+                order_id=sid, swap_type="fixed", direction="send",
+                from_asset="lusdt", to_asset="usdtrx",
+                settle_address="TX", deposit_address="lq1q",
+                refund_address=None, wallet_name=None,
+                status="new", created_at="2026-05-08T12:00:00+00:00",
+            ))
+        assert set(storage.list_changelly_swaps()) == {"a", "b", "c"}
+
+    @pytest.mark.skipif(
+        __import__("sys").platform == "win32",
+        reason="POSIX file permissions not enforced on Windows",
+    )
+    def test_file_permissions_0600(self, storage):
+        import os
+
+        storage.save_changelly_swap(ChangellySwap(
+            order_id="permcheck", swap_type="fixed", direction="send",
+            from_asset="lusdt", to_asset="usdtrx",
+            settle_address="TX", deposit_address="lq1q",
+            refund_address=None, wallet_name=None,
+            status="new", created_at="2026-05-08T12:00:00+00:00",
+        ))
+        path = storage.changelly_swaps_dir / "permcheck.json"
+        assert (os.stat(path).st_mode & 0o777) == 0o600
+
+
+# ---------------------------------------------------------------------------
+# REST client (HTTP layer)
+# ---------------------------------------------------------------------------
+
+
+class TestChangellyClient:
+    def test_default_base_url_is_aqua_proxy(self):
+        client = ChangellyClient()
+        assert client.base_url == CHANGELLY_BASE_URL.rstrip("/")
+        assert "ankara.aquabtc.com" in client.base_url
+
+    def test_custom_base_url(self):
+        client = ChangellyClient(base_url="https://example.com/proxy/")
+        # Trailing slash stripped
+        assert client.base_url == "https://example.com/proxy"
+
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_get_currencies_handles_wrapped_result(self, mock_urlopen):
+        # AQUA's proxy wraps in {result: [...]}
+        mock_urlopen.return_value = _mock_response({"result": ["btc", "lusdt", "usdt20"]})
+        client = ChangellyClient()
+        assert client.get_currencies() == ["btc", "lusdt", "usdt20"]
+
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_get_currencies_handles_bare_list(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response(["btc", "lusdt"])
+        client = ChangellyClient()
+        assert client.get_currencies() == ["btc", "lusdt"]
+
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_get_pairs_lowercases_filters(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response([{"from": "lusdt", "to": "usdtrx"}])
+        client = ChangellyClient()
+        client.get_pairs(from_asset="LUSDT", to_asset="USDTRX")
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body == {"from": "lusdt", "to": "usdtrx"}
+
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_get_fix_rate_for_amount_sends_amount_from(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"id": "q1", "result": "0.99",
+                                                     "amountFrom": "100"})
+        client = ChangellyClient()
+        client.get_fix_rate_for_amount("lusdt", "usdtrx", amount_from="100")
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body["from"] == "lusdt"
+        assert body["to"] == "usdtrx"
+        assert body["amountFrom"] == "100"
+
+    def test_get_fix_rate_requires_exactly_one_amount(self):
+        client = ChangellyClient()
+        with pytest.raises(ValueError, match="exactly one"):
+            client.get_fix_rate_for_amount("lusdt", "usdtrx")
+        with pytest.raises(ValueError, match="exactly one"):
+            client.get_fix_rate_for_amount("lusdt", "usdtrx",
+                                           amount_from="100", amount_to="99")
+
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_get_variable_quote_takes_first_of_list(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response([
+            {"from": "lusdt", "to": "usdtrx", "rate": "0.99"},
+            {"from": "lusdt", "to": "usdtrx", "rate": "0.98"},
+        ])
+        client = ChangellyClient()
+        result = client.get_variable_quote("lusdt", "usdtrx", amount_from="100")
+        assert result["rate"] == "0.99"
+
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_create_fixed_transaction_body(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"id": "ord1", "payinAddress": "lq1q"})
+        client = ChangellyClient()
+        client.create_fixed_transaction(
+            from_asset="lusdt", to_asset="usdtrx",
+            rate_id="r1", address="TX", refund_address="lq1qrefund",
+            amount_from="100",
+        )
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body == {
+            "from": "lusdt", "to": "usdtrx",
+            "rateId": "r1", "address": "TX",
+            "refundAddress": "lq1qrefund",
+            "amountFrom": "100",
+        }
+
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_create_variable_transaction_body(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"id": "ord2", "payinAddress": "TX"})
+        client = ChangellyClient()
+        client.create_variable_transaction(
+            from_asset="usdtrx", to_asset="lusdt",
+            address="lq1q", refund_address="TXrefund",
+        )
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body["from"] == "usdtrx"
+        assert body["to"] == "lusdt"
+        assert body["address"] == "lq1q"
+        assert body["refundAddress"] == "TXrefund"
+
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_get_status_handles_bare_string(self, mock_urlopen):
+        # AQUA's proxy returns the status as a bare JSON string
+        mock_urlopen.return_value = _mock_response("finished")
+        client = ChangellyClient()
+        assert client.get_status("ord1") == "finished"
+
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_http_error_extracts_message(self, mock_urlopen):
+        err = urllib.error.HTTPError(
+            url="https://ankara.aquabtc.com/api/v1/changelly/quote",
+            code=400, msg="Bad Request", hdrs=None,
+            fp=io.BytesIO(json.dumps({"error": "amount too small"}).encode()),
+        )
+        mock_urlopen.side_effect = err
+        client = ChangellyClient()
+        with pytest.raises(RuntimeError, match="amount too small"):
+            client.get_currencies()
+
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_unreachable_host_raises(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.URLError("name resolution failed")
+        client = ChangellyClient()
+        with pytest.raises(RuntimeError, match="unreachable"):
+            client.get_currencies()
+
+
+# ---------------------------------------------------------------------------
+# Manager (with mocked HTTP and wallet manager)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager_setup(storage):
+    """Build a ChangellyManager with a fake wallet manager + temp Storage."""
+    wallet = WalletData(
+        name="default",
+        network="mainnet",
+        descriptor="ct(slip77(deadbeef),elwpkh([fp/84'/1776'/0']tpubD.../0/*))",
+        encrypted_mnemonic=None,
+    )
+    storage.save_wallet(wallet)
+
+    class _AddrResult:
+        def __init__(self, addr):
+            self.address = addr
+
+    class FakeWalletManager:
+        def __init__(self):
+            self.sent: list[tuple] = []
+            self.next_address = "lq1qreceive"
+
+        def get_address(self, name, index=None):  # noqa: ARG002
+            return _AddrResult(self.next_address)
+
+        def send(self, name, address, amount, asset_id=None, password=None):  # noqa: ARG002
+            self.sent.append((name, address, amount, asset_id, password))
+            return "lqtxid" + ("0" * 58)
+
+    wm = FakeWalletManager()
+    mgr = ChangellyManager(storage=storage, wallet_manager=wm)
+    return mgr, wm, storage
+
+
+class TestManagerSend:
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_send_lusdt_to_usdt_tron_happy_path(self, mock_urlopen, manager_setup):
+        # The headline flow: USDt-Liquid → USDt-Tron via Changelly.
+        mgr, wm, storage = manager_setup
+        mock_urlopen.side_effect = [
+            # Step 1: get_fix_rate_for_amount
+            _mock_response({
+                "id": "rate_xyz",
+                "result": "0.99",
+                "from": "lusdt",
+                "to": "usdtrx",
+                "amountFrom": "100",
+                "amountTo": "99",
+                "expiredAt": 1_900_000_000,
+            }),
+            # Step 2: create_fixed_transaction
+            _mock_response({
+                "id": "order_xyz",
+                "trackUrl": "https://changelly.com/track/order_xyz",
+                "createdAt": 1_700_000_000,
+                "type": "fixed",
+                "status": "new",
+                "currencyFrom": "lusdt",
+                "currencyTo": "usdtrx",
+                "payinAddress": "lq1qdeposit",
+                "amountExpectedFrom": "100",
+                "payoutAddress": "TXrecv",
+                "amountExpectedTo": "99",
+                "networkFee": "1",
+                "payTill": "2026-05-08T12:15:00Z",
+            }),
+        ]
+        swap = mgr.send_swap(
+            external_network="tron",
+            amount_from="100",
+            settle_address="TXrecv",
+            wallet_name="default",
+        )
+        assert swap.order_id == "order_xyz"
+        assert swap.deposit_address == "lq1qdeposit"
+        assert swap.deposit_hash and swap.deposit_hash.startswith("lqtxid")
+        # Refund address is the wallet's own Liquid address
+        assert swap.refund_address == "lq1qreceive"
+        # 100 USDt-Liquid = 100 * 1e8 sats; passed with the USDt-Liquid asset id
+        assert wm.sent == [("default", "lq1qdeposit", 10_000_000_000, LIQUID_USDT_HEX, None)]
+        # Persisted across the whole flow
+        loaded = storage.load_changelly_swap("order_xyz")
+        assert loaded is not None
+        assert loaded.deposit_hash == swap.deposit_hash
+
+    def test_send_rejects_unknown_external_network(self, manager_setup):
+        mgr, _, _ = manager_setup
+        with pytest.raises(ValueError, match="Unknown network"):
+            mgr.send_swap(
+                external_network="avalanche",
+                amount_from="100",
+                settle_address="0xfoo",
+                wallet_name="default",
+            )
+
+    def test_send_rejects_unknown_wallet(self, manager_setup):
+        mgr, _, _ = manager_setup
+        with pytest.raises(ValueError, match="not found"):
+            mgr.send_swap(
+                external_network="tron",
+                amount_from="100",
+                settle_address="TX",
+                wallet_name="ghost",
+            )
+
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_send_persists_swap_before_broadcast_so_failure_is_recoverable(
+        self, mock_urlopen, manager_setup
+    ):
+        # If create_fixed_transaction succeeded but broadcast failed, the
+        # swap must still be on disk for refund/retry.
+        mgr, wm, storage = manager_setup
+        mock_urlopen.side_effect = [
+            _mock_response({"id": "rate1", "result": "0.99", "amountFrom": "100"}),
+            _mock_response({
+                "id": "order_persist",
+                "payinAddress": "lq1qdeposit",
+                "amountExpectedFrom": "100",
+                "currencyFrom": "lusdt",
+                "currencyTo": "usdtrx",
+                "status": "new",
+            }),
+        ]
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("broadcast network down")
+        wm.send = boom
+
+        with pytest.raises(RuntimeError, match="broadcast network down"):
+            mgr.send_swap(
+                external_network="tron",
+                amount_from="100",
+                settle_address="TX",
+                wallet_name="default",
+            )
+        loaded = storage.load_changelly_swap("order_persist")
+        assert loaded is not None
+        assert loaded.last_error and "broadcast network down" in loaded.last_error
+
+
+class TestManagerReceive:
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_receive_returns_deposit_address(self, mock_urlopen, manager_setup):
+        mgr, _, storage = manager_setup
+        mock_urlopen.return_value = _mock_response({
+            "id": "ord_recv",
+            "trackUrl": "https://changelly.com/track/ord_recv",
+            "type": "float",
+            "status": "new",
+            "currencyFrom": "usdtrx",
+            "currencyTo": "lusdt",
+            "payinAddress": "TXdepositAddr",
+            "payoutAddress": "lq1qreceive",
+            "amountExpectedFrom": "0",
+            "amountExpectedTo": "0",
+            "networkFee": "1",
+        })
+        swap = mgr.receive_swap(
+            external_network="tron",
+            wallet_name="default",
+            external_refund_address="TXrefund",
+        )
+        assert swap.order_id == "ord_recv"
+        assert swap.swap_type == "variable"
+        assert swap.direction == "receive"
+        assert swap.deposit_address == "TXdepositAddr"
+        assert swap.refund_address == "TXrefund"
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        assert body["from"] == "usdtrx"
+        assert body["to"] == "lusdt"
+        assert body["address"] == "lq1qreceive"
+        assert body["refundAddress"] == "TXrefund"
+        loaded = storage.load_changelly_swap("ord_recv")
+        assert loaded is not None
+
+    def test_receive_rejects_unknown_external_network(self, manager_setup):
+        mgr, _, _ = manager_setup
+        with pytest.raises(ValueError, match="Unknown network"):
+            mgr.receive_swap(external_network="avalanche", wallet_name="default")
+
+
+class TestManagerStatus:
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_status_refreshes_persisted_record(self, mock_urlopen, manager_setup):
+        mgr, _, storage = manager_setup
+        original = ChangellySwap(
+            order_id="poll1", swap_type="fixed", direction="send",
+            from_asset="lusdt", to_asset="usdtrx",
+            settle_address="TX", deposit_address="lq1q",
+            refund_address="lq1q", wallet_name="default",
+            status="new", created_at="2026-05-08T12:00:00+00:00",
+        )
+        storage.save_changelly_swap(original)
+        mock_urlopen.return_value = _mock_response("finished")
+
+        result = mgr.status("poll1")
+        assert result["status"] == "finished"
+        assert result["is_final"] is True
+        assert result["is_success"] is True
+        assert result["is_failed"] is False
+        loaded = storage.load_changelly_swap("poll1")
+        assert loaded.status == "finished"
+        assert loaded.last_checked_at is not None
+
+    def test_status_unknown_raises(self, manager_setup):
+        mgr, _, _ = manager_setup
+        with pytest.raises(ValueError, match="not found"):
+            mgr.status("nope")
+
+    @patch("aqua.changelly.urllib.request.urlopen")
+    def test_status_warns_on_remote_error(self, mock_urlopen, manager_setup):
+        mgr, _, storage = manager_setup
+        original = ChangellySwap(
+            order_id="poll2", swap_type="fixed", direction="send",
+            from_asset="lusdt", to_asset="usdtrx",
+            settle_address="TX", deposit_address="lq1q",
+            refund_address="lq1q", wallet_name="default",
+            status="new", created_at="2026-05-08T12:00:00+00:00",
+        )
+        storage.save_changelly_swap(original)
+        mock_urlopen.side_effect = urllib.error.URLError("boom")
+
+        result = mgr.status("poll2")
+        assert "warning" in result
+        assert result["status"] == "new"  # unchanged

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -758,6 +758,228 @@ class TestLightningCommands:
         assert result.exit_code == 1
 
 
+# ---------------------------------------------------------------------------
+# Changelly CLI
+# ---------------------------------------------------------------------------
+
+
+class _FakeChangellyManager:
+    """Stand-in for ChangellyManager — records calls, returns canned responses."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+        self.currencies_response = ["btc", "lusdt", "usdt20", "usdtrx"]
+        self.quote_response = {
+            "id": "rate1",
+            "result": "0.99",
+            "amountFrom": "100",
+            "amountTo": "99",
+            "networkFee": "1",
+            "expiredAt": 1_900_000_000,
+        }
+        self.send_response = None
+        self.receive_response = None
+        self.status_response = None
+
+    def list_currencies(self):
+        self.calls.append(("list_currencies", {}))
+        return self.currencies_response
+
+    def fixed_quote(self, from_asset, to_asset, amount_from=None, amount_to=None):
+        self.calls.append(("fixed_quote", {
+            "from_asset": from_asset, "to_asset": to_asset,
+            "amount_from": amount_from, "amount_to": amount_to,
+        }))
+        return self.quote_response
+
+    def send_swap(self, **kwargs):
+        from aqua.changelly import ChangellySwap
+
+        self.calls.append(("send_swap", kwargs))
+        if self.send_response is not None:
+            return self.send_response
+        return ChangellySwap(
+            order_id="ord_send",
+            swap_type="fixed",
+            direction="send",
+            from_asset="lusdt",
+            to_asset=f"usdt-{kwargs['external_network']}",
+            settle_address=kwargs["settle_address"],
+            deposit_address="lq1qdeposit",
+            refund_address="lq1qrefund",
+            wallet_name=kwargs["wallet_name"],
+            status="new",
+            created_at="2026-05-08T12:00:00+00:00",
+            amount_from=kwargs["amount_from"],
+            amount_to="99",
+            deposit_hash="lqtxid" + ("0" * 58),
+            track_url="https://changelly.com/track/ord_send",
+        )
+
+    def receive_swap(self, **kwargs):
+        from aqua.changelly import ChangellySwap
+
+        self.calls.append(("receive_swap", kwargs))
+        if self.receive_response is not None:
+            return self.receive_response
+        return ChangellySwap(
+            order_id="ord_recv",
+            swap_type="variable",
+            direction="receive",
+            from_asset=f"usdt-{kwargs['external_network']}",
+            to_asset="lusdt",
+            settle_address="lq1qreceive",
+            deposit_address="TXdepositAddr",
+            refund_address=kwargs.get("external_refund_address"),
+            wallet_name=kwargs["wallet_name"],
+            status="new",
+            created_at="2026-05-08T12:00:00+00:00",
+            track_url="https://changelly.com/track/ord_recv",
+        )
+
+    def status(self, order_id):
+        self.calls.append(("status", {"order_id": order_id}))
+        if self.status_response is not None:
+            return {**self.status_response, "order_id": order_id}
+        return {
+            "order_id": order_id,
+            "status": "finished",
+            "is_final": True,
+            "is_success": True,
+            "is_failed": False,
+        }
+
+
+@pytest.fixture
+def changelly_manager():
+    """Inject a fake ChangellyManager into the global tool layer."""
+    import aqua.tools as tools_module
+
+    fake = _FakeChangellyManager()
+    saved = tools_module._changelly_manager
+    tools_module._changelly_manager = fake
+    try:
+        yield fake
+    finally:
+        tools_module._changelly_manager = saved
+
+
+class TestChangellyCurrencies:
+    def test_currencies_returns_list(self, runner, changelly_manager):
+        result = runner.invoke(cli, ["--format", "json", "changelly", "currencies"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["count"] == 4
+        assert "lusdt" in data["currencies"]
+
+
+class TestChangellyQuote:
+    def test_quote_requires_exactly_one_amount(self, runner):
+        result = runner.invoke(
+            cli,
+            ["changelly", "quote", "--external-network", "tron"],
+        )
+        assert result.exit_code == 2
+
+    def test_quote_rejects_both_amounts(self, runner):
+        result = runner.invoke(
+            cli,
+            ["changelly", "quote", "--external-network", "tron",
+             "--amount-from", "100", "--amount-to", "99"],
+        )
+        assert result.exit_code == 2
+
+    def test_quote_send_direction(self, runner, changelly_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "changelly", "quote",
+             "--external-network", "tron", "--amount-from", "100"],
+        )
+        assert result.exit_code == 0
+        last = changelly_manager.calls[-1]
+        assert last[0] == "fixed_quote"
+        assert last[1]["from_asset"] == "lusdt"
+        assert last[1]["to_asset"] == "usdtrx"
+
+    def test_quote_receive_direction(self, runner, changelly_manager):
+        runner.invoke(
+            cli,
+            ["changelly", "quote", "--external-network", "ethereum",
+             "--direction", "receive", "--amount-from", "100"],
+        )
+        last = changelly_manager.calls[-1]
+        assert last[1]["from_asset"] == "usdt20"
+        assert last[1]["to_asset"] == "lusdt"
+
+    def test_quote_rejects_unsupported_network(self, runner):
+        result = runner.invoke(
+            cli,
+            ["changelly", "quote", "--external-network", "avalanche",
+             "--amount-from", "100"],
+        )
+        assert result.exit_code == 2  # Click choice validation
+
+
+class TestChangellySend:
+    def test_send_with_yes_skips_prompt(self, runner, changelly_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "changelly", "send",
+             "--external-network", "tron",
+             "--settle-address", "TXrecv",
+             "--amount-from", "100",
+             "--yes"],
+            env=_cli_env(),
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["order_id"] == "ord_send"
+        assert data["deposit_hash"].startswith("lqtxid")
+        send_call = next(c for c in changelly_manager.calls if c[0] == "send_swap")
+        assert send_call[1]["external_network"] == "tron"
+        assert send_call[1]["amount_from"] == "100"
+        assert send_call[1]["settle_address"] == "TXrecv"
+
+    def test_send_rejects_unsupported_network(self, runner):
+        result = runner.invoke(
+            cli,
+            ["changelly", "send",
+             "--external-network", "avalanche",
+             "--settle-address", "0xfoo",
+             "--amount-from", "100",
+             "--yes"],
+        )
+        assert result.exit_code == 2
+
+
+class TestChangellyReceive:
+    def test_receive_returns_deposit_address(self, runner, changelly_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "changelly", "receive",
+             "--external-network", "tron",
+             "--external-refund-address", "TXrefund"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["deposit_address"] == "TXdepositAddr"
+        assert data["refund_address"] == "TXrefund"
+        recv_call = next(c for c in changelly_manager.calls if c[0] == "receive_swap")
+        assert recv_call[1]["external_network"] == "tron"
+
+
+class TestChangellyStatus:
+    def test_status_passes_order_id(self, runner, changelly_manager):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "changelly", "status", "--order-id", "ord_xyz"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["order_id"] == "ord_xyz"
+        assert data["is_final"] is True
+
+
 # Error handling
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -958,7 +958,8 @@ class TestChangellyReceive:
             cli,
             ["--format", "json", "changelly", "receive",
              "--external-network", "tron",
-             "--external-refund-address", "TXrefund"],
+             "--external-refund-address", "TXrefund",
+             "--amount-from", "50"],
         )
         assert result.exit_code == 0
         data = json.loads(result.output)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,6 +13,7 @@ from aqua.tools import (
     _manager,
     btc_export_descriptor,
     btc_import_descriptor,
+    changelly_send,
     delete_wallet,
     get_btc_manager,
     get_manager,
@@ -884,6 +885,35 @@ class TestBtcExportDescriptor:
         """Exporting descriptor for a non-existent wallet raises ValueError matching 'not found'."""
         with pytest.raises(ValueError, match="not found"):
             btc_export_descriptor(wallet_name="ghost_btc")
+
+
+# ---------------------------------------------------------------------------
+# changelly_send — amount_from validation
+# ---------------------------------------------------------------------------
+
+
+class TestChangellySendAmountValidation:
+    """amount_from must be a positive decimal before hitting Changelly."""
+
+    def test_empty_amount_from_raises(self):
+        with pytest.raises(ValueError, match="amount_from must be a non-empty"):
+            changelly_send("solana", "So11111111111111111111111111111111111111112", "")
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(ValueError, match="amount_from must be a non-empty"):
+            changelly_send("solana", "So11111111111111111111111111111111111111112", "   ")
+
+    def test_zero_raises(self):
+        with pytest.raises(ValueError, match="amount_from must be positive"):
+            changelly_send("solana", "So11111111111111111111111111111111111111112", "0")
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="amount_from must be positive"):
+            changelly_send("solana", "So11111111111111111111111111111111111111112", "-10")
+
+    def test_invalid_decimal_raises(self):
+        with pytest.raises(ValueError, match="amount_from must be a valid decimal"):
+            changelly_send("solana", "So11111111111111111111111111111111111111112", "not-a-number")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -720,6 +720,11 @@ class TestToolRegistry:
             "delete_wallet",
             "btc_import_descriptor",
             "btc_export_descriptor",
+            "changelly_list_currencies",
+            "changelly_quote",
+            "changelly_send",
+            "changelly_receive",
+            "changelly_status",
         }
         assert set(TOOLS.keys()) == expected
 


### PR DESCRIPTION
> **Independent of all other open PRs** — branched off `main` so it can land on its own merits.

## Summary

- Adds USDt cross-chain swap support via Changelly, routed through AQUA's Ankara backend proxy (`https://ankara.aquabtc.com/api/v1/changelly`).
- Scope: **USDt-Liquid ↔ USDt on the same 6 external chains we allow in SideShift** — Ethereum, Tron, BSC, Solana, Polygon, TON.
- 5 new MCP tools, 2 prompts, an `aqua changelly` CLI subcommand group, 62 new tests (389 passing total).

## What's in this PR

**`src/aqua/changelly.py`**: REST client (stdlib `urllib`, mirroring Boltz / Ankara / SideShift), dataclasses, high-level `ChangellyManager` orchestrating send / receive / status, pair-allowlist enforcement, status state-machine helpers.

**5 new MCP tools**:
- `changelly_list_currencies` — list Changelly's supported currencies
- `changelly_quote` — fixed-rate quote for USDt-Liquid ↔ USDt-on-X
- `changelly_send` — send USDt-Liquid OUT (we sign + broadcast deposit; refund address auto-set)
- `changelly_receive` — receive USDt-Liquid IN via variable-rate order
- `changelly_status` — poll order status with `is_final` / `is_success` / `is_failed` booleans

**2 new prompts**: `usdt_cross_chain_send`, `usdt_cross_chain_receive`.

**CLI subcommand group**: `aqua changelly {currencies,quote,send,receive,status}` mirroring the tool surface. `send` fetches a fresh quote and prompts for confirmation by default (`--yes` to skip). Password resolution follows the existing `--password-stdin` / `AQUA_PASSWORD` pattern.

**Storage** at `~/.aqua/changelly_swaps/{order_id}.json`, mode `0o600`, atomic writes; persisted before broadcast on send so failures are recoverable.

## Why both Changelly and SideShift

Both are USDt cross-chain swap services and cover roughly the same chains. They're redundant on supported pairs by design. Agents can pick whichever has better rates at quote time, or fall back to the other if one is degraded or unavailable.

## Curated allowlist

`ALLOWED_PAIRS` in `src/aqua/changelly.py` mirrors AQUA Flutter's `ChangellyAssetIds` set in `lib/features/changelly/models/changelly_models.dart` (intersected with our SideShift allowlist for consistency). One leg must be `lusdt` (USDt-Liquid); the other must be one of the 6 external USDt variants. 6 chains × 2 directions = 12 ordered pairs.

Drift-detection: `tests/test_changelly.py::TestAllowedPairs::test_allowlist_matches_aqua_flutter` asserts the exact set so any future addition forces a conscious update on both sides.

Override available via `CHANGELLY_ALLOW_ALL_PAIRS=1` for testing or power use.

## Test plan

Module tests (`test_changelly.py`, 49 tests):
- [x] Decimal → sats conversion (4)
- [x] Status helpers + state machine (8)
- [x] Network → asset id mapping (9)
- [x] Allowlist contract + override semantics (16)
- [x] `ChangellySwap` dataclass + storage round-trip + 0o600 file permissions (5)
- [x] REST client: base URL handling, all 7 endpoints, error extraction, unreachable host (12)
- [x] Manager send: happy path L-BTC-USDt → USDt-Tron, unknown network, unknown wallet, persists before broadcast (4)
- [x] Manager receive: deposit address, unknown network (2)
- [x] Manager status: refreshes record, unknown raises, warns on remote error (3)

CLI tests (added to `test_cli.py`, 13 tests): all 5 subcommands, fake manager injection, argument validation.

Tool registry test updated for the 5 new tools.

- [ ] **Manual testnet smoke test** — required before mainnet sign-off. Procedure:
  1. Set `CHANGELLY_BASE_URL` to a testnet proxy (or use AQUA's mainnet with small amounts)
  2. `aqua changelly currencies` to verify connectivity
  3. Small `aqua changelly receive --external-network tron` and have someone send a tiny USDt-Tron amount
  4. Small `aqua changelly send --external-network tron --settle-address <my Tron addr> --amount-from 1`
  5. Confirm balances change as expected and order progresses through `new` → `confirming` → `exchanging` → `sending` → `finished`

## Reviewer notes

- This PR is fully **independent** of the SideSwap stack (#27, #31, #32) and the SideShift PR (#33). Branched off `main`. Can land in any order.
- The default `CHANGELLY_BASE_URL` points at AQUA's existing Ankara backend. If you want to test against a different proxy (or Changelly directly with API keys), override the env var.
- The fake `_FakeChangellyManager` test helper duck-types the real manager; if the manager API changes, tests will surface a TypeError on argument mismatch.
