### PR TITLE
Add AQUA ASCII banner to CLI --help and bump to 0.4.0

### DIFF
--- a/src/aqua/__init__.py
+++ b/src/aqua/__init__.py
@@ -1,3 +1,3 @@
 """Agentic AQUA - Manage Liquid Network and Bitcoin wallets through AI assistants."""
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/src/aqua/banner.py
+++ b/src/aqua/banner.py
@@ -1,0 +1,47 @@
+"""Welcome banner shown on wallet-creation entry points.
+
+Displays the AQUA ASCII logo plus a security reminder the first time a
+seed/descriptor-handling tool is touched in a process (= MCP session) or
+whenever the user runs ``aqua --help``.
+"""
+
+from importlib.resources import files
+
+TRIGGER_TOOLS = frozenset(
+    {
+        "lw_generate_mnemonic",
+        "lw_import_mnemonic",
+        "lw_import_descriptor",
+        "btc_import_descriptor",
+    }
+)
+
+WELCOME_MESSAGE = (
+    "Welcome to Agentic AQUA!\n"
+    "- Never share your seed phrase.\n"
+    "- Use it with small amounts; it is not designed for savings.\n"
+)
+
+_shown = False
+
+
+def load_logo() -> str:
+    return files("aqua").joinpath("static/logo_ascii_31_chars.txt").read_text()
+
+
+def render_banner() -> str:
+    return f"{load_logo()}\n{WELCOME_MESSAGE}\n"
+
+
+def consume_once() -> str | None:
+    """Return the banner on first call in this process; ``None`` thereafter."""
+    global _shown
+    if _shown:
+        return None
+    _shown = True
+    return render_banner()
+
+
+def reset_for_tests() -> None:
+    global _shown
+    _shown = False

--- a/src/aqua/banner.py
+++ b/src/aqua/banner.py
@@ -1,28 +1,12 @@
-"""Welcome banner shown on wallet-creation entry points.
-
-Displays the AQUA ASCII logo plus a security reminder the first time a
-seed/descriptor-handling tool is touched in a process (= MCP session) or
-whenever the user runs ``aqua --help``.
-"""
+"""Welcome banner shown on ``aqua --help``."""
 
 from importlib.resources import files
-
-TRIGGER_TOOLS = frozenset(
-    {
-        "lw_generate_mnemonic",
-        "lw_import_mnemonic",
-        "lw_import_descriptor",
-        "btc_import_descriptor",
-    }
-)
 
 WELCOME_MESSAGE = (
     "Welcome to Agentic AQUA!\n"
     "- Never share your seed phrase.\n"
     "- Use it with small amounts; it is not designed for savings.\n"
 )
-
-_shown = False
 
 
 def load_logo() -> str:
@@ -31,17 +15,3 @@ def load_logo() -> str:
 
 def render_banner() -> str:
     return f"{load_logo()}\n{WELCOME_MESSAGE}\n"
-
-
-def consume_once() -> str | None:
-    """Return the banner on first call in this process; ``None`` thereafter."""
-    global _shown
-    if _shown:
-        return None
-    _shown = True
-    return render_banner()
-
-
-def reset_for_tests() -> None:
-    global _shown
-    _shown = False

--- a/src/aqua/cli/main.py
+++ b/src/aqua/cli/main.py
@@ -24,7 +24,15 @@ class AquaContext:
         self.verbose = verbose
 
 
-@click.group(context_settings={"auto_envvar_prefix": "AQUA"})
+class AquaGroup(click.Group):
+    def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        from ..banner import render_banner
+
+        click.echo(render_banner(), nl=False)
+        super().format_help(ctx, formatter)
+
+
+@click.group(cls=AquaGroup, context_settings={"auto_envvar_prefix": "AQUA"})
 @click.option(
     "--format",
     "fmt",

--- a/src/aqua/cli/main.py
+++ b/src/aqua/cli/main.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 _project_root = Path(__file__).resolve().parent.parent.parent.parent
 load_dotenv(_project_root / ".env")
 
+from ..banner import render_banner  # noqa: E402
 from .commands import register_commands  # noqa: E402
 
 # Default to WARNING so tool-level INFO logs don't spam stderr in CLI mode
@@ -26,8 +27,6 @@ class AquaContext:
 
 class AquaGroup(click.Group):
     def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
-        from ..banner import render_banner
-
         click.echo(render_banner(), nl=False)
         super().format_help(ctx, formatter)
 

--- a/src/aqua/static/logo_ascii_31_chars.txt
+++ b/src/aqua/static/logo_ascii_31_chars.txt
@@ -1,0 +1,17 @@
+               A               
+              AAA              
+             AAAAA             
+            AAAAAAA            
+           AAAAAAAAA           
+          AAAAA AAAAA          
+         AAAAA   AAAAA         
+        AAAAA     AAAAA        
+       AAAAA   A   AAAAA       
+      AAAAAA  AAA  AAAAAA      
+     AAAAAA  AAAAA  AAAAAA     
+    AAAAAA   AAAAA   AAAAAA    
+   AAAAAA   AAAAAAA   AAAAAA   
+ AAAAAAA   AAAAAAAAA   AAAAAAA 
+AAAAAAA   AAAAAAAAAAA   AAAAAAA
+           AAAAAAAAA            
+           

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,9 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
+
+[options]
+exclude-newer = "2026-04-05T00:00:00Z"
 
 [[package]]
 name = "agentic-aqua"


### PR DESCRIPTION
### Purpose

Show the AQUA ASCII logo plus a brief security reminder when the user runs `aqua --help`, and bump the package version to `0.4.0`.

#### Main Changes

- ✨ Added `aqua/banner.py` with `render_banner()` that loads `static/logo_ascii_31_chars.txt` and appends the welcome/security message
- ✨ Wired a custom `AquaGroup(click.Group)` in `cli/main.py` so the banner is printed at the top of `aqua --help`
- 📦️ Shipped the logo as a package data file at `src/aqua/static/logo_ascii_31_chars.txt`
- 🔧 Bumped `__version__` to `0.4.0` in `src/aqua/__init__.py`

### Checklist

- [x] No hardcoded values (they should go in constants.py, .env, or our database)
- [ ] Added/updated tests (if necessary)
- [ ] Added/updated relevant documentation (if necessary)

### Screenshot
<img width="784" height="838" alt="image" src="https://github.com/user-attachments/assets/a6db7d8d-d3d2-4670-af8d-4b3b42c3fd50" />
