### PR TITLE
fix: mock Liquid sync_wallet in unified balance tests

### DIFF
--- a/tests/test_bitcoin.py
+++ b/tests/test_bitcoin.py
@@ -21,6 +21,7 @@ from aqua.tools import (
     btc_send,
     btc_transactions,
     get_btc_manager,
+    get_manager,
     lw_import_mnemonic,
     unified_balance,
 )
@@ -229,7 +230,9 @@ class TestUnifiedImportAndBalance:
     def test_unified_balance_aggregates_both_networks(self, isolated_managers):
         """unified_balance returns bitcoin and liquid sections."""
         lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="u", network="mainnet")
-        with patch.object(get_btc_manager(), "sync_wallet"):
+        with patch.object(get_btc_manager(), "sync_wallet"), patch.object(
+            get_manager(), "sync_wallet"
+        ):
             result = unified_balance(wallet_name="u")
         assert result["wallet_name"] == "u"
         assert "bitcoin" in result
@@ -247,7 +250,8 @@ class TestUnifiedImportAndBalance:
         signer = lwk.Signer(m, net)
         desc = str(signer.wpkh_slip77_descriptor())
         manager.import_descriptor(desc, "liquid_only", "mainnet")
-        result = unified_balance(wallet_name="liquid_only")
+        with patch.object(manager, "sync_wallet"):
+            result = unified_balance(wallet_name="liquid_only")
         assert result["wallet_name"] == "liquid_only"
         assert result["bitcoin"] is None
         assert "bitcoin_error" in result


### PR DESCRIPTION
Description:
Two tests in TestUnifiedImportAndBalance were failing in any network-restricted environment (CI, Docker, GitHub Actions) because they attempted to connect to a live Electrum node via lwk.Network.default_electrum_client().
Root Cause
test_unified_balance_aggregates_both_networks was patching get_btc_manager().sync_wallet but not the Liquid manager's sync_wallet. When unified_balance() ran, the Liquid side still called sync_wallet → _get_client → default_electrum_client(), which throws Address family not supported by protocol in restricted environments.
test_unified_balance_wallet_without_btc_descriptors had no network mocking at all.
Fix

Added patch.object(get_manager(), "sync_wallet") alongside the existing BTC patch in test_unified_balance_aggregates_both_networks
Wrapped the unified_balance() call in test_unified_balance_wallet_without_btc_descriptors with patch.object(manager, "sync_wallet")
Added get_manager to imports

Diff
diff--- a/tests/test_bitcoin.py
+++ b/tests/test_bitcoin.py
@@ -21,6 +21,7 @@ from aqua.tools import (
     btc_send,
     btc_transactions,
     get_btc_manager,
+    get_manager,
     lw_import_mnemonic,
     unified_balance,
 )
@@ -229,7 +230,9 @@ class TestUnifiedImportAndBalance:
     def test_unified_balance_aggregates_both_networks(self, isolated_managers):
         """unified_balance returns bitcoin and liquid sections."""
         lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="u", network="mainnet")
-        with patch.object(get_btc_manager(), "sync_wallet"):
+        with patch.object(get_btc_manager(), "sync_wallet"), patch.object(
+            get_manager(), "sync_wallet"
+        ):
             result = unified_balance(wallet_name="u")
@@ -247,7 +250,8 @@ class TestUnifiedImportAndBalance:
         manager.import_descriptor(desc, "liquid_only", "mainnet")
-        result = unified_balance(wallet_name="liquid_only")
+        with patch.object(manager, "sync_wallet"):
+            result = unified_balance(wallet_name="liquid_only")
Testing
bashuv run python -m pytest tests/test_bitcoin.py::TestUnifiedImportAndBalance -v
# 3 passed
Risk: Low — test-only change, no production code affected.