### PR TITLE
Add Pix → DePix on-ramp (Eulen API)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,9 @@ AI Assistant ←→ MCP Server (Python) ←→ LWK (Liquid) ──→ Electrum/E
 
 No local server required. Liquid uses Electrum/Esplora; Bitcoin uses Esplora only. All via Blockstream's public infrastructure.
 
-## Tools (22 total)
+## Tools (24 total)
 
-Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`.
+Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified tools are `unified_*`; Lightning tools are `lightning_*`; Pix → DePix tools are `pix_*`.
 
 ### Wallet Management
 
@@ -74,6 +74,13 @@ Liquid tools use the `lw_` prefix; Bitcoin tools use the `btc_` prefix; unified 
 | `lightning_send` | Pay a Lightning invoice using L-BTC via Boltz submarine swap. Fees: ~0.1% + miner fees. Limits: 100 – 25,000,000 sats | `invoice`: BOLT11 string (lnbc... or lntb...), `wallet_name`: optional, `password`: optional |
 | `lightning_transaction_status` | Check status of a Lightning swap (send or receive). For receive: auto-claims L-BTC when settled. For send: retrieves preimage when claimed. | `swap_id`: string |
 
+### Pix → DePix (Brazilian Real on-ramp)
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `pix_receive` | Mint a Pix charge that pays out DePix (BRL stablecoin on Liquid) to the wallet's next address. Returns Pix Copia e Cola string + hosted QR image URL. Amount is in BRL **cents** (100 = R$1.00). Requires `EULEN_API_TOKEN`. | `amount_cents`: int, `wallet_name`: optional, `password`: optional |
+| `pix_status` | Check the status of a Pix → DePix deposit. Eulen pushes DePix automatically; no claim step. | `swap_id`: string |
+
 ## Resources (3 total)
 
 MCP resources provide static documentation to AI assistants.
@@ -84,7 +91,7 @@ MCP resources provide static documentation to AI assistants.
 | `aqua://docs/networks` | Network Reference | Bitcoin and Liquid network details, address formats, explorers, common assets |
 | `aqua://docs/security` | Security Best Practices | Password usage, at-rest encryption, backup, watch-only wallets, recovery |
 
-## Prompts (14 total)
+## Prompts (15 total)
 
 MCP prompts provide pre-built conversation starters for common workflows.
 
@@ -104,6 +111,7 @@ MCP prompts provide pre-built conversation starters for common workflows.
 | `export_descriptor` | Export descriptor for watch-only wallet | `wallet_name`: optional |
 | `delete_wallet` | Safely delete a wallet with balance check and seed backup reminder | `wallet_name`: required |
 | `pay_lightning` | Pay a Lightning invoice using Liquid Bitcoin | `wallet_name`: optional |
+| `receive_via_pix` | Receive DePix by paying a Pix charge in your Brazilian banking app | `wallet_name`: optional |
 
 ## Data Storage
 
@@ -120,6 +128,8 @@ Wallet data stored in `~/.aqua/`:
 │   └── {swap_id}.json   # Contains swap details + preimage when settled
 ├── lightning_swaps/     # Unified Lightning swap data (send & receive)
 │   └── {swap_id}.json   # Contains swap details + status + optional preimage
+├── pix_swaps/           # Pix → DePix deposit records (Eulen)
+│   └── {swap_id}.json   # Contains Pix charge details + status + optional blockchain_txid
 └── cache/
     └── <wallet_name>/
         └── btc/
@@ -226,6 +236,27 @@ Or for send swaps (Boltz):
 
 File permissions: `0o600`. Status values: `pending` | `processing` | `completed` | `failed`. The `lightning_transaction_status` tool auto-claims settled receive swaps.
 
+### Pix Swap File Structure
+
+```json
+{
+  "swap_id": "eulen_deposit_uuid",
+  "amount_cents": 5000,
+  "wallet_name": "default",
+  "depix_address": "lq1qq...",
+  "qr_copy_paste": "00020126580014br.gov.bcb.pix...",
+  "qr_image_url": "https://depix.eulen.app/qr/...png",
+  "status": "pending",
+  "network": "mainnet",
+  "created_at": "2026-05-08T12:00:00Z",
+  "expiration": "2026-05-08T23:59:59Z",
+  "blockchain_txid": null,
+  "payer_name": null
+}
+```
+
+File permissions: `0o600`. Status values (raw from Eulen): `pending` | `depix_sent` | `under_review` | `canceled` | `error` | `refunded` | `expired`. There is no claim step — Eulen pushes DePix to `depix_address` automatically once the Pix payment settles.
+
 ### Config Structure
 
 ```json
@@ -269,6 +300,22 @@ File permissions: `0o600`. Status values: `pending` | `processing` | `completed`
 - `mcp` - Model Context Protocol SDK
 - `cryptography` - For mnemonic encryption (PBKDF2 + Fernet)
 - `coincurve` - secp256k1 for Boltz swap keypair generation
+
+## Pix / Eulen Integration
+
+Eulen runs the public Pix → DePix REST API. AQUA mints a Pix charge, the user pays it in their Brazilian banking app, and Eulen credits DePix (BRL stablecoin on Liquid) to the address bound at deposit creation.
+
+**Configuration**:
+- `EULEN_API_TOKEN` (required): Bearer token. Obtain from https://depix.info/#partners.
+- `EULEN_API_URL` (optional): defaults to `https://depix.eulen.app/api`.
+
+**Endpoints used**:
+- `POST /deposit` with body `{ amountInCents, depixAddress }` → `{ id, qrCopyPaste, qrImageUrl, expiration }`. Headers: `Authorization: Bearer <token>`, `X-Nonce: <uuid4-hex>`.
+- `GET /deposit-status?id={id}` → `{ status, valueInCents, payerName?, blockchainTxID?, expiration? }`.
+
+**Amount Limits**: `amount_cents` is in BRL **cents** (100 = R$1.00). Eulen's absolute floor is R$1.00; first-time users typically have a daily limit around R$500 that scales up over time. There are no fixed published fees — verify current rates at depix.info.
+
+**Status semantics**: Eulen delivers DePix automatically; AQUA only polls. Terminal states are `depix_sent` (success), `canceled` / `error` / `refunded` / `expired` (failure).
 
 ## Ankara Integration
 
@@ -400,6 +447,7 @@ agentic-aqua/
 │       ├── lightning.py # Lightning abstraction layer (unified send/receive manager)
 │       ├── boltz.py    # Boltz Exchange integration (submarine swaps, send)
 │       ├── ankara.py   # Ankara backend integration (Lightning receive)
+│       ├── pix.py      # Pix → DePix integration (Eulen API)
 │       ├── assets.py   # Asset registry
 │       └── storage.py  # Persistence layer (encryption, config, wallet data)
 └── tests/
@@ -409,6 +457,7 @@ agentic-aqua/
     ├── test_bitcoin.py
     ├── test_boltz.py
     ├── test_ankara.py
+    ├── test_pix.py
     └── test_server.py
 ```
 
@@ -445,4 +494,4 @@ Use standard Grep/Glob only for: exact string matches, simple file lookups, conf
 
 ---
 
-*Last updated: 2026-03-17*
+*Last updated: 2026-05-08*

--- a/src/aqua/pix.py
+++ b/src/aqua/pix.py
@@ -63,8 +63,6 @@ class PixSwap:
     def from_dict(cls, data: dict) -> "PixSwap":
         known = {f.name for f in fields(cls)}
         filtered = {k: v for k, v in data.items() if k in known}
-        for field_name in ("qr_image_url", "expiration", "blockchain_txid", "payer_name"):
-            filtered.setdefault(field_name, None)
         return cls(**filtered)
 
 
@@ -114,7 +112,7 @@ class EulenClient:
             detail = ""
             try:
                 err_body = json.loads(e.read().decode())
-                detail = err_body.get("error") or err_body.get("message") or str(err_body)
+                detail = err_body.get("error") or err_body.get("message") or ""
             except Exception:
                 pass
             msg = f"Eulen API error ({e.code} {method} {path})"
@@ -199,13 +197,21 @@ class PixManager:
         wallet_data = self.storage.load_wallet(wallet_name)
         if not wallet_data:
             raise ValueError(f"Wallet '{wallet_name}' not found")
+        # DePix is a mainnet-only Liquid asset. Eulen has no testnet endpoint;
+        # a testnet wallet would generate a tlq1... address Eulen cannot pay to,
+        # leaving the user out-of-pocket if the Pix charge settled.
+        if wallet_data.network != "mainnet":
+            raise ValueError(
+                "Pix → DePix is only available on Liquid mainnet "
+                f"(wallet '{wallet_name}' is on {wallet_data.network!r})."
+            )
 
         addr = self.wallet_manager.get_address(wallet_name)
         depix_address = addr.address
 
         resp = client.create_deposit(amount_cents, depix_address)
 
-        deposit_id = resp.get("id") or resp.get("depositId")
+        deposit_id = resp.get("id")
         qr_copy_paste = resp.get("qrCopyPaste")
         if not deposit_id or not qr_copy_paste:
             raise RuntimeError(f"Eulen response missing required fields: {resp}")
@@ -249,7 +255,7 @@ class PixManager:
                             f"Eulen returned unknown status '{new_status}'; "
                             f"keeping cached '{swap.status}'."
                         )
-                txid = resp.get("blockchainTxID") or resp.get("blockchainTxId")
+                txid = resp.get("blockchainTxID")
                 if txid:
                     swap.blockchain_txid = txid
                 payer = resp.get("payerName")
@@ -259,7 +265,11 @@ class PixManager:
                 if expiration:
                     swap.expiration = expiration
                 self.storage.save_pix_swap(swap)
-            except Exception as e:
+            except (RuntimeError, urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+                # Network / Eulen-side problems are recoverable on the next
+                # poll. Programming errors (AttributeError, KeyError, etc.)
+                # propagate so the bug surfaces instead of hiding behind a
+                # generic "Could not fetch remote status" warning.
                 warning = f"Could not fetch remote status: {e}"
 
         result = {

--- a/src/aqua/pix.py
+++ b/src/aqua/pix.py
@@ -1,0 +1,271 @@
+"""Pix → DePix integration via the Eulen public API.
+
+Pix is Brazil's instant payment system; DePix is a BRL-pegged Liquid asset
+issued by Eulen. This module mints Pix charges, persists them as PixSwap
+records, and polls Eulen for delivery status. Unlike Ankara (Lightning →
+L-BTC), there is no claim step — Eulen pushes DePix directly to the Liquid
+address bound at deposit creation.
+"""
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Optional
+
+EULEN_API_URL = os.environ.get("EULEN_API_URL", "https://depix.eulen.app/api")
+EULEN_API_TOKEN_ENV = "EULEN_API_TOKEN"
+
+# Eulen first-transaction floor — surfaced in error messages so the agent can
+# explain it to the user rather than passing the raw API error through.
+PIX_MIN_AMOUNT_CENTS = 100  # R$1.00 — Eulen's documented absolute minimum
+
+# Eulen status values returned by GET /deposit-status.
+EULEN_STATUS_VALUES = frozenset(
+    {
+        "pending",
+        "depix_sent",
+        "under_review",
+        "canceled",
+        "error",
+        "refunded",
+        "expired",
+    }
+)
+TERMINAL_STATUSES = frozenset({"depix_sent", "canceled", "error", "refunded", "expired"})
+
+
+@dataclass
+class PixSwap:
+    """Persisted record of a Pix → DePix deposit."""
+
+    swap_id: str  # Eulen deposit id
+    amount_cents: int
+    wallet_name: str
+    depix_address: str
+    qr_copy_paste: str
+    status: str  # raw Eulen status (see EULEN_STATUS_VALUES)
+    network: str
+    created_at: str
+    qr_image_url: Optional[str] = None
+    expiration: Optional[str] = None
+    blockchain_txid: Optional[str] = None
+    payer_name: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PixSwap":
+        data = {**data}
+        for field_name in ("qr_image_url", "expiration", "blockchain_txid", "payer_name"):
+            data.setdefault(field_name, None)
+        return cls(**data)
+
+
+class EulenClient:
+    """HTTP client for the Eulen Pix-to-DePix API.
+
+    The token is read once from the environment at construction time so unit
+    tests can `monkeypatch.delenv` and assert the manager raises a clear error
+    before any HTTP call is attempted.
+    """
+
+    def __init__(self, base_url: Optional[str] = None, token: Optional[str] = None):
+        self.base_url = (base_url or EULEN_API_URL).rstrip("/")
+        self.token = token if token is not None else os.environ.get(EULEN_API_TOKEN_ENV)
+        if not self.token:
+            raise RuntimeError(
+                f"Eulen API token missing. Set {EULEN_API_TOKEN_ENV} in your environment "
+                "(get one from https://depix.info/#partners)."
+            )
+
+    def _api_request(
+        self,
+        method: str,
+        path: str,
+        body: Optional[dict] = None,
+        query: Optional[dict] = None,
+    ) -> dict:
+        url = f"{self.base_url}{path}"
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query)}"
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "agentic-aqua",
+                "Authorization": f"Bearer {self.token}",
+                "X-Nonce": uuid.uuid4().hex,
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode())
+        except urllib.error.HTTPError as e:
+            detail = ""
+            try:
+                err_body = json.loads(e.read().decode())
+                detail = err_body.get("error") or err_body.get("message") or str(err_body)
+            except Exception:
+                pass
+            msg = f"Eulen API error ({e.code} {method} {path})"
+            if detail:
+                msg += f": {detail}"
+            raise RuntimeError(msg) from e
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"Eulen API unreachable ({method} {path}): {e.reason}") from e
+
+    def create_deposit(self, amount_cents: int, depix_address: str) -> dict:
+        """POST /deposit — create a Pix charge that pays out DePix to depix_address."""
+        return self._api_request(
+            "POST",
+            "/deposit",
+            {
+                "amountInCents": amount_cents,
+                "depixAddress": depix_address,
+            },
+        )
+
+    def get_deposit_status(self, deposit_id: str) -> dict:
+        """GET /deposit-status?id=<deposit_id> — poll Eulen for delivery state."""
+        return self._api_request("GET", "/deposit-status", query={"id": deposit_id})
+
+
+def _format_brl(amount_cents: int) -> str:
+    """Render cents as 'R$1.234,56' (Brazilian convention)."""
+    integer, fraction = divmod(amount_cents, 100)
+    integer_str = f"{integer:,}".replace(",", ".")
+    return f"R${integer_str},{fraction:02d}"
+
+
+_STATUS_MESSAGES = {
+    "pending": "Waiting for Pix payment. Pay the QR / Copia e Cola in your banking app.",
+    "depix_sent": "DePix delivered to your Liquid wallet.",
+    "under_review": "Eulen is reviewing the payment (compliance/AML). This may take time.",
+    "canceled": "The deposit was canceled.",
+    "error": "Eulen reported an error processing this deposit.",
+    "refunded": "The Pix payment was refunded; no DePix was issued.",
+    "expired": "The Pix charge expired before it was paid.",
+}
+
+
+class PixManager:
+    """Pix → DePix manager. Mirrors the receive half of LightningManager."""
+
+    def __init__(self, storage, wallet_manager):
+        self.storage = storage
+        self.wallet_manager = wallet_manager
+
+    def create_deposit(
+        self,
+        amount_cents: int,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+    ) -> PixSwap:
+        """Create a Pix charge. DePix is delivered to the wallet's next address.
+
+        Args:
+            amount_cents: Amount in BRL cents (100 = R$1.00). Eulen's absolute
+                minimum is R$1.00; the practical floor for first-time users is
+                typically R$100, but limits scale up over time.
+            wallet_name: Liquid wallet to receive DePix into. Default: "default".
+            password: Accepted for symmetry with other receive flows but currently
+                unused — receiving DePix needs only an address.
+
+        Returns:
+            Persisted PixSwap with status="pending".
+        """
+        if not isinstance(amount_cents, int) or isinstance(amount_cents, bool):
+            raise ValueError("amount_cents must be an integer (cents of BRL, 100 = R$1.00)")
+        if amount_cents < PIX_MIN_AMOUNT_CENTS:
+            raise ValueError(
+                f"amount_cents {amount_cents} is below the minimum "
+                f"({PIX_MIN_AMOUNT_CENTS} cents = R$1.00)"
+            )
+
+        wallet_data = self.storage.load_wallet(wallet_name)
+        if not wallet_data:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+
+        addr = self.wallet_manager.get_address(wallet_name)
+        depix_address = addr.address
+
+        client = EulenClient()
+        try:
+            resp = client.create_deposit(amount_cents, depix_address)
+        except Exception as e:
+            raise RuntimeError(f"Failed to create Pix deposit: {e}") from e
+
+        deposit_id = resp.get("id") or resp.get("depositId")
+        qr_copy_paste = resp.get("qrCopyPaste")
+        if not deposit_id or not qr_copy_paste:
+            raise RuntimeError(f"Eulen response missing required fields: {resp}")
+
+        swap = PixSwap(
+            swap_id=str(deposit_id),
+            amount_cents=amount_cents,
+            wallet_name=wallet_name,
+            depix_address=depix_address,
+            qr_copy_paste=qr_copy_paste,
+            status="pending",
+            network=wallet_data.network,
+            created_at=datetime.now(UTC).isoformat(),
+            qr_image_url=resp.get("qrImageUrl"),
+            expiration=resp.get("expiration"),
+        )
+        self.storage.save_pix_swap(swap)
+        return swap
+
+    def get_deposit_status(self, swap_id: str) -> dict:
+        """Poll Eulen for the deposit status and persist any changes."""
+        swap = self.storage.load_pix_swap(swap_id)
+        if not swap:
+            raise ValueError(f"Pix swap not found: {swap_id}")
+
+        warning = None
+        try:
+            client = EulenClient()
+            resp = client.get_deposit_status(swap_id)
+            new_status = resp.get("status")
+            if new_status and new_status != swap.status:
+                swap.status = new_status
+            txid = resp.get("blockchainTxID") or resp.get("blockchainTxId")
+            if txid:
+                swap.blockchain_txid = txid
+            payer = resp.get("payerName")
+            if payer:
+                swap.payer_name = payer
+            expiration = resp.get("expiration")
+            if expiration:
+                swap.expiration = expiration
+            self.storage.save_pix_swap(swap)
+        except Exception as e:
+            warning = f"Could not fetch remote status: {e}"
+
+        result = {
+            "swap_id": swap.swap_id,
+            "status": swap.status,
+            "amount_cents": swap.amount_cents,
+            "amount_brl": _format_brl(swap.amount_cents),
+            "wallet_name": swap.wallet_name,
+            "depix_address": swap.depix_address,
+            "network": swap.network,
+            "message": _STATUS_MESSAGES.get(swap.status, f"Status: {swap.status}"),
+        }
+        if swap.blockchain_txid:
+            result["blockchain_txid"] = swap.blockchain_txid
+        if swap.payer_name:
+            result["payer_name"] = swap.payer_name
+        if swap.expiration:
+            result["expiration"] = swap.expiration
+        if warning:
+            result["warning"] = warning
+        return result

--- a/src/aqua/pix.py
+++ b/src/aqua/pix.py
@@ -13,7 +13,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from datetime import UTC, datetime
 from typing import Optional
 
@@ -61,10 +61,11 @@ class PixSwap:
 
     @classmethod
     def from_dict(cls, data: dict) -> "PixSwap":
-        data = {**data}
+        known = {f.name for f in fields(cls)}
+        filtered = {k: v for k, v in data.items() if k in known}
         for field_name in ("qr_image_url", "expiration", "blockchain_txid", "payer_name"):
-            data.setdefault(field_name, None)
-        return cls(**data)
+            filtered.setdefault(field_name, None)
+        return cls(**filtered)
 
 
 class EulenClient:
@@ -139,7 +140,7 @@ class EulenClient:
         return self._api_request("GET", "/deposit-status", query={"id": deposit_id})
 
 
-def _format_brl(amount_cents: int) -> str:
+def format_brl(amount_cents: int) -> str:
     """Render cents as 'R$1.234,56' (Brazilian convention)."""
     integer, fraction = divmod(amount_cents, 100)
     integer_str = f"{integer:,}".replace(",", ".")
@@ -191,6 +192,10 @@ class PixManager:
                 f"({PIX_MIN_AMOUNT_CENTS} cents = R$1.00)"
             )
 
+        # Fail fast on missing token before any wallet I/O — otherwise
+        # get_address() may advance the LWK address index for nothing.
+        client = EulenClient()
+
         wallet_data = self.storage.load_wallet(wallet_name)
         if not wallet_data:
             raise ValueError(f"Wallet '{wallet_name}' not found")
@@ -198,11 +203,7 @@ class PixManager:
         addr = self.wallet_manager.get_address(wallet_name)
         depix_address = addr.address
 
-        client = EulenClient()
-        try:
-            resp = client.create_deposit(amount_cents, depix_address)
-        except Exception as e:
-            raise RuntimeError(f"Failed to create Pix deposit: {e}") from e
+        resp = client.create_deposit(amount_cents, depix_address)
 
         deposit_id = resp.get("id") or resp.get("depositId")
         qr_copy_paste = resp.get("qrCopyPaste")
@@ -225,36 +226,47 @@ class PixManager:
         return swap
 
     def get_deposit_status(self, swap_id: str) -> dict:
-        """Poll Eulen for the deposit status and persist any changes."""
+        """Poll Eulen for the deposit status and persist any changes.
+
+        Skips the network call when the cached status is already terminal —
+        Eulen will not change a settled / canceled / refunded record.
+        """
         swap = self.storage.load_pix_swap(swap_id)
         if not swap:
             raise ValueError(f"Pix swap not found: {swap_id}")
 
         warning = None
-        try:
-            client = EulenClient()
-            resp = client.get_deposit_status(swap_id)
-            new_status = resp.get("status")
-            if new_status and new_status != swap.status:
-                swap.status = new_status
-            txid = resp.get("blockchainTxID") or resp.get("blockchainTxId")
-            if txid:
-                swap.blockchain_txid = txid
-            payer = resp.get("payerName")
-            if payer:
-                swap.payer_name = payer
-            expiration = resp.get("expiration")
-            if expiration:
-                swap.expiration = expiration
-            self.storage.save_pix_swap(swap)
-        except Exception as e:
-            warning = f"Could not fetch remote status: {e}"
+        if swap.status not in TERMINAL_STATUSES:
+            try:
+                client = EulenClient()
+                resp = client.get_deposit_status(swap_id)
+                new_status = resp.get("status")
+                if new_status and new_status != swap.status:
+                    if new_status in EULEN_STATUS_VALUES:
+                        swap.status = new_status
+                    else:
+                        warning = (
+                            f"Eulen returned unknown status '{new_status}'; "
+                            f"keeping cached '{swap.status}'."
+                        )
+                txid = resp.get("blockchainTxID") or resp.get("blockchainTxId")
+                if txid:
+                    swap.blockchain_txid = txid
+                payer = resp.get("payerName")
+                if payer:
+                    swap.payer_name = payer
+                expiration = resp.get("expiration")
+                if expiration:
+                    swap.expiration = expiration
+                self.storage.save_pix_swap(swap)
+            except Exception as e:
+                warning = f"Could not fetch remote status: {e}"
 
         result = {
             "swap_id": swap.swap_id,
             "status": swap.status,
             "amount_cents": swap.amount_cents,
-            "amount_brl": _format_brl(swap.amount_cents),
+            "amount_brl": format_brl(swap.amount_cents),
             "wallet_name": swap.wallet_name,
             "depix_address": swap.depix_address,
             "network": swap.network,

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -453,6 +453,41 @@ TOOL_SCHEMAS = {
             "required": ["swap_id"],
         },
     },
+    "pix_receive": {
+        "description": "Mint a Pix charge (Brazil) that pays out DePix (BRL stablecoin on Liquid) to the named wallet's next address. Returns the Pix Copia e Cola string and a hosted QR image URL — the user pays from their banking app. Amount is in BRL CENTS (100 = R$1.00). Requires EULEN_API_TOKEN env var.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "amount_cents": {
+                    "type": "integer",
+                    "description": "Amount in BRL cents (100 = R$1.00). NOT reais — be precise about the unit.",
+                },
+                "wallet_name": {
+                    "type": "string",
+                    "description": "Liquid wallet to receive DePix into",
+                    "default": "default",
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Accepted for symmetry; not currently used by Pix receive (no signing needed).",
+                },
+            },
+            "required": ["amount_cents"],
+        },
+    },
+    "pix_status": {
+        "description": "Check the status of a Pix → DePix deposit. Status values: pending, depix_sent, under_review, canceled, error, refunded, expired. Eulen delivers DePix automatically — no claim step.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "swap_id": {
+                    "type": "string",
+                    "description": "Swap ID returned from pix_receive",
+                },
+            },
+            "required": ["swap_id"],
+        },
+    },
 }
 
 
@@ -519,6 +554,19 @@ LIGHTNING:
 - Use lightning_send to pay a BOLT11 invoice using L-BTC (submarine swap via Boltz)
   Fees: ~0.1% + miner fees, Limits: 100 - 25,000,000 Sats
 - Use lightning_transaction_status to check status of any Lightning swap (send or receive)
+
+PIX → DEPIX (Brazilian Real on-ramp via Eulen):
+- Use pix_receive to mint a Pix charge that pays out DePix (BRL stablecoin on Liquid)
+  Amount is in BRL CENTS (100 = R$1.00). Be very explicit about the unit when asking the user.
+  Requires the EULEN_API_TOKEN environment variable; if missing, tell the user to set it
+  (token comes from https://depix.info/#partners).
+- The tool returns a `qr_copy_paste` string (EMV BR-Code) and a `qr_image_url`. Show BOTH
+  to the user and explain they can either paste the string into their banking app's
+  "Pix Copia e Cola" field, or open the URL on their phone and scan the QR.
+- After the user pays, call pix_status with the swap_id until status="depix_sent".
+  Eulen pushes DePix automatically — no claim step.
+- First-time users on Eulen typically have a low limit (around R$500); limits scale up
+  with usage. If a deposit fails with an amount error, suggest a smaller amount.
 
 WATCH-ONLY WALLETS:
 - For a Bitcoin-only watch wallet: btc_import_descriptor (BIP84 wpkh xpub).
@@ -649,6 +697,16 @@ WALLET DELETION:
                 description="Pay a Lightning invoice using Liquid Bitcoin (via Boltz submarine swap)",
                 arguments=[
                     PromptArgument(name="wallet_name", description="Wallet name", required=False),
+                ],
+            ),
+            # Pix → DePix
+            Prompt(
+                name="receive_via_pix",
+                description="Receive DePix (BRL stablecoin on Liquid) by paying a Pix charge in your Brazilian banking app",
+                arguments=[
+                    PromptArgument(
+                        name="wallet_name", description="Wallet name", required=False
+                    ),
                 ],
             ),
         ]
@@ -981,6 +1039,31 @@ Please:
    - Preimage (proof of payment)
    - Explorer link for lockup transaction
 8. If swap fails, explain that L-BTC is locked until timeout and can be refunded""",
+                        ),
+                    )
+                ]
+            )
+
+        elif name == "receive_via_pix":
+            return GetPromptResult(
+                messages=[
+                    PromptMessage(
+                        role="user",
+                        content=TextContent(
+                            type="text",
+                            text=f"""I want to receive DePix (BRL stablecoin on Liquid) into my wallet '{wallet_name}' by paying via Pix.
+
+Please:
+1. Verify the EULEN_API_TOKEN environment variable is set. If not, tell me to obtain one from https://depix.info/#partners and stop here.
+2. Ask me how much I want to deposit, IN REAIS (e.g. "R$50"). Convert to cents (R$50 → 5000 cents) before calling pix_receive. Be explicit about the unit so I do not get a 100× error.
+3. Mention the practical first-time limit on Eulen is around R$500; offer to use a smaller amount if mine is higher.
+4. Call pix_receive(amount_cents=…, wallet_name='{wallet_name}').
+5. Show me BOTH:
+   - The `qr_copy_paste` string (EMV BR-Code) — I can paste this into my banking app's "Pix Copia e Cola" field.
+   - The `qr_image_url` — I can open this on my phone and scan the QR with my bank app.
+   Explain I only need to do ONE of those, not both.
+6. After I confirm I have paid, call pix_status(swap_id=…) and report the status. Re-check on request until status="depix_sent" (DePix delivered) or a terminal failure.
+7. When delivered, show the `blockchain_txid` (Liquid txid) so I can verify on a block explorer.""",
                         ),
                     )
                 ]

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -83,6 +83,7 @@ class Storage:
         self.swaps_dir = self.base_dir / "swaps"
         self.ankara_swaps_dir = self.base_dir / "ankara_swaps"
         self.lightning_swaps_dir = self.base_dir / "lightning_swaps"
+        self.pix_swaps_dir = self.base_dir / "pix_swaps"
         self.config_path = self.base_dir / "config.json"
         self._ensure_dirs()
 
@@ -100,6 +101,8 @@ class Storage:
         os.chmod(self.ankara_swaps_dir, 0o700)
         self.lightning_swaps_dir.mkdir(exist_ok=True, mode=0o700)
         os.chmod(self.lightning_swaps_dir, 0o700)
+        self.pix_swaps_dir.mkdir(exist_ok=True, mode=0o700)
+        os.chmod(self.pix_swaps_dir, 0o700)
 
     def _derive_key(self, password: str, salt: bytes) -> bytes:
         """Derive encryption key from password."""
@@ -329,6 +332,40 @@ class Storage:
         return [
             p.stem
             for p in self.lightning_swaps_dir.glob("*.json")
+            if SWAP_ID_PATTERN.fullmatch(p.stem)
+        ]
+
+    # Pix swap operations
+
+    def _pix_swap_path(self, swap_id: str) -> Path:
+        """Get path to Pix swap file, validating the ID to prevent path traversal."""
+        if not SWAP_ID_PATTERN.fullmatch(swap_id):
+            raise ValueError(
+                f"Invalid swap ID '{swap_id}'. "
+                "Use only letters, numbers, hyphens and underscores (max 128 chars)."
+            )
+        return self.pix_swaps_dir / f"{swap_id}.json"
+
+    def save_pix_swap(self, swap) -> None:
+        """Save Pix swap data for recovery."""
+        path = self._pix_swap_path(swap.swap_id)
+        self._atomic_write_json(path, swap.to_dict())
+
+    def load_pix_swap(self, swap_id: str):
+        """Load Pix swap data. Returns PixSwap or None."""
+        from .pix import PixSwap
+
+        path = self._pix_swap_path(swap_id)
+        if not path.exists():
+            return None
+        with open(path) as f:
+            return PixSwap.from_dict(json.load(f))
+
+    def list_pix_swaps(self) -> list[str]:
+        """List all Pix swap IDs."""
+        return [
+            p.stem
+            for p in self.pix_swaps_dir.glob("*.json")
             if SWAP_ID_PATTERN.fullmatch(p.stem)
         ]
 

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -28,6 +28,7 @@ EXPLORER_URLS = {
 _manager: WalletManager | None = None
 _btc_manager: BitcoinWalletManager | None = None
 _lightning_manager: "LightningManager | None" = None
+_pix_manager: "PixManager | None" = None
 
 
 def get_manager() -> WalletManager:
@@ -57,6 +58,19 @@ def get_lightning_manager() -> "LightningManager":
             wallet_manager=get_manager(),
         )
     return _lightning_manager
+
+
+def get_pix_manager() -> "PixManager":
+    """Get or create Pix manager (shares storage and wallet manager)."""
+    global _pix_manager
+    if _pix_manager is None:
+        from .pix import PixManager
+
+        _pix_manager = PixManager(
+            storage=get_manager().storage,
+            wallet_manager=get_manager(),
+        )
+    return _pix_manager
 
 
 # Tool implementations
@@ -751,6 +765,79 @@ def lightning_transaction_status(swap_id: str) -> dict[str, Any]:
     return manager.get_swap_status(swap_id)
 
 
+# ---------------------------------------------------------------------------
+# Pix → DePix tools (Brazilian Real on-ramp via Eulen)
+# ---------------------------------------------------------------------------
+
+
+def pix_receive(
+    amount_cents: int,
+    wallet_name: str = "default",
+    password: str | None = None,
+) -> dict[str, Any]:
+    """Mint a Pix charge that pays out DePix to your Liquid wallet.
+
+    Pix is Brazil's instant payment system; DePix is a BRL-pegged Liquid asset
+    issued by Eulen. The user pays the returned `qr_copy_paste` string in their
+    banking app's "Pix Copia e Cola" field (or scans `qr_image_url` from a
+    second device); Eulen credits DePix to the wallet's next address.
+
+    Requires the EULEN_API_TOKEN environment variable.
+
+    Args:
+        amount_cents: Amount in BRL cents (100 = R$1.00). NOT reais.
+        wallet_name: Liquid wallet to receive DePix into. Default: "default".
+        password: Accepted for symmetry; receiving DePix needs only an address.
+
+    Returns:
+        swap_id, qr_copy_paste, qr_image_url, amount_cents, amount_brl,
+        depix_address, expiration, message.
+    """
+    manager = get_pix_manager()
+    swap = manager.create_deposit(amount_cents, wallet_name, password)
+
+    from .pix import _format_brl
+
+    amount_brl = _format_brl(swap.amount_cents)
+    all_wallets = get_manager().storage.list_wallets()
+    wallet_note = f" in wallet '{wallet_name}'" if len(all_wallets) > 1 else ""
+    return {
+        "swap_id": swap.swap_id,
+        "qr_copy_paste": swap.qr_copy_paste,
+        "qr_image_url": swap.qr_image_url,
+        "amount_cents": swap.amount_cents,
+        "amount_brl": amount_brl,
+        "depix_address": swap.depix_address,
+        "expiration": swap.expiration,
+        "wallet_name": wallet_name,
+        "message": (
+            f"Pay {amount_brl} via Pix to receive DePix{wallet_note}. "
+            "Paste qr_copy_paste into your banking app's 'Pix Copia e Cola' field, "
+            "or open qr_image_url on your phone and scan with your bank app. "
+            f"Check status with swap_id: {swap.swap_id}"
+        ),
+    }
+
+
+def pix_status(swap_id: str) -> dict[str, Any]:
+    """Check the status of a Pix → DePix deposit.
+
+    Eulen pushes DePix automatically once the Pix payment settles, so there is
+    no claim step. Status values from the upstream API: pending, depix_sent,
+    under_review, canceled, error, refunded, expired.
+
+    Args:
+        swap_id: Swap ID returned from pix_receive.
+
+    Returns:
+        swap_id, status, amount_cents, amount_brl, wallet_name, depix_address,
+        network, message; optionally blockchain_txid, payer_name, expiration,
+        warning.
+    """
+    manager = get_pix_manager()
+    return manager.get_deposit_status(swap_id)
+
+
 # Tool registry for MCP
 TOOLS = {
     "lw_generate_mnemonic": lw_generate_mnemonic,
@@ -776,4 +863,6 @@ TOOLS = {
     "lightning_receive": lightning_receive,
     "lightning_send": lightning_send,
     "lightning_transaction_status": lightning_transaction_status,
+    "pix_receive": pix_receive,
+    "pix_status": pix_status,
 }

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -796,9 +796,9 @@ def pix_receive(
     manager = get_pix_manager()
     swap = manager.create_deposit(amount_cents, wallet_name, password)
 
-    from .pix import _format_brl
+    from .pix import format_brl
 
-    amount_brl = _format_brl(swap.amount_cents)
+    amount_brl = format_brl(swap.amount_cents)
     all_wallets = get_manager().storage.list_wallets()
     wallet_note = f" in wallet '{wallet_name}'" if len(all_wallets) > 1 else ""
     return {

--- a/tests/test_pix.py
+++ b/tests/test_pix.py
@@ -87,6 +87,14 @@ def isolated_managers():
 @pytest.fixture
 def test_wallet(isolated_managers):
     storage, wm = isolated_managers
+    # Pix → DePix is mainnet-only. The fixture mirrors that constraint.
+    wm.import_mnemonic(TEST_MNEMONIC, "default", "mainnet")
+    return storage, wm
+
+
+@pytest.fixture
+def testnet_wallet(isolated_managers):
+    storage, wm = isolated_managers
     wm.import_mnemonic(TEST_MNEMONIC, "default", "testnet")
     return storage, wm
 
@@ -196,6 +204,22 @@ class TestEulenClient:
             assert "invalid amount" in str(exc.value)
             assert "400" in str(exc.value)
 
+    def test_create_deposit_http_error_empty_body_omits_literal_braces(self):
+        # An HTTP error with an empty (or unrecognised-shape) JSON body must
+        # not surface "{}" or "{'foo': 'bar'}" as a fake "error detail" —
+        # that reads like an AQUA bug rather than a provider error.
+        client = EulenClient()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            err = urllib.error.HTTPError("url", 500, "Server Error", {}, MagicMock())
+            err.read = MagicMock(return_value=b"{}")
+            mock_urlopen.side_effect = err
+            with pytest.raises(RuntimeError) as exc:
+                client.create_deposit(5000, "lq1test")
+            message = str(exc.value)
+            assert "500" in message
+            assert "{}" not in message
+            assert "{'" not in message
+
     def test_get_deposit_status_builds_query(self):
         client = EulenClient()
         with patch("urllib.request.urlopen") as mock_urlopen:
@@ -285,6 +309,17 @@ class TestPixManagerCreateDeposit:
             with pytest.raises(RuntimeError, match="missing required fields"):
                 manager.create_deposit(5000, "default")
 
+    def test_rejects_testnet_wallet(self, testnet_wallet):
+        # DePix is a mainnet-only Liquid asset. A testnet wallet must fail
+        # before any HTTP call so the user doesn't pay a Pix charge that
+        # cannot be settled.
+        storage, wm = testnet_wallet
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            with pytest.raises(ValueError, match="mainnet"):
+                manager.create_deposit(5000, "default")
+            mock_urlopen.assert_not_called()
+
 
 class TestPixManagerGetDepositStatus:
     def _seed_swap(self, storage, wm) -> PixSwap:
@@ -331,6 +366,19 @@ class TestPixManagerGetDepositStatus:
         assert result["status"] == "pending"
         assert "warning" in result
         assert "offline" in result["warning"]
+
+    def test_programming_error_propagates(self, test_wallet):
+        # Internal bugs (AttributeError, KeyError, etc.) must not be hidden
+        # behind a "Could not fetch remote status" warning — they would
+        # otherwise look like a transient Eulen issue.
+        storage, wm = test_wallet
+        seeded = self._seed_swap(storage, wm)
+
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with patch("aqua.pix.EulenClient") as mock_client_cls:
+            mock_client_cls.return_value.get_deposit_status.side_effect = AttributeError("boom")
+            with pytest.raises(AttributeError, match="boom"):
+                manager.get_deposit_status(seeded.swap_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pix.py
+++ b/tests/test_pix.py
@@ -1,0 +1,443 @@
+"""Tests for the Pix → DePix integration (Eulen API)."""
+
+import json
+import re
+import tempfile
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aqua.pix import (
+    EULEN_API_TOKEN_ENV,
+    EulenClient,
+    PixManager,
+    PixSwap,
+    _format_brl,
+)
+from aqua.storage import Storage
+from aqua.wallet import WalletManager
+
+TEST_MNEMONIC = (
+    "abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon abandon about"
+)
+
+MOCK_DEPOSIT_RESPONSE = {
+    "id": "eulen_deposit_abc",
+    "qrCopyPaste": "00020126580014br.gov.bcb.pix0136example-pix-copy-paste-string6304ABCD",
+    "qrImageUrl": "https://depix.eulen.app/qr/eulen_deposit_abc.png",
+    "expiration": "2026-05-08T23:59:59Z",
+    "async": False,
+}
+
+MOCK_STATUS_PENDING = {
+    "status": "pending",
+    "valueInCents": 5000,
+    "expiration": "2026-05-08T23:59:59Z",
+}
+
+MOCK_STATUS_SETTLED = {
+    "status": "depix_sent",
+    "valueInCents": 5000,
+    "payerName": "FULANO DE TAL",
+    "blockchainTxID": "deadbeef" * 8,
+    "expiration": "2026-05-08T23:59:59Z",
+}
+
+
+def _mock_response(data, status=200):
+    """Create a mock urllib response (context manager) that returns JSON."""
+    resp = MagicMock()
+    if isinstance(data, dict):
+        resp.read.return_value = json.dumps(data).encode()
+    else:
+        resp.read.return_value = data
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def eulen_token(monkeypatch):
+    """Default to a present token; tests that need it absent call delenv themselves."""
+    monkeypatch.setenv(EULEN_API_TOKEN_ENV, "test-token-xyz")
+
+
+@pytest.fixture
+def isolated_managers():
+    """Storage + WalletManager + PixManager backed by a temp dir."""
+    import aqua.tools as tools_module
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        storage = Storage(Path(tmpdir))
+        wm = WalletManager(storage=storage)
+        tools_module._manager = wm
+        tools_module._btc_manager = None
+        tools_module._lightning_manager = None
+        tools_module._pix_manager = None
+        yield storage, wm
+        tools_module._manager = None
+        tools_module._btc_manager = None
+        tools_module._lightning_manager = None
+        tools_module._pix_manager = None
+
+
+@pytest.fixture
+def test_wallet(isolated_managers):
+    storage, wm = isolated_managers
+    wm.import_mnemonic(TEST_MNEMONIC, "default", "testnet")
+    return storage, wm
+
+
+# ---------------------------------------------------------------------------
+# PixSwap dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestPixSwap:
+    def test_to_dict_round_trip(self):
+        swap = PixSwap(
+            swap_id="dep_1",
+            amount_cents=5000,
+            wallet_name="default",
+            depix_address="lq1test",
+            qr_copy_paste="00020126...",
+            status="pending",
+            network="mainnet",
+            created_at="2026-05-08T00:00:00+00:00",
+        )
+        data = swap.to_dict()
+        round_tripped = PixSwap.from_dict(data)
+        assert round_tripped == swap
+
+    def test_from_dict_back_compat_missing_optional_fields(self):
+        """A persisted record missing newer optional fields still loads."""
+        data = {
+            "swap_id": "dep_1",
+            "amount_cents": 5000,
+            "wallet_name": "default",
+            "depix_address": "lq1test",
+            "qr_copy_paste": "00020126...",
+            "status": "pending",
+            "network": "mainnet",
+            "created_at": "2026-05-08T00:00:00+00:00",
+        }
+        swap = PixSwap.from_dict(data)
+        assert swap.qr_image_url is None
+        assert swap.blockchain_txid is None
+        assert swap.payer_name is None
+        assert swap.expiration is None
+
+
+# ---------------------------------------------------------------------------
+# Helper formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatBRL:
+    @pytest.mark.parametrize(
+        "cents,expected",
+        [
+            (100, "R$1,00"),
+            (5000, "R$50,00"),
+            (12345, "R$123,45"),
+            (123456, "R$1.234,56"),
+            (10000000, "R$100.000,00"),
+            (1, "R$0,01"),
+        ],
+    )
+    def test_format_brl(self, cents, expected):
+        assert _format_brl(cents) == expected
+
+
+# ---------------------------------------------------------------------------
+# EulenClient HTTP behavior
+# ---------------------------------------------------------------------------
+
+
+class TestEulenClient:
+    def test_missing_token_raises(self, monkeypatch):
+        monkeypatch.delenv(EULEN_API_TOKEN_ENV, raising=False)
+        with pytest.raises(RuntimeError) as exc:
+            EulenClient()
+        assert EULEN_API_TOKEN_ENV in str(exc.value)
+
+    def test_create_deposit_sends_bearer_and_nonce(self):
+        client = EulenClient()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value = _mock_response(MOCK_DEPOSIT_RESPONSE)
+            result = client.create_deposit(5000, "lq1test")
+
+            assert result["id"] == "eulen_deposit_abc"
+
+            # Inspect the Request object that was passed in
+            called_req = mock_urlopen.call_args.args[0]
+            assert called_req.method == "POST"
+            assert called_req.full_url.endswith("/deposit")
+            assert called_req.headers["Authorization"] == "Bearer test-token-xyz"
+            nonce = called_req.headers["X-nonce"]  # urllib lowercases the second char
+            # nonce should be a uuid4 hex (32 chars, lowercase hex)
+            assert re.fullmatch(r"[0-9a-f]{32}", nonce)
+            body = json.loads(called_req.data.decode())
+            assert body == {"amountInCents": 5000, "depixAddress": "lq1test"}
+
+    def test_create_deposit_http_error_includes_detail(self):
+        client = EulenClient()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            err = urllib.error.HTTPError("url", 400, "Bad Request", {}, MagicMock())
+            err.read = MagicMock(
+                return_value=json.dumps({"error": "invalid amount"}).encode()
+            )
+            mock_urlopen.side_effect = err
+            with pytest.raises(RuntimeError) as exc:
+                client.create_deposit(0, "lq1test")
+            assert "invalid amount" in str(exc.value)
+            assert "400" in str(exc.value)
+
+    def test_get_deposit_status_builds_query(self):
+        client = EulenClient()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value = _mock_response(MOCK_STATUS_PENDING)
+            result = client.get_deposit_status("eulen_deposit_abc")
+
+            assert result["status"] == "pending"
+            called_req = mock_urlopen.call_args.args[0]
+            assert called_req.method == "GET"
+            assert "id=eulen_deposit_abc" in called_req.full_url
+
+    def test_url_error_is_wrapped(self):
+        client = EulenClient()
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = urllib.error.URLError("connection refused")
+            with pytest.raises(RuntimeError) as exc:
+                client.get_deposit_status("dep_x")
+            assert "unreachable" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# PixManager — orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestPixManagerCreateDeposit:
+    def test_rejects_non_int_amount(self, test_wallet):
+        storage, wm = test_wallet
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with pytest.raises(ValueError, match="integer"):
+            manager.create_deposit(50.0, "default")  # type: ignore[arg-type]
+
+    def test_rejects_bool_amount(self, test_wallet):
+        storage, wm = test_wallet
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with pytest.raises(ValueError, match="integer"):
+            manager.create_deposit(True, "default")  # type: ignore[arg-type]
+
+    def test_rejects_below_minimum(self, test_wallet):
+        storage, wm = test_wallet
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with pytest.raises(ValueError, match="below the minimum"):
+            manager.create_deposit(50, "default")
+
+    def test_unknown_wallet(self, isolated_managers):
+        storage, wm = isolated_managers
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with pytest.raises(ValueError, match="not found"):
+            manager.create_deposit(5000, "ghost")
+
+    def test_missing_token_surfaces_clear_error(self, test_wallet, monkeypatch):
+        storage, wm = test_wallet
+        monkeypatch.delenv(EULEN_API_TOKEN_ENV, raising=False)
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with pytest.raises(RuntimeError) as exc:
+            manager.create_deposit(5000, "default")
+        assert EULEN_API_TOKEN_ENV in str(exc.value)
+
+    def test_happy_path_persists_swap(self, test_wallet):
+        storage, wm = test_wallet
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value = _mock_response(MOCK_DEPOSIT_RESPONSE)
+            swap = manager.create_deposit(5000, "default")
+
+        assert swap.swap_id == "eulen_deposit_abc"
+        assert swap.amount_cents == 5000
+        assert swap.qr_copy_paste.startswith("00020126")
+        assert swap.qr_image_url == MOCK_DEPOSIT_RESPONSE["qrImageUrl"]
+        assert swap.depix_address  # populated from wallet
+        assert swap.status == "pending"
+        # Confirm it was persisted
+        loaded = storage.load_pix_swap(swap.swap_id)
+        assert loaded is not None
+        assert loaded.swap_id == swap.swap_id
+
+        # Confirm the request body sent the wallet's address as depixAddress
+        called_req = mock_urlopen.call_args.args[0]
+        body = json.loads(called_req.data.decode())
+        assert body["depixAddress"] == swap.depix_address
+
+    def test_response_missing_required_fields_raises(self, test_wallet):
+        storage, wm = test_wallet
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value = _mock_response({"id": "x"})  # no qrCopyPaste
+            with pytest.raises(RuntimeError, match="missing required fields"):
+                manager.create_deposit(5000, "default")
+
+
+class TestPixManagerGetDepositStatus:
+    def _seed_swap(self, storage, wm) -> PixSwap:
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value = _mock_response(MOCK_DEPOSIT_RESPONSE)
+            return manager.create_deposit(5000, "default")
+
+    def test_unknown_swap_id(self, test_wallet):
+        storage, wm = test_wallet
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with pytest.raises(ValueError, match="not found"):
+            manager.get_deposit_status("missing_id")
+
+    def test_pending_to_settled_transition_persists(self, test_wallet):
+        storage, wm = test_wallet
+        seeded = self._seed_swap(storage, wm)
+
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value = _mock_response(MOCK_STATUS_SETTLED)
+            result = manager.get_deposit_status(seeded.swap_id)
+
+        assert result["status"] == "depix_sent"
+        assert result["blockchain_txid"] == "deadbeef" * 8
+        assert result["payer_name"] == "FULANO DE TAL"
+        assert result["amount_brl"] == "R$50,00"
+
+        reloaded = storage.load_pix_swap(seeded.swap_id)
+        assert reloaded is not None
+        assert reloaded.status == "depix_sent"
+        assert reloaded.blockchain_txid == "deadbeef" * 8
+
+    def test_warning_on_remote_failure(self, test_wallet):
+        storage, wm = test_wallet
+        seeded = self._seed_swap(storage, wm)
+
+        manager = PixManager(storage=storage, wallet_manager=wm)
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = urllib.error.URLError("offline")
+            result = manager.get_deposit_status(seeded.swap_id)
+
+        # Status preserved from local record; warning surfaced.
+        assert result["status"] == "pending"
+        assert "warning" in result
+        assert "offline" in result["warning"]
+
+
+# ---------------------------------------------------------------------------
+# Storage persistence
+# ---------------------------------------------------------------------------
+
+
+class TestPixStoragePersistence:
+    @pytest.fixture
+    def storage(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Storage(Path(tmpdir))
+
+    def test_save_and_load(self, storage):
+        swap = PixSwap(
+            swap_id="dep_1",
+            amount_cents=5000,
+            wallet_name="default",
+            depix_address="lq1test",
+            qr_copy_paste="00020126",
+            status="pending",
+            network="mainnet",
+            created_at="2026-05-08T00:00:00+00:00",
+        )
+        storage.save_pix_swap(swap)
+        assert (storage.pix_swaps_dir / "dep_1.json").exists()
+        loaded = storage.load_pix_swap("dep_1")
+        assert loaded is not None
+        assert loaded.swap_id == "dep_1"
+
+    def test_load_missing_returns_none(self, storage):
+        assert storage.load_pix_swap("nonexistent") is None
+
+    def test_list(self, storage):
+        for sid in ("a_1", "b_2"):
+            storage.save_pix_swap(
+                PixSwap(
+                    swap_id=sid,
+                    amount_cents=100,
+                    wallet_name="w",
+                    depix_address="lq1",
+                    qr_copy_paste="qr",
+                    status="pending",
+                    network="mainnet",
+                    created_at="2026-05-08T00:00:00+00:00",
+                )
+            )
+        listed = storage.list_pix_swaps()
+        assert set(listed) == {"a_1", "b_2"}
+
+    def test_invalid_swap_id_rejected(self, storage):
+        with pytest.raises(ValueError, match="Invalid swap ID"):
+            storage._pix_swap_path("../etc/passwd")
+
+    @pytest.mark.skipif(
+        __import__("sys").platform == "win32",
+        reason="POSIX file permissions not enforced on Windows",
+    )
+    def test_file_permissions(self, storage):
+        swap = PixSwap(
+            swap_id="dep_perm",
+            amount_cents=100,
+            wallet_name="w",
+            depix_address="lq1",
+            qr_copy_paste="qr",
+            status="pending",
+            network="mainnet",
+            created_at="2026-05-08T00:00:00+00:00",
+        )
+        storage.save_pix_swap(swap)
+        path = storage.pix_swaps_dir / "dep_perm.json"
+        import os
+
+        mode = os.stat(path).st_mode & 0o777
+        assert mode == 0o600
+
+
+# ---------------------------------------------------------------------------
+# Tool dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestPixTools:
+    def test_pix_receive_returns_qr_payload(self, test_wallet):
+        from aqua.tools import pix_receive
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value = _mock_response(MOCK_DEPOSIT_RESPONSE)
+            result = pix_receive(amount_cents=5000)
+
+        assert result["swap_id"] == "eulen_deposit_abc"
+        assert result["qr_copy_paste"].startswith("00020126")
+        assert result["qr_image_url"] == MOCK_DEPOSIT_RESPONSE["qrImageUrl"]
+        assert result["amount_cents"] == 5000
+        assert result["amount_brl"] == "R$50,00"
+        assert "Copia e Cola" in result["message"]
+
+    def test_pix_status_dispatches(self, test_wallet):
+        from aqua.tools import pix_receive, pix_status
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value = _mock_response(MOCK_DEPOSIT_RESPONSE)
+            created = pix_receive(amount_cents=5000)
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.return_value = _mock_response(MOCK_STATUS_SETTLED)
+            status = pix_status(swap_id=created["swap_id"])
+
+        assert status["status"] == "depix_sent"
+        assert status["blockchain_txid"] == "deadbeef" * 8

--- a/tests/test_pix.py
+++ b/tests/test_pix.py
@@ -14,7 +14,7 @@ from aqua.pix import (
     EulenClient,
     PixManager,
     PixSwap,
-    _format_brl,
+    format_brl,
 )
 from aqua.storage import Storage
 from aqua.wallet import WalletManager
@@ -149,7 +149,7 @@ class TestFormatBRL:
         ],
     )
     def test_format_brl(self, cents, expected):
-        assert _format_brl(cents) == expected
+        assert format_brl(cents) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -44,10 +44,12 @@ def isolated_manager():
         tools_module._manager = manager
         tools_module._btc_manager = None  # so get_btc_manager() uses same storage
         tools_module._lightning_manager = None
+        tools_module._pix_manager = None
         yield manager
         tools_module._manager = None
         tools_module._btc_manager = None
         tools_module._lightning_manager = None
+        tools_module._pix_manager = None
 
 
 # ---------------------------------------------------------------------------
@@ -717,6 +719,8 @@ class TestToolRegistry:
             "lightning_receive",
             "lightning_send",
             "lightning_transaction_status",
+            "pix_receive",
+            "pix_status",
             "delete_wallet",
             "btc_import_descriptor",
             "btc_export_descriptor",


### PR DESCRIPTION
## Summary

Adds a Pix → DePix receive flow: AQUA mints a Pix charge for X reais, the user pays it in their Brazilian banking app, and Eulen credits DePix (BRL stablecoin on Liquid) to the wallet's next address.

- **`pix_receive(amount_cents, wallet_name="default")`** — mints a Pix charge, returns the EMV BR-Code `qr_copy_paste` string + Eulen's hosted `qr_image_url`. Persists a `PixSwap` record to `~/.aqua/pix_swaps/{id}.json` (0o600).
- **`pix_status(swap_id)`** — polls Eulen, persists status changes. Eulen pushes DePix automatically — there is no claim step.
- **`receive_via_pix` prompt** — guides the agent through the flow, stresses the cents-not-reais unit, and reminds about Eulen's first-time R$500 limit.

## Why

Completes the parallel of "external rail → Liquid asset" started by Ankara (Lightning → L-BTC). Gives BR users an on-ramp that AQUA didn't previously have.

## Architecture

Mirrors the Ankara / Lightning receive flow:

| File | Change |
|---|---|
| `src/aqua/pix.py` (new) | `EulenClient` (HTTP, Bearer + `X-Nonce: uuid4`), `PixSwap` dataclass, `PixManager` orchestration |
| `src/aqua/storage.py` | `pix_swaps_dir` + `save_pix_swap` / `load_pix_swap` / `list_pix_swaps` |
| `src/aqua/tools.py` | `pix_receive`, `pix_status`, `get_pix_manager` singleton |
| `src/aqua/server.py` | JSON schemas + `receive_via_pix` prompt + agent instructions |
| `AGENTS.md` | Tool/prompt counts, project tree, Pix Swap File Structure, Pix / Eulen Integration section |

Eulen endpoints used:
- `POST /deposit` with `{ amountInCents, depixAddress }`, headers `Authorization: Bearer <token>` + `X-Nonce: <uuid4-hex>`.
- `GET /deposit-status?id={id}`.

## Configuration

| Var | Required | Default |
|---|---|---|
| `EULEN_API_TOKEN` | yes | — (get from https://depix.info/#partners) |
| `EULEN_API_URL`   | no  | `https://depix.eulen.app/api` |

