### PR TITLE
Fix: add agentic-aqua console script so uvx agentic-aqua works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
 [project.scripts]
 aqua = "aqua.cli.main:cli"
 aqua-mcp = "aqua.server:main"
+agentic-aqua = "aqua.server:main"
 
 [project.urls]
 Homepage = "https://github.com/jan3dev/agentic-aqua"


### PR DESCRIPTION
### Purpose

Fix broken first-run experience: the README documents `uvx agentic-aqua` as the recommended MCP server setup, but the package had no console script by that name — only `aqua` and `aqua-mcp`. Any new user following the README would get an error.

#### Main Changes

- 🐛 Add `agentic-aqua = "aqua.server:main"` to `[project.scripts]` in `pyproject.toml` — makes `uvx agentic-aqua` resolve correctly as an alias for the MCP server entry point

### Checklist

- [x] No hardcoded values (they should go in constants.py, .env, or our database)
- [ ] Added/updated tests (if necessary)
- [ ] Added/updated relevant documentation (if necessary)