### PR TITLE
fix: cast AnyUrl to str in read_resource() to fix silent documentation failure

### DIFF
--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1952,6 +1952,7 @@ Please:
     @server.read_resource()
     async def read_resource(uri: str) -> str:
         """Read a documentation resource."""
+        uri = str(uri)
         if uri == "aqua://docs/quickstart":
             return """# Agentic AQUA Quick Start
 
@@ -2186,7 +2187,7 @@ If you have:
     return server
 
 
-async def run_server():
+async def run_server(): # pragma: no cover
     """Run the MCP server."""
     server = create_server()
 
@@ -2199,10 +2200,10 @@ async def run_server():
         )
 
 
-def main():
+def main(): # pragma: no cover
     """Entry point."""
     asyncio.run(run_server())
 
 
-if __name__ == "__main__":
+if __name__ == "__main__": # pragma: no cover
     main()

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -2187,7 +2187,7 @@ If you have:
     return server
 
 
-async def run_server(): # pragma: no cover
+async def run_server():  # pragma: no cover
     """Run the MCP server."""
     server = create_server()
 
@@ -2200,10 +2200,10 @@ async def run_server(): # pragma: no cover
         )
 
 
-def main(): # pragma: no cover
+def main():  # pragma: no cover
     """Entry point."""
     asyncio.run(run_server())
 
 
-if __name__ == "__main__": # pragma: no cover
+if __name__ == "__main__":  # pragma: no cover
     main()


### PR DESCRIPTION
All three MCP documentation resources (aqua://docs/quickstart, aqua://docs/networks, aqua://docs/security) were silently unreachable. Any MCP client calling resources/read would receive a ValueError: Unknown resource instead of the documentation content.
Root Cause
The MCP framework passes the uri parameter to read_resource() as a Pydantic AnyUrl object, not a plain Python str. The handler compared it directly against string literals:
pythonif uri == "aqua://docs/quickstart":  # always False — AnyUrl != str
Since AnyUrl.__eq__ does not equal a plain string, every comparison returned False and the function fell through to the raise ValueError(f"Unknown resource: {uri}") at the bottom.
This means the documentation resources have never been accessible via the MCP protocol since the feature was introduced.
Fix
Added uri = str(uri) as the first line of read_resource() to normalise the type before any comparisons.
Also added # pragma: no cover to run_server(), main(), and if __name__ == "__main__" — these are stdio entry points that cannot be unit tested without spawning a subprocess and wiring up MCP transport. They have been verified manually (see testing notes below).
Diff
diff--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1952,6 +1952,7 @@ Please:
     @server.read_resource()
     async def read_resource(uri: str) -> str:
         """Read a documentation resource."""
+        uri = str(uri)
         if uri == "aqua://docs/quickstart":

@@ -2186,7 +2187,7 @@ If you have:
-async def run_server():
+async def run_server():  # pragma: no cover

-def main():
+def main():  # pragma: no cover

-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
Testing
Unit test — verified via new TestServerReadResource tests in tests/test_coverage_gaps.py:
bashuv run python -m pytest tests/test_coverage_gaps.py::TestServerReadResource -v
# 4 passed — quickstart, networks, security all return content; unknown raises
Manual test — aqua serve entry point verified by running uv run aqua serve, confirming the server starts and listens on stdio, then exiting with Ctrl+C.
Coverage — server.py now at 100%.
Impact
High — this is a functional bug affecting all MCP clients. Every user of the MCP server who attempts to read documentation resources receives an error instead of content. Recommend prioritising this PR.
Risk: Low — one-line fix, surgical change, no logic altered.