### PR TITLE
[BUG] Add ln-address support to lightning CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,3 +106,10 @@ Project-level `CLAUDE.md` is symlinked from this file. Key user rules:
 - Never use silent-fallback "fake success" patterns — raise or report.
 
 <!-- MANUAL: Add project-specific notes below this line — preserved on regeneration. -->
+
+## Branching / PR target
+
+- `main` is the production branch.
+- `develop` is the integration branch for code that is still pending broader testing.
+- When opening code PRs by default, target `develop`, not `main`, unless the user explicitly asks otherwise.
+- When comparing branch work for PR prep, prefer `git diff develop...HEAD` / `git log develop...HEAD --oneline` unless a different base branch is requested.

--- a/src/aqua/cli/lightning.py
+++ b/src/aqua/cli/lightning.py
@@ -49,7 +49,19 @@ def receive(ctx, amount, wallet_name, password_stdin):
 
 
 @lightning.command("send")
-@click.option("--invoice", required=True, help="BOLT11 Lightning invoice (lnbc... or lntb...).")
+@click.option(
+    "--invoice",
+    help="BOLT11 Lightning invoice (lnbc... or lntb...). Mutually exclusive with --ln-address.",
+)
+@click.option(
+    "--ln-address",
+    help="Lightning Address (user@domain.com). Requires --amount-sats. Mutually exclusive with --invoice.",
+)
+@click.option(
+    "--amount-sats",
+    type=int,
+    help="Amount in satoshis. Required with --ln-address; optional with --invoice (must match encoded amount if supplied).",
+)
 @click.option(
     "--wallet-name", default="default", show_default=True, help="Liquid wallet to pay from."
 )
@@ -65,8 +77,16 @@ def receive(ctx, amount, wallet_name, password_stdin):
     ),
 )
 @click.pass_obj
-def send(ctx, invoice, wallet_name, password_stdin):
-    """Pay a Lightning invoice using L-BTC (submarine swap via Boltz)."""
+def send(ctx, invoice, ln_address, amount_sats, wallet_name, password_stdin):
+    """Pay a Lightning invoice or Lightning Address using L-BTC."""
+    if bool(invoice) == bool(ln_address):
+        raise click.UsageError("Provide exactly one of --invoice or --ln-address")
+
+    if ln_address and amount_sats is None:
+        raise click.UsageError("--amount-sats is required when using --ln-address")
+
+    payment_target = ln_address or invoice
+
     password = resolve_secret(
         "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
     )
@@ -74,7 +94,12 @@ def send(ctx, invoice, wallet_name, password_stdin):
         ctx,
         lambda: handle_password_retry(
             lightning_send,
-            {"invoice": invoice, "wallet_name": wallet_name, "password": password},
+            {
+                "invoice": payment_target,
+                "wallet_name": wallet_name,
+                "password": password,
+                "amount_sats": amount_sats,
+            },
         ),
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -757,6 +757,75 @@ class TestLightningCommands:
         )
         assert result.exit_code == 1
 
+    def test_send_help_mentions_ln_address_and_amount_sats(self, runner):
+        result = runner.invoke(cli, ["lightning", "send", "--help"])
+        assert result.exit_code == 0
+        normalized = " ".join(result.output.split())
+        assert "--ln-address" in result.output
+        assert "--amount-sats" in result.output
+        assert "Mutually exclusive with --invoice" in normalized
+
+    def test_send_requires_exactly_one_of_invoice_or_ln_address(self, runner):
+        result = runner.invoke(cli, ["lightning", "send"])
+        assert result.exit_code != 0
+        assert "Provide exactly one of --invoice or --ln-address" in result.output
+
+    def test_send_rejects_both_invoice_and_ln_address(self, runner):
+        result = runner.invoke(
+            cli,
+            [
+                "lightning",
+                "send",
+                "--invoice",
+                "lnbc500u1ptest_valid_invoice",
+                "--ln-address",
+                "alice@getalby.com",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Provide exactly one of --invoice or --ln-address" in result.output
+
+    def test_send_requires_amount_sats_with_ln_address(self, runner):
+        result = runner.invoke(
+            cli,
+            ["lightning", "send", "--ln-address", "alice@getalby.com"],
+        )
+        assert result.exit_code != 0
+        assert "--amount-sats is required when using --ln-address" in result.output
+
+    def test_send_ln_address_passes_amount_sats_to_tool(self, runner):
+        with patch("aqua.cli.lightning.lightning_send") as mock_send:
+            mock_send.return_value = {
+                "swap_id": "boltz_123",
+                "lockup_txid": "abc123",
+                "status": "processing",
+                "amount": 1020,
+            }
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "lightning",
+                    "send",
+                    "--ln-address",
+                    "alice@getalby.com",
+                    "--amount-sats",
+                    "1000",
+                    "--wallet-name",
+                    "tuna",
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["swap_id"] == "boltz_123"
+        mock_send.assert_called_once_with(
+            invoice="alice@getalby.com",
+            wallet_name="tuna",
+            password=None,
+            amount_sats=1000,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Changelly CLI


### PR DESCRIPTION
### Purpose

Expose Lightning Address payments properly in the CLI so users can send with:

```bash
aqua lightning send --ln-address user@domain.com --amount-sats 1000 --wallet-name wallet
```

#### Description

The backend and MCP toolchain already support Lightning Address payments, but the CLI was lagging behind like a shopping cart with one bad wheel.

`lightning_send(...)` already accepts a Lightning Address plus `amount_sats`, resolves it through LNURL-pay, and executes the swap. The MCP schema also exposes that capability correctly. But `aqua lightning send` only exposed `--invoice`, so the feature existed and worked through MCP while remaining effectively unavailable from the CLI.

This PR aligns the CLI with the underlying implementation without breaking the existing BOLT11 flow.

#### Main Changes

- ⚡ Add `--ln-address` to `aqua lightning send`
- 🔢 Add `--amount-sats` support to the CLI send flow
- 🧠 Enforce clear validation rules:
  - exactly one of `--invoice` or `--ln-address`
  - `--amount-sats` is required with `--ln-address`
- ♻️ Keep existing `--invoice` usage working for BOLT11 invoices
- ✅ Add CLI tests for help text, validation errors, and successful argument forwarding

### Verification

Tested successfully with:

```bash
uv run --python 3.13 aqua lightning send --ln-address andy@wapu.app --amount-sats 1010 --wallet-name tuna --password-stdin
```

The command completed and created a valid swap.

### Checklist

- [x] No hardcoded values (they belong in `constants.py`, `.env`, or our database).
- [x] Added/updated tests (if necessary).
- [ ] Added/updated relevant documentation (if necessary).