If the token is unset, `pix_receive` raises a clear, actionable error before any HTTP call.

## Out of scope (deferred)

- DePix → Pix sell direction.
- KYC handling on the Eulen side.
- Storing the API token in `config.json`.
- ASCII / PNG QR rendering in tool output (we return the BR-Code string + hosted URL).

## Test plan

- [x] `tests/test_pix.py`: 30 new tests — dataclass round-trip, BRL formatting, `EulenClient` (token-missing, Bearer + `X-Nonce` header shape, HTTP 4xx detail extraction, query-string build, URLError wrap), `PixManager` (validation, unknown wallet, missing-token surfaces clear error, happy path persistence, response-field validation, pending → settled transition, remote-failure warning), storage round-trip / list / invalid-id rejection / `0o600` permissions, tool dispatch end-to-end.
- [x] `tests/test_tools.py` registry test updated to include the new tools.
- [x] Full suite: \`uv run python -m pytest tests/\` — **343 passed, 2 skipped, 0 failed**.
- [ ] Live smoke (requires partner token): \`EULEN_API_TOKEN=… uv run python -c "from aqua.tools import pix_receive; print(pix_receive(amount_cents=10000))"\` should return a \`qr_copy_paste\` starting with \`00020126…\`.
- [ ] MCP smoke: \`tools/list\` advertises \`pix_receive\` + \`pix_status\`; \`prompts/list\` shows \`receive_via_pix\`.