### PR TITLE
Fix lightning send test to neutralize AQUA_PASSWORD from .env

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -812,6 +812,7 @@ class TestLightningCommands:
                     "--wallet-name",
                     "tuna",
                 ],
+                env=_cli_env(),
             )
         assert result.exit_code == 0
         data = json.loads(result.output)


### PR DESCRIPTION
### Purpose

Fix `TestLightningCommands.test_send_ln_address_passes_amount_sats_to_tool` which fails locally for anyone with `AQUA_PASSWORD` exported or set in the repo `.env`. The test asserts `password=None` is passed to `lightning_send`, but the CLI loads `.env` at import time and `resolve_secret` correctly returns the env value, so the assertion fails.

#### Description

This is a test bug, not a code bug. The CLI behavior (honor `AQUA_PASSWORD` env var when `--password-stdin` isn't passed) is documented and covered by `TestResolveSecret::test_resolve_from_env_var`. The file already has a `_cli_env()` helper (tests/test_cli.py:69) whose docstring spells out exactly this trap — "CliRunner's env argument is an overlay, not a full replacement. Because the CLI loads repo .env at import time, omitting AQUA_* keys from a copied env does not remove them from os.environ during invoke()." Other tests in the file use it consistently; this one was missed.

#### Main Changes

- 🐛 Pass `env=_cli_env()` to `runner.invoke` in `test_send_ln_address_passes_amount_sats_to_tool` so the loaded `AQUA_PASSWORD` is neutralized for the assertion.

### Checklist

- [ ] No hardcoded values (they should go in constants.py, .env, or our database)
- [ ] Added/updated tests (if necessary)
- [ ] Added/updated relevant documentation (if necessary)