### PR TITLE
Add QR decode and Lightning invoice inspection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,3 +106,10 @@ Project-level `CLAUDE.md` is symlinked from this file. Key user rules:
 - Never use silent-fallback "fake success" patterns — raise or report.
 
 <!-- MANUAL: Add project-specific notes below this line — preserved on regeneration. -->
+
+## Branching / PR target
+
+- `main` is the production branch.
+- `develop` is the integration branch for code that is still pending broader testing.
+- When opening code PRs by default, target `develop`, not `main`, unless the user explicitly asks otherwise.
+- When comparing branch work for PR prep, prefer `git diff develop...HEAD` / `git log develop...HEAD --oneline` unless a different base branch is requested.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "click>=8.1",
     "websockets>=12.0",
+    "pillow>=10.0.0",
+    "pyzbar>=0.1.9",
 ]
 
 [project.optional-dependencies]

--- a/src/aqua/cli/commands.py
+++ b/src/aqua/cli/commands.py
@@ -12,6 +12,7 @@ def register_commands(cli):
     from .changelly import changelly
     from .lightning import lightning
     from .liquid import liquid
+    from .qr import qr
     from .serve import serve
     from .sideshift import sideshift
     from .sideswap import sideswap
@@ -21,6 +22,7 @@ def register_commands(cli):
     cli.add_command(liquid)
     cli.add_command(btc)
     cli.add_command(lightning)
+    cli.add_command(qr)
     cli.add_command(changelly)
     cli.add_command(sideshift)
     cli.add_command(sideswap)

--- a/src/aqua/cli/lightning.py
+++ b/src/aqua/cli/lightning.py
@@ -49,7 +49,19 @@ def receive(ctx, amount, wallet_name, password_stdin):
 
 
 @lightning.command("send")
-@click.option("--invoice", required=True, help="BOLT11 Lightning invoice (lnbc... or lntb...).")
+@click.option(
+    "--invoice",
+    help="BOLT11 Lightning invoice (lnbc... or lntb...). Mutually exclusive with --ln-address.",
+)
+@click.option(
+    "--ln-address",
+    help="Lightning Address (user@domain.com). Requires --amount-sats. Mutually exclusive with --invoice.",
+)
+@click.option(
+    "--amount-sats",
+    type=int,
+    help="Amount in satoshis. Required with --ln-address; optional with --invoice (must match encoded amount if supplied).",
+)
 @click.option(
     "--wallet-name", default="default", show_default=True, help="Liquid wallet to pay from."
 )
@@ -65,8 +77,16 @@ def receive(ctx, amount, wallet_name, password_stdin):
     ),
 )
 @click.pass_obj
-def send(ctx, invoice, wallet_name, password_stdin):
-    """Pay a Lightning invoice using L-BTC (submarine swap via Boltz)."""
+def send(ctx, invoice, ln_address, amount_sats, wallet_name, password_stdin):
+    """Pay a Lightning invoice or Lightning Address using L-BTC."""
+    if bool(invoice) == bool(ln_address):
+        raise click.UsageError("Provide exactly one of --invoice or --ln-address")
+
+    if ln_address and amount_sats is None:
+        raise click.UsageError("--amount-sats is required when using --ln-address")
+
+    payment_target = ln_address or invoice
+
     password = resolve_secret(
         "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
     )
@@ -74,7 +94,12 @@ def send(ctx, invoice, wallet_name, password_stdin):
         ctx,
         lambda: handle_password_retry(
             lightning_send,
-            {"invoice": invoice, "wallet_name": wallet_name, "password": password},
+            {
+                "invoice": payment_target,
+                "wallet_name": wallet_name,
+                "password": password,
+                "amount_sats": amount_sats,
+            },
         ),
     )
 

--- a/src/aqua/cli/lightning.py
+++ b/src/aqua/cli/lightning.py
@@ -2,6 +2,7 @@
 
 import click
 
+from ..boltz import decode_bolt11_amount_sats
 from ..tools import (
     lightning_receive,
     lightning_send,
@@ -101,6 +102,23 @@ def send(ctx, invoice, ln_address, amount_sats, wallet_name, password_stdin):
                 "amount_sats": amount_sats,
             },
         ),
+    )
+
+
+@lightning.command("decode")
+@click.option("--invoice", required=True, help="BOLT11 Lightning invoice (lnbc... or lntb...).")
+@click.pass_obj
+def decode_invoice(ctx, invoice):
+    """Decode a BOLT11 invoice without paying it."""
+    normalized = invoice.strip().lower()
+    amount_sats = decode_bolt11_amount_sats(normalized)
+    run_tool(
+        ctx,
+        lambda: {
+            "invoice": normalized,
+            "amount_sats": amount_sats,
+            "network": "mainnet" if normalized.startswith("lnbc") else "testnet",
+        },
     )
 
 

--- a/src/aqua/cli/qr.py
+++ b/src/aqua/cli/qr.py
@@ -1,0 +1,20 @@
+"""QR-related CLI commands."""
+
+import click
+
+from ..tools import decode_payment_qr
+from .output import run_tool
+
+
+@click.group()
+def qr():
+    """QR operations."""
+    pass
+
+
+@qr.command("decode")
+@click.option("--image", "image_path", required=True, help="Path to the QR image file.")
+@click.pass_obj
+def decode_cmd(ctx, image_path):
+    """Decode a QR image and return the raw string it contains."""
+    run_tool(ctx, lambda: decode_payment_qr(image_path))

--- a/src/aqua/qr.py
+++ b/src/aqua/qr.py
@@ -1,0 +1,52 @@
+"""QR decoding helpers."""
+
+from pathlib import Path
+from typing import Any
+
+from PIL import Image
+from pyzbar.pyzbar import decode
+
+
+class QrDecodeError(ValueError):
+    """Raised when a QR image cannot be decoded."""
+
+
+def decode_qr_image(image_path: str) -> dict[str, Any]:
+    """Decode a QR image file and return its raw string contents.
+
+    Args:
+        image_path: Path to an image file containing a QR code.
+
+    Returns:
+        Dict with the image path and decoded text.
+
+    Raises:
+        QrDecodeError: if no QR is found, more than one QR is found, or the QR
+            payload cannot be decoded as UTF-8 text.
+    """
+    path = Path(image_path).expanduser()
+    if not path.exists():
+        raise QrDecodeError(f"Image file not found: {image_path}")
+    if not path.is_file():
+        raise QrDecodeError(f"Path is not a file: {image_path}")
+
+    with Image.open(path) as img:
+        results = decode(img)
+
+    if not results:
+        raise QrDecodeError("No QR code found in image")
+    if len(results) > 1:
+        raise QrDecodeError(
+            f"Expected exactly one QR code, found {len(results)}"
+        )
+
+    raw_bytes = results[0].data
+    try:
+        raw_text = raw_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise QrDecodeError("QR payload is not valid UTF-8 text") from exc
+
+    return {
+        "image_path": str(path),
+        "text": raw_text,
+    }

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -241,6 +241,19 @@ TOOL_SCHEMAS = {
             },
         },
     },
+    "decode_payment_qr": {
+        "description": "Decode a QR image and return the raw string inside it. Supports local image paths only. Expects exactly one QR code in the image.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "image_path": {
+                    "type": "string",
+                    "description": "Path to a local image file containing a QR code",
+                }
+            },
+            "required": ["image_path"],
+        },
+    },
     "delete_wallet": {
         "description": "Delete a wallet and all its cached data. IMPORTANT: The agent MUST check balances and ask for user confirmation before calling this tool. Use the 'delete_wallet' prompt for the safe workflow.",
         "inputSchema": {

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from .assets import MAINNET_ASSETS, TESTNET_ASSETS, resolve_asset_name
 from .bitcoin import BitcoinWalletManager
+from .qr import decode_qr_image
 from .wallet import WalletManager
 
 logger = logging.getLogger(__name__)
@@ -720,6 +721,19 @@ def lw_list_assets(network: str = "mainnet") -> dict[str, Any]:
             for info in registry.values()
         ],
     }
+
+
+def decode_payment_qr(image_path: str) -> dict[str, Any]:
+    """Decode a QR image and return the raw string inside it.
+
+    Args:
+        image_path: Path to an image file containing exactly one QR code.
+
+    Returns:
+        image_path: Normalized path to the image file.
+        text: Raw decoded QR string.
+    """
+    return decode_qr_image(image_path)
 
 
 def delete_wallet(wallet_name: str) -> dict[str, Any]:
@@ -1721,6 +1735,7 @@ TOOLS = {
     "lw_tx_status": lw_tx_status,
     "lw_list_wallets": lw_list_wallets,
     "lw_list_assets": lw_list_assets,
+    "decode_payment_qr": decode_payment_qr,
     "delete_wallet": delete_wallet,
     "btc_balance": btc_balance,
     "btc_address": btc_address,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -748,6 +748,19 @@ class TestBtcDescriptorCli:
 # Lightning commands
 
 
+class TestQrCommands:
+    def test_decode_qr_command(self, runner):
+        with patch("aqua.cli.qr.decode_payment_qr", return_value={"image_path": "./qr.png", "text": "bitcoin:bc1qexample"}) as mock_decode:
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "qr", "decode", "--image", "./qr.png"],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["text"] == "bitcoin:bc1qexample"
+        mock_decode.assert_called_once_with("./qr.png")
+
+
 class TestLightningCommands:
     def test_status_missing_swap(self, runner):
         """Status for nonexistent swap should error."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -762,6 +762,17 @@ class TestQrCommands:
 
 
 class TestLightningCommands:
+    def test_decode_invoice_returns_amount(self, runner):
+        invoice = "lnbc5u1p4pp9jxpp5l2nhh8dexvrv44p7j9yetznda2hvszaawqy3nfxqc3ljecnj33pssp550t5t0qp78syw0lh3dm266yasw5mtadgud3vy9nst48p2rga25lsxqyz5vqnp4qvyndeaqzman7h898jxm98dzkm0mlrsx36s93smrur7h0azyyuxc5rzjqwghf7zxvfkxq5a6sr65g0gdkv768p83mhsnt0msszapamzx2qvuxqqqqrt49lmtcqqqqqqqqqqq86qq9qrzjq25carzepgd4vqsyn44jrk85ezrpju92xyrk9apw4cdjh6yrwt5jgqqqqrt49lmtcqqqqqqqqqqq86qq9qrzjqdqk3f6qkpdx8s74wngv95h3dkumkdyyh0g5mv6jetkskxkcsvf74apyqr6zgqqqq8hxk2qqae4jsqyugqcqzpudqjdphkccfq2fhkx6m9ws9qyyssqg8aq5vj247zlwds357g2389p62mg8hmt4efrk8arm8yt8k2mlrz3xc725sts6w5w4ww3h6yz7m8lcyhzmnk27nt3yl683dax2vdcjpqqxfhx43"
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "lightning", "decode", "--invoice", invoice],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["amount_sats"] == 500
+        assert data["network"] == "mainnet"
+
     def test_status_missing_swap(self, runner):
         """Status for nonexistent swap should error."""
         result = runner.invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -757,6 +757,75 @@ class TestLightningCommands:
         )
         assert result.exit_code == 1
 
+    def test_send_help_mentions_ln_address_and_amount_sats(self, runner):
+        result = runner.invoke(cli, ["lightning", "send", "--help"])
+        assert result.exit_code == 0
+        normalized = " ".join(result.output.split())
+        assert "--ln-address" in result.output
+        assert "--amount-sats" in result.output
+        assert "Mutually exclusive with --invoice" in normalized
+
+    def test_send_requires_exactly_one_of_invoice_or_ln_address(self, runner):
+        result = runner.invoke(cli, ["lightning", "send"])
+        assert result.exit_code != 0
+        assert "Provide exactly one of --invoice or --ln-address" in result.output
+
+    def test_send_rejects_both_invoice_and_ln_address(self, runner):
+        result = runner.invoke(
+            cli,
+            [
+                "lightning",
+                "send",
+                "--invoice",
+                "lnbc500u1ptest_valid_invoice",
+                "--ln-address",
+                "alice@getalby.com",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Provide exactly one of --invoice or --ln-address" in result.output
+
+    def test_send_requires_amount_sats_with_ln_address(self, runner):
+        result = runner.invoke(
+            cli,
+            ["lightning", "send", "--ln-address", "alice@getalby.com"],
+        )
+        assert result.exit_code != 0
+        assert "--amount-sats is required when using --ln-address" in result.output
+
+    def test_send_ln_address_passes_amount_sats_to_tool(self, runner):
+        with patch("aqua.cli.lightning.lightning_send") as mock_send:
+            mock_send.return_value = {
+                "swap_id": "boltz_123",
+                "lockup_txid": "abc123",
+                "status": "processing",
+                "amount": 1020,
+            }
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "lightning",
+                    "send",
+                    "--ln-address",
+                    "alice@getalby.com",
+                    "--amount-sats",
+                    "1000",
+                    "--wallet-name",
+                    "tuna",
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["swap_id"] == "boltz_123"
+        mock_send.assert_called_once_with(
+            invoice="alice@getalby.com",
+            wallet_name="tuna",
+            password=None,
+            amount_sats=1000,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Changelly CLI

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -14,6 +14,7 @@ from aqua.tools import (
     btc_export_descriptor,
     btc_import_descriptor,
     changelly_send,
+    decode_payment_qr,
     delete_wallet,
     get_btc_manager,
     get_manager,
@@ -722,6 +723,7 @@ class TestToolRegistry:
             "lightning_transaction_status",
             "pix_receive",
             "pix_status",
+            "decode_payment_qr",
             "delete_wallet",
             "btc_import_descriptor",
             "btc_export_descriptor",
@@ -756,6 +758,51 @@ class TestToolRegistry:
 
         for name, fn in TOOLS.items():
             assert callable(fn), f"Tool {name} is not callable"
+
+
+# ---------------------------------------------------------------------------
+# decode_payment_qr
+# ---------------------------------------------------------------------------
+
+
+class TestDecodePaymentQr:
+    def test_missing_image_raises(self):
+        with pytest.raises(ValueError, match="Image file not found"):
+            decode_payment_qr("/no/such/file.png")
+
+    @patch("aqua.qr.decode")
+    def test_no_qr_found_raises(self, mock_decode):
+        mock_decode.return_value = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            image_path = Path(tmpdir) / "qr.png"
+            image_path.write_bytes(
+                b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc``\x00\x00\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+            )
+            with pytest.raises(ValueError, match="No QR code found"):
+                decode_payment_qr(str(image_path))
+
+    @patch("aqua.qr.decode")
+    def test_multiple_qrs_raise(self, mock_decode):
+        mock_decode.return_value = [MagicMock(data=b"one"), MagicMock(data=b"two")]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            image_path = Path(tmpdir) / "qr.png"
+            image_path.write_bytes(
+                b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc``\x00\x00\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+            )
+            with pytest.raises(ValueError, match="Expected exactly one QR code"):
+                decode_payment_qr(str(image_path))
+
+    @patch("aqua.qr.decode")
+    def test_decodes_single_qr(self, mock_decode):
+        mock_decode.return_value = [MagicMock(data=b"bitcoin:bc1qexample")]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            image_path = Path(tmpdir) / "qr.png"
+            image_path.write_bytes(
+                b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc``\x00\x00\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+            )
+            result = decode_payment_qr(str(image_path))
+        assert result["text"] == "bitcoin:bc1qexample"
+        assert result["image_path"].endswith("qr.png")
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,6 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
-
-[options]
-exclude-newer = "2026-04-05T00:00:00Z"
 
 [[package]]
 name = "agentic-aqua"
@@ -15,7 +12,9 @@ dependencies = [
     { name = "cryptography" },
     { name = "lwk" },
     { name = "mcp" },
+    { name = "pillow" },
     { name = "python-dotenv" },
+    { name = "pyzbar" },
     { name = "websockets" },
 ]
 
@@ -37,10 +36,12 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "lwk", specifier = ">=0.8.0" },
     { name = "mcp", specifier = ">=1.0.0" },
+    { name = "pillow", specifier = ">=10.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "pyzbar", specifier = ">=0.1.9" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "websockets", specifier = ">=12.0" },
 ]
@@ -483,6 +484,64 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -709,6 +768,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pyzbar"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/24/81ebe6a1c00760471a3028a23cbe0b94e5fa2926e5ba47adc895920887bc/pyzbar-0.1.9-py2.py3-none-any.whl", hash = "sha256:4559628b8192feb25766d954b36a3753baaf5c97c03135aec7e4a026036b475d", size = 32560, upload-time = "2022-03-15T14:53:40.637Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/87/7b596730179ddf17857eea33ba820354dd4e1cf941e57f51ffccce26c409/pyzbar-0.1.9-py2.py3-none-win32.whl", hash = "sha256:8f4c5264c9c7c6b9f20d01efc52a4eba1ded47d9ba857a94130afe33703eb518", size = 810633, upload-time = "2022-03-15T14:53:43.446Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e2/1c6a8e94197612dbdfc51eab8dfb674168829885fac2c4f50ac8366c25ca/pyzbar-0.1.9-py2.py3-none-win_amd64.whl", hash = "sha256:13e3ee5a2f3a545204a285f41814d5c0db571967e8d4af8699a03afc55182a9c", size = 817363, upload-time = "2022-03-15T14:53:46.691Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Purpose
Add QR decoding support to the CLI/MCP surface and expose a read-only Lightning invoice decoder in the CLI so payment payloads can be inspected before any send flow.

#### Description
This closes the gap between receiving a payment QR and being able to do something useful with it locally. The new QR path returns the raw decoded string, and the Lightning CLI now exposes invoice amount/network inspection without touching any payment execution flow.

#### Main Changes
- ✨ add `decode_payment_qr` to the MCP tool surface for decoding a local image containing exactly one QR code
- ✨ add `aqua qr decode --image ...` to expose QR decoding in the CLI
- ✨ add `aqua lightning decode --invoice ...` to inspect BOLT11 invoices and report amount/network without paying them
- ➕ add `pillow` and `pyzbar` project dependencies and update the lockfile
- ✅ add CLI and tool tests covering QR decode success/failure cases and Lightning invoice decode output
- 📝 document `develop` as the default PR target in `AGENTS.md`

### Checklist
- [ ] No hardcoded values (they belong in `constants.py`, `.env`, or our database).
- [ ] Added/updated tests (if necessary).
- [ ] Added/updated relevant documentation (if necessary).
