### PR TITLE
#84 Enhancement: Use a default password to encrypt in disk

### DIFF
--- a/src/aqua/bitcoin.py
+++ b/src/aqua/bitcoin.py
@@ -468,10 +468,10 @@ class BitcoinWalletManager:
             raise ValueError(
                 "No mnemonic available for signing (import wallet with mnemonic to enable sending)"
             )
-        needs_password = self.storage.is_mnemonic_encrypted(wallet_data.encrypted_mnemonic)
+        needs_password = self.storage.requires_user_password(wallet_data.encrypted_mnemonic)
         if needs_password and not password:
             raise ValueError("Password required to decrypt mnemonic")
-        mnemonic = self.storage.retrieve_mnemonic(wallet_data.encrypted_mnemonic, password)
+        mnemonic = self.storage.read_and_migrate_mnemonic(wallet_data, password)
         wallet, network = self._get_wallet_with_signer(wallet_name, mnemonic)
         self.sync_wallet(wallet_name)
 

--- a/src/aqua/changelly.py
+++ b/src/aqua/changelly.py
@@ -595,7 +595,7 @@ class ChangellyManager:
             raise ValueError(f"Wallet '{wallet_name}' not found")
         if wallet_data.watch_only:
             raise ValueError("Watch-only wallet cannot sign a Changelly deposit")
-        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
+        if wallet_data.encrypted_mnemonic and self.storage.requires_user_password(
             wallet_data.encrypted_mnemonic
         ):
             if not password:

--- a/src/aqua/lightning.py
+++ b/src/aqua/lightning.py
@@ -114,7 +114,7 @@ class LightningManager:
             raise ValueError(f"Wallet '{wallet_name}' not found")
         if wallet_data.watch_only:
             raise ValueError("Watch-only wallet cannot receive funds directly")
-        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
+        if wallet_data.encrypted_mnemonic and self.storage.requires_user_password(
             wallet_data.encrypted_mnemonic
         ):
             if not password:
@@ -199,7 +199,7 @@ class LightningManager:
             raise ValueError(f"Wallet '{wallet_name}' not found")
         if wallet_data.watch_only:
             raise ValueError("Watch-only wallet cannot sign transactions")
-        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
+        if wallet_data.encrypted_mnemonic and self.storage.requires_user_password(
             wallet_data.encrypted_mnemonic
         ):
             if not password:

--- a/src/aqua/sideshift.py
+++ b/src/aqua/sideshift.py
@@ -735,7 +735,7 @@ class SideShiftManager:
         # Pre-validate the mnemonic decryption BEFORE creating the SideShift
         # order. Without this, a wrong password only surfaces at broadcast
         # time — leaving an orphan custodial order behind for every retry.
-        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
+        if wallet_data.encrypted_mnemonic and self.storage.requires_user_password(
             wallet_data.encrypted_mnemonic
         ):
             if not password:

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -1144,7 +1144,7 @@ class SideSwapPegManager:
         # a wrong password would only surface at broadcast time — leaving an
         # orphaned SideSwap peg order behind for every retry. Watch-only and
         # unencrypted wallets skip this check (no mnemonic to decrypt).
-        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
+        if wallet_data.encrypted_mnemonic and self.storage.requires_user_password(
             wallet_data.encrypted_mnemonic
         ):
             if not password:
@@ -1409,7 +1409,7 @@ class SideSwapSwapManager:
             raise ValueError(f"Wallet '{wallet_name}' not found")
         if wallet_data.watch_only:
             raise ValueError("Watch-only wallet cannot sign a SideSwap swap")
-        if wallet_data.encrypted_mnemonic and self.storage.is_mnemonic_encrypted(
+        if wallet_data.encrypted_mnemonic and self.storage.requires_user_password(
             wallet_data.encrypted_mnemonic
         ):
             if not password:

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 import shutil
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Optional
@@ -22,6 +22,19 @@ SALT_LENGTH = 16
 
 DEFAULT_DIR = Path.home() / ".aqua"
 SWAP_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
+
+# Hardcoded default password used to encrypt mnemonics at rest when the user
+# does not supply one. This is *obfuscation, not security* — it defeats
+# plaintext-seed scanners but offers no protection against an attacker with
+# source-code access. Treat as stable. If ever rotated, keep historical values
+# and try them in order in retrieve_mnemonic (the `default:N:` version prefix
+# enables this without format ambiguity).
+_DEFAULT_MNEMONIC_PASSWORD = "Delphinus entropiam novit sed semen suum numquam revelat"
+
+# Version embedded in the `default:N:` prefix. Bump this if the
+# _DEFAULT_MNEMONIC_PASSWORD ever rotates. Both encode and decode reference this
+# constant so they cannot desync.
+_DEFAULT_PWD_VERSION = 1
 
 
 @dataclass
@@ -170,28 +183,109 @@ class Storage:
         return f.decrypt(encrypted_data).decode()
 
     def store_mnemonic(self, mnemonic: str, password: Optional[str] = None) -> str:
-        """Store mnemonic, encrypting only when a password is provided.
+        """Store mnemonic, encrypting with user password or default password.
 
         NOTE: ``password`` is used exclusively to encrypt the mnemonic on disk.
         It is NOT used as a BIP39 passphrase — the derived seed/keys depend
         only on the mnemonic itself, so descriptors stay portable across
         wallets that accept the same mnemonic (AQUA, Blockstream Green, etc.).
+
+        When no password is supplied, the mnemonic is still encrypted using a
+        hardcoded default password (``default:N:`` prefix). This is
+        obfuscation, not security — it defeats automated plaintext-seed
+        scanners but does not protect against an attacker with source access.
         """
         if password:
-            return self.encrypt_mnemonic(mnemonic, password)
-        return "plain:" + base64.b64encode(mnemonic.encode()).decode()
+            return "user:" + self.encrypt_mnemonic(mnemonic, password)
+        return (
+            f"default:{_DEFAULT_PWD_VERSION}:"
+            + self.encrypt_mnemonic(mnemonic, _DEFAULT_MNEMONIC_PASSWORD)
+        )
 
     def retrieve_mnemonic(self, stored: str, password: Optional[str] = None) -> str:
-        """Retrieve mnemonic stored by store_mnemonic."""
+        """Retrieve mnemonic stored by store_mnemonic.
+
+        Recognizes four prefix formats:
+          * ``default:N:<blob>`` — encrypted with the hardcoded default
+            password at version ``N``. ``password`` is ignored.
+          * ``user:<blob>`` — encrypted with a user-supplied password.
+          * ``plain:<blob>`` — legacy base64-only blob (no password).
+          * untagged — legacy raw encrypted blob from a user password.
+        """
+        if stored.startswith("default:"):
+            # Parse "default:<version>:<blob>"
+            rest = stored[len("default:") :]
+            try:
+                version_str, blob = rest.split(":", 1)
+                version = int(version_str)
+            except ValueError as e:
+                raise ValueError(
+                    f"Malformed default-encrypted mnemonic prefix: {stored[:32]!r}"
+                ) from e
+            if version != _DEFAULT_PWD_VERSION:
+                raise ValueError(
+                    f"Unsupported default encryption version: {version}"
+                )
+            return self.decrypt_mnemonic(blob, _DEFAULT_MNEMONIC_PASSWORD)
+        if stored.startswith("user:"):
+            if not password:
+                raise ValueError("Password required to decrypt mnemonic")
+            return self.decrypt_mnemonic(stored[len("user:") :], password)
         if stored.startswith("plain:"):
-            return base64.b64decode(stored[6:]).decode()
+            return base64.b64decode(stored[len("plain:") :]).decode()
+        # Untagged legacy blob: assume user-password-encrypted.
         if not password:
             raise ValueError("Password required to decrypt mnemonic")
         return self.decrypt_mnemonic(stored, password)
 
-    def is_mnemonic_encrypted(self, stored: str) -> bool:
-        """Check whether a stored mnemonic requires a password to decrypt."""
-        return not stored.startswith("plain:")
+    def requires_user_password(self, stored: str) -> bool:
+        """Return True if decrypting ``stored`` needs a user-supplied password.
+
+        Returns True only for ``user:`` and untagged legacy blobs.
+        Returns False for ``default:`` (any version) and ``plain:`` prefixes.
+        """
+        if stored.startswith("default:") or stored.startswith("plain:"):
+            return False
+        # "user:" prefix and untagged legacy blobs require a password.
+        return True
+
+    def read_and_migrate_mnemonic(
+        self, wallet: WalletData, password: Optional[str] = None
+    ) -> str:
+        """Decrypt the wallet's mnemonic and lazily migrate ``plain:`` blobs.
+
+        Accepts an already-loaded ``WalletData`` (no redundant disk read).
+        If the stored blob uses the legacy ``plain:`` prefix, re-encrypt it
+        with the default password and atomically write it back. Write-back
+        failures are logged but never raised — the returned plaintext is
+        always correct so signing continues to work even on a read-only
+        filesystem.
+        """
+        if not wallet.encrypted_mnemonic:
+            raise ValueError(f"Wallet '{wallet.name}' has no stored mnemonic")
+        plaintext = self.retrieve_mnemonic(wallet.encrypted_mnemonic, password)
+        if wallet.encrypted_mnemonic.startswith("plain:"):
+            new_blob = self.store_mnemonic(plaintext)
+            try:
+                # Persist first via a temporary copy. Only mutate the caller's
+                # WalletData on success so the in-memory object never diverges
+                # from disk on a write failure.
+                self.save_wallet(replace(wallet, encrypted_mnemonic=new_blob))
+                wallet.encrypted_mnemonic = new_blob
+                logger.info(
+                    "Migrated wallet '%s' from plain to default encryption",
+                    wallet.name,
+                )
+            except OSError as e:
+                # Housekeeping fault tolerance: the read succeeded; only the
+                # optional re-write failed. Signing must not break on a
+                # read-only filesystem.
+                logger.warning(
+                    "Migration write-back failed for wallet '%s': %s",
+                    wallet.name,
+                    e,
+                )
+        return plaintext
 
     # Config operations
 

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -185,9 +185,9 @@ class WalletManager:
             raise ValueError(f"Wallet '{wallet_name}' not found")
 
         if wallet.encrypted_mnemonic:
-            needs_password = self.storage.is_mnemonic_encrypted(wallet.encrypted_mnemonic)
+            needs_password = self.storage.requires_user_password(wallet.encrypted_mnemonic)
             if not needs_password or password:
-                mnemonic = self.storage.retrieve_mnemonic(wallet.encrypted_mnemonic, password)
+                mnemonic = self.storage.read_and_migrate_mnemonic(wallet, password)
                 net = self._get_network(wallet.network)
                 lwk_mnemonic = lwk.Mnemonic(mnemonic)
                 self._signers[wallet_name] = lwk.Signer(lwk_mnemonic, net)
@@ -331,7 +331,7 @@ class WalletManager:
         if wallet_name not in self._signers:
             if not wallet.encrypted_mnemonic:
                 raise ValueError("No mnemonic available for signing")
-            needs_password = self.storage.is_mnemonic_encrypted(wallet.encrypted_mnemonic)
+            needs_password = self.storage.requires_user_password(wallet.encrypted_mnemonic)
             if needs_password and not password:
                 raise ValueError("Password required to decrypt mnemonic")
             self.load_wallet(wallet_name, password)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -285,7 +285,7 @@ class TestWalletCommands:
         )
         assert result.exit_code == 0, result.output
         stored = manager.storage.load_wallet("enc_stdin")
-        assert manager.storage.is_mnemonic_encrypted(stored.encrypted_mnemonic)
+        assert manager.storage.requires_user_password(stored.encrypted_mnemonic)
 
     def test_password_via_env_var_encrypts_wallet(self, runner, isolated_manager):
         """AQUA_PASSWORD env var produces an encrypted wallet (regression test)."""
@@ -297,7 +297,7 @@ class TestWalletCommands:
         )
         assert result.exit_code == 0, result.output
         stored = manager.storage.load_wallet("enc_env")
-        assert manager.storage.is_mnemonic_encrypted(stored.encrypted_mnemonic)
+        assert manager.storage.requires_user_password(stored.encrypted_mnemonic)
 
     def test_password_via_prompt_encrypts_wallet(self, runner, isolated_manager):
         """--password-stdin on a TTY: read_secret prompts and encrypts the wallet.
@@ -325,10 +325,10 @@ class TestWalletCommands:
         assert result.exit_code == 0, result.output
         mock_read.assert_called_once_with("Password")
         stored = manager.storage.load_wallet("enc_prompt")
-        assert manager.storage.is_mnemonic_encrypted(stored.encrypted_mnemonic)
+        assert manager.storage.requires_user_password(stored.encrypted_mnemonic)
 
-    def test_no_password_stores_plaintext(self, runner, isolated_manager):
-        """No stdin flag, no env var, --password-stdin omitted → wallet unencrypted."""
+    def test_no_password_stores_default_encrypted(self, runner, isolated_manager):
+        """No stdin flag, no env var, --password-stdin omitted → wallet uses default encryption."""
         manager, _ = isolated_manager
         result = runner.invoke(
             cli,
@@ -337,8 +337,8 @@ class TestWalletCommands:
         )
         assert result.exit_code == 0, result.output
         stored = manager.storage.load_wallet("plain_one")
-        assert not manager.storage.is_mnemonic_encrypted(stored.encrypted_mnemonic)
-        assert stored.encrypted_mnemonic.startswith("plain:")
+        assert not manager.storage.requires_user_password(stored.encrypted_mnemonic)
+        assert stored.encrypted_mnemonic.startswith("default:1:")
 
     def test_list_wallets_empty(self, runner):
         result = runner.invoke(cli, ["--format", "json", "wallet", "list"])

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -471,6 +471,28 @@ class TestDefaultPasswordEncryption:
         with pytest.raises(ValueError, match="Unsupported default encryption version"):
             temp_storage.retrieve_mnemonic(bogus, None)
 
+    # --- malformed default: prefix parsing ------------------------------
+
+    @pytest.mark.parametrize(
+        "bad_blob",
+        [
+            "default:",  # nothing after the prefix
+            "default:novalidversion",  # single segment, no second colon
+            "default::blob",  # empty version string
+            "default:abc:blob",  # non-integer version
+        ],
+    )
+    def test_retrieve_malformed_default_prefix_raises(self, temp_storage, bad_blob):
+        with pytest.raises(ValueError, match="Malformed default-encrypted mnemonic prefix"):
+            temp_storage.retrieve_mnemonic(bad_blob, None)
+
+    def test_malformed_prefix_error_truncates_long_input(self, temp_storage):
+        # Error message must not echo arbitrarily long ciphertext.
+        long_garbage = "default:abc:" + ("X" * 5000)
+        with pytest.raises(ValueError) as excinfo:
+            temp_storage.retrieve_mnemonic(long_garbage, None)
+        assert "X" * 100 not in str(excinfo.value)
+
     # --- requires_user_password truth table ------------------------------
 
     @pytest.mark.parametrize(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,14 +1,24 @@
 """Tests for storage module."""
 
+import base64
+import logging
 import os
 import stat
 import sys
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from aqua.storage import Storage, WalletData, Config, _validate_wallet_name
+from aqua.storage import (
+    Storage,
+    WalletData,
+    Config,
+    _DEFAULT_MNEMONIC_PASSWORD,
+    _DEFAULT_PWD_VERSION,
+    _validate_wallet_name,
+)
 from tests.conftest import TEST_MNEMONIC
 
 
@@ -393,3 +403,276 @@ class TestLightningSwapStorage:
         path = temp_storage._lightning_swap_path("secure_swap")
         mode = stat.S_IMODE(os.stat(path).st_mode)
         assert mode == 0o600, f"Expected 0600, got {oct(mode)}"
+
+
+# ---------------------------------------------------------------------------
+# Default at-rest encryption (issue #84)
+# ---------------------------------------------------------------------------
+
+
+def _make_plain_blob(mnemonic: str) -> str:
+    """Build a legacy ``plain:`` mnemonic blob (no encryption)."""
+    return "plain:" + base64.b64encode(mnemonic.encode()).decode()
+
+
+def _make_untagged_legacy_blob(storage: Storage, mnemonic: str, password: str) -> str:
+    """Build a legacy untagged blob (raw user-password-encrypted, no prefix)."""
+    return storage.encrypt_mnemonic(mnemonic, password)
+
+
+class TestDefaultPasswordEncryption:
+    """Tests for the default-password at-rest encryption (#84)."""
+
+    # --- store_mnemonic / retrieve_mnemonic ------------------------------
+
+    def test_store_mnemonic_no_password_produces_default_prefix(self, temp_storage):
+        stored = temp_storage.store_mnemonic(TEST_MNEMONIC, None)
+        assert stored.startswith(f"default:{_DEFAULT_PWD_VERSION}:")
+
+    def test_store_mnemonic_with_password_produces_user_prefix(self, temp_storage):
+        stored = temp_storage.store_mnemonic(TEST_MNEMONIC, "s3cret")
+        assert stored.startswith("user:")
+        # Sanity: payload is not the literal mnemonic.
+        assert TEST_MNEMONIC not in stored
+
+    def test_retrieve_default_prefix_no_password_needed(self, temp_storage):
+        stored = temp_storage.store_mnemonic(TEST_MNEMONIC, None)
+        assert temp_storage.retrieve_mnemonic(stored, None) == TEST_MNEMONIC
+        # Even with a (wrong/extra) password argument, default decrypt ignores it.
+        assert temp_storage.retrieve_mnemonic(stored, "ignored") == TEST_MNEMONIC
+
+    def test_retrieve_user_prefix_needs_password(self, temp_storage):
+        stored = temp_storage.store_mnemonic(TEST_MNEMONIC, "s3cret")
+        with pytest.raises(ValueError, match="Password required"):
+            temp_storage.retrieve_mnemonic(stored, None)
+
+    def test_retrieve_user_prefix_with_password(self, temp_storage):
+        stored = temp_storage.store_mnemonic(TEST_MNEMONIC, "s3cret")
+        assert temp_storage.retrieve_mnemonic(stored, "s3cret") == TEST_MNEMONIC
+
+    def test_retrieve_plain_prefix_legacy(self, temp_storage):
+        legacy = _make_plain_blob(TEST_MNEMONIC)
+        # No migration happens inside retrieve_mnemonic (pure read).
+        assert temp_storage.retrieve_mnemonic(legacy, None) == TEST_MNEMONIC
+
+    def test_retrieve_untagged_legacy_needs_password(self, temp_storage):
+        legacy = _make_untagged_legacy_blob(temp_storage, TEST_MNEMONIC, "s3cret")
+        with pytest.raises(ValueError, match="Password required"):
+            temp_storage.retrieve_mnemonic(legacy, None)
+
+    def test_retrieve_untagged_legacy_with_password(self, temp_storage):
+        legacy = _make_untagged_legacy_blob(temp_storage, TEST_MNEMONIC, "s3cret")
+        assert temp_storage.retrieve_mnemonic(legacy, "s3cret") == TEST_MNEMONIC
+
+    def test_retrieve_unsupported_default_version_raises(self, temp_storage):
+        # Encrypted with the real default password but tagged as v99.
+        raw = temp_storage.encrypt_mnemonic(TEST_MNEMONIC, _DEFAULT_MNEMONIC_PASSWORD)
+        bogus = f"default:99:{raw}"
+        with pytest.raises(ValueError, match="Unsupported default encryption version"):
+            temp_storage.retrieve_mnemonic(bogus, None)
+
+    # --- requires_user_password truth table ------------------------------
+
+    @pytest.mark.parametrize(
+        "make_blob, expected",
+        [
+            (lambda s: s.store_mnemonic(TEST_MNEMONIC, None), False),  # default:1:
+            (
+                lambda s: "default:99:"
+                + s.encrypt_mnemonic(TEST_MNEMONIC, _DEFAULT_MNEMONIC_PASSWORD),
+                False,
+            ),  # default:99: (unsupported version still doesn't require user pw)
+            (lambda s: s.store_mnemonic(TEST_MNEMONIC, "pw"), True),  # user:
+            (lambda s: _make_plain_blob(TEST_MNEMONIC), False),  # plain:
+            (
+                lambda s: _make_untagged_legacy_blob(s, TEST_MNEMONIC, "pw"),
+                True,
+            ),  # untagged legacy
+        ],
+        ids=["default-v1", "default-v99", "user", "plain", "untagged-legacy"],
+    )
+    def test_requires_user_password_truth_table(self, temp_storage, make_blob, expected):
+        blob = make_blob(temp_storage)
+        assert temp_storage.requires_user_password(blob) is expected
+
+    # --- read_and_migrate_mnemonic ---------------------------------------
+
+    def test_lazy_migration_plain_to_default(self, temp_storage):
+        """A ``plain:`` wallet read via read_and_migrate_mnemonic is rewritten to ``default:1:``."""
+        wallet = WalletData(
+            name="legacy_plain",
+            network="mainnet",
+            descriptor="ct(...)",
+            encrypted_mnemonic=_make_plain_blob(TEST_MNEMONIC),
+        )
+        temp_storage.save_wallet(wallet)
+
+        returned = temp_storage.read_and_migrate_mnemonic(wallet, None)
+        assert returned == TEST_MNEMONIC
+
+        # Reload from disk and verify it was rewritten.
+        reloaded = temp_storage.load_wallet("legacy_plain")
+        assert reloaded.encrypted_mnemonic.startswith(f"default:{_DEFAULT_PWD_VERSION}:")
+        assert not temp_storage.requires_user_password(reloaded.encrypted_mnemonic)
+        # And the round-trip still gives the original mnemonic.
+        assert temp_storage.retrieve_mnemonic(reloaded.encrypted_mnemonic, None) == TEST_MNEMONIC
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Unix mode bits")
+    def test_lazy_migration_atomicity(self, temp_storage):
+        """After migration the wallet file remains 0o600 and is valid JSON."""
+        import json
+
+        wallet = WalletData(
+            name="atomic_plain",
+            network="mainnet",
+            descriptor="ct(...)",
+            encrypted_mnemonic=_make_plain_blob(TEST_MNEMONIC),
+        )
+        temp_storage.save_wallet(wallet)
+
+        temp_storage.read_and_migrate_mnemonic(wallet, None)
+
+        path = temp_storage._wallet_path("atomic_plain")
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        assert mode == 0o600, f"Expected 0600 after migration, got {oct(mode)}"
+        with open(path) as f:
+            data = json.load(f)
+        assert data["encrypted_mnemonic"].startswith(f"default:{_DEFAULT_PWD_VERSION}:")
+
+    def test_lazy_migration_continues_on_write_failure(self, temp_storage, caplog):
+        """If save_wallet raises OSError during migration, plaintext is still returned."""
+        wallet = WalletData(
+            name="ro_plain",
+            network="mainnet",
+            descriptor="ct(...)",
+            encrypted_mnemonic=_make_plain_blob(TEST_MNEMONIC),
+        )
+        temp_storage.save_wallet(wallet)
+
+        with patch.object(
+            temp_storage, "save_wallet", side_effect=OSError("read-only filesystem")
+        ):
+            with caplog.at_level(logging.WARNING, logger="aqua.storage"):
+                returned = temp_storage.read_and_migrate_mnemonic(wallet, None)
+
+        assert returned == TEST_MNEMONIC
+        # logger.warning must mention the wallet name.
+        assert any("ro_plain" in rec.message for rec in caplog.records)
+        assert any(rec.levelno == logging.WARNING for rec in caplog.records)
+
+    def test_read_and_migrate_does_not_touch_default_user_or_untagged(self, temp_storage):
+        """Non-plain blobs are NOT rewritten by read_and_migrate_mnemonic."""
+        # default:1: blob — should pass through untouched.
+        default_blob = temp_storage.store_mnemonic(TEST_MNEMONIC, None)
+        w1 = WalletData(
+            name="def_w", network="mainnet", descriptor="ct(...)",
+            encrypted_mnemonic=default_blob,
+        )
+        temp_storage.save_wallet(w1)
+        assert temp_storage.read_and_migrate_mnemonic(w1, None) == TEST_MNEMONIC
+        assert temp_storage.load_wallet("def_w").encrypted_mnemonic == default_blob
+
+        # user: blob.
+        user_blob = temp_storage.store_mnemonic(TEST_MNEMONIC, "pw")
+        w2 = WalletData(
+            name="user_w", network="mainnet", descriptor="ct(...)",
+            encrypted_mnemonic=user_blob,
+        )
+        temp_storage.save_wallet(w2)
+        assert temp_storage.read_and_migrate_mnemonic(w2, "pw") == TEST_MNEMONIC
+        assert temp_storage.load_wallet("user_w").encrypted_mnemonic == user_blob
+
+        # untagged legacy.
+        untagged = _make_untagged_legacy_blob(temp_storage, TEST_MNEMONIC, "pw")
+        w3 = WalletData(
+            name="untagged_w", network="mainnet", descriptor="ct(...)",
+            encrypted_mnemonic=untagged,
+        )
+        temp_storage.save_wallet(w3)
+        assert temp_storage.read_and_migrate_mnemonic(w3, "pw") == TEST_MNEMONIC
+        assert temp_storage.load_wallet("untagged_w").encrypted_mnemonic == untagged
+
+    # --- End-to-end via WalletManager / BitcoinWalletManager -------------
+
+    def test_default_encrypted_wallet_signs_without_password(self, temp_storage):
+        """No-password import yields a wallet that loads signer with no password."""
+        from aqua.wallet import WalletManager
+
+        wm = WalletManager(storage=temp_storage)
+        wm.import_mnemonic(TEST_MNEMONIC, "default_signer", "mainnet")
+
+        # Drop cached signer to force the disk read path.
+        wm._signers.pop("default_signer", None)
+        loaded = wm.load_wallet("default_signer")
+        assert loaded.encrypted_mnemonic.startswith(f"default:{_DEFAULT_PWD_VERSION}:")
+        assert "default_signer" in wm._signers
+
+    def test_user_encrypted_wallet_still_requires_password(self, temp_storage):
+        """User-password wallets continue to need the password.
+
+        Contract: load_wallet without password silently skips signer caching
+        (legacy behavior), but any signing operation (``send``) must raise
+        ``ValueError("Password required ...")``. With the correct password,
+        both load and signing setup succeed.
+        """
+        from aqua.wallet import WalletManager
+
+        wm = WalletManager(storage=temp_storage)
+        wm.import_mnemonic(TEST_MNEMONIC, "user_signer", "mainnet", password="s3cret")
+        wm._signers.pop("user_signer", None)
+
+        # Without a password: signer is NOT loaded (legacy behavior preserved;
+        # load_wallet does not raise here, but the signer simply is not cached).
+        wm.load_wallet("user_signer")
+        assert "user_signer" not in wm._signers
+
+        # A signing operation without the password must raise.
+        with pytest.raises(ValueError, match="Password required"):
+            wm.send("user_signer", "lq1qbogus", 1000)
+
+        # With the correct password the signer loads.
+        wm.load_wallet("user_signer", password="s3cret")
+        assert "user_signer" in wm._signers
+
+    def test_bitcoin_send_migrates_plain_wallet(self, temp_storage):
+        """BitcoinWalletManager.send on a legacy plain: wallet migrates it on disk.
+
+        We intercept ``_get_wallet_with_signer`` to short-circuit the BDK
+        broadcast path; by that point ``read_and_migrate_mnemonic`` must have
+        already rewritten the on-disk blob to ``default:1:``.
+        """
+        from aqua.bitcoin import BitcoinWalletManager
+
+        # Build a plain: BTC-capable wallet directly via the storage layer.
+        # We do not call WalletManager.import_mnemonic (that path now produces
+        # default:1:), so we hand-roll the legacy state for this test.
+        legacy_blob = _make_plain_blob(TEST_MNEMONIC)
+        wallet = WalletData(
+            name="btc_plain",
+            network="mainnet",
+            descriptor="ct(...)",  # not exercised; bitcoin.py only uses btc_* fields
+            btc_descriptor="wpkh([deadbeef/84'/0'/0']xpub.../0/*)",
+            btc_change_descriptor="wpkh([deadbeef/84'/0'/0']xpub.../1/*)",
+            encrypted_mnemonic=legacy_blob,
+            watch_only=False,
+        )
+        temp_storage.save_wallet(wallet)
+
+        btc_manager = BitcoinWalletManager(storage=temp_storage)
+
+        # Short-circuit BDK after migration has already happened.
+        sentinel = RuntimeError("short-circuit after migration")
+        with patch.object(
+            btc_manager, "_get_wallet_with_signer", side_effect=sentinel
+        ):
+            with pytest.raises(RuntimeError, match="short-circuit after migration"):
+                btc_manager.send(
+                    wallet_name="btc_plain",
+                    address="bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+                    amount=1000,
+                )
+
+        # The on-disk blob must now be default:1: regardless of the short-circuit.
+        reloaded = temp_storage.load_wallet("btc_plain")
+        assert reloaded.encrypted_mnemonic.startswith(f"default:{_DEFAULT_PWD_VERSION}:")
+        assert temp_storage.retrieve_mnemonic(reloaded.encrypted_mnemonic, None) == TEST_MNEMONIC

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -675,14 +675,14 @@ class TestWalletManagerInternals:
         isolated_manager.load_wallet("restore_test", password="mypass")
         assert "restore_test" in isolated_manager._signers
 
-    def test_send_no_password_uses_plaintext_mnemonic(self, isolated_manager):
-        """Wallet imported without password stores mnemonic as plaintext and can sign."""
+    def test_send_no_password_uses_default_encryption(self, isolated_manager):
+        """Wallet imported without password uses default encryption and can sign."""
         lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="no_sign")
         isolated_manager._signers.pop("no_sign", None)
         wallet = isolated_manager.storage.load_wallet("no_sign")
         assert wallet.encrypted_mnemonic is not None
-        assert wallet.encrypted_mnemonic.startswith("plain:")
-        assert not isolated_manager.storage.is_mnemonic_encrypted(wallet.encrypted_mnemonic)
+        assert wallet.encrypted_mnemonic.startswith("default:1:")
+        assert not isolated_manager.storage.requires_user_password(wallet.encrypted_mnemonic)
 
         isolated_manager.load_wallet("no_sign")
         assert "no_sign" in isolated_manager._signers


### PR DESCRIPTION
### Purpose

Encrypt every mnemonic at rest, even when the user provides no password. Previously, wallets imported without a password stored the mnemonic as base64-only plaintext (`plain:` prefix), making it trivially readable by any process scanning for BIP39 word patterns. A hardcoded default password is now applied automatically so no mnemonic ever lands in plaintext on disk.

Closes #84 Enhancement: Use a default password to encrypt in disk

#### Description

This is **obfuscation, not full security** — the default password lives in source code and won't stop a targeted attacker with code access. The stated goal is to defeat automated plaintext-seed scanners. Wallets encrypted with a user-supplied password are unaffected and continue to require that password for signing.

Lazy migration: existing `plain:` wallets are silently re-encrypted to `default:1:` the first time their mnemonic is read (signing or load), with an atomic write-back. Write-back failures are logged as warnings but never break signing.

#### Main Changes

- New prefix-tagged storage format: `default:1:` (default-encrypted), `user:` (user-password), `plain:` (legacy read-only), untagged (legacy user-password)
- New `Storage.read_and_migrate_mnemonic(wallet, password)` — single lazy-migration choke point wired at `wallet.py:load_wallet` and `bitcoin.py:send`
- Rename `is_mnemonic_encrypted` → `requires_user_password` across 9 production call sites (`wallet.py`, `bitcoin.py`, `lightning.py`, `sideshift.py`, `changelly.py`, `sideswap.py`) — correctly reflects that default-encrypted wallets do not need a user password
- Versioned `default:N:` prefix from day one — `default:1:` today, rotation-ready via version integer
- `_DEFAULT_MNEMONIC_PASSWORD` + `_DEFAULT_PWD_VERSION = 1` constants in `storage.py`; unsupported versions raise `ValueError` (no silent fallback)
- 21 new unit tests: prefix detection, lazy migration round-trip, predicate truth table, signing flows for default/user wallets, atomicity, perms (`0o600`) preservation, write-failure tolerance via `caplog`, bitcoin-side migration wiring

#### Backwards compatibility

- Existing `plain:` wallets auto-migrate to `default:1:` on next read — no user action required
- Existing user-password wallets (untagged legacy) continue working identically
- Watch-only wallets unaffected (no mnemonic)

#### ⚠️ Breaking Changes

- `Storage.is_mnemonic_encrypted` is removed; callers must use `Storage.requires_user_password` (different semantics: returns `False` for `default:` blobs).
- New wallets imported without a password now store `default:1:...` instead of `plain:...`. Tests asserting the `plain:` prefix must be updated (already done in this PR for `test_tools.py` and `test_cli.py`).

### Checklist

- [x] Added/updated tests (21 new + 5 updated)
- [x] Merged develop (includes #85 lightning test fix — full suite now 809 passed, 25 skipped, 0 failed)
- [ ] Added/updated relevant documentation (server.py LLM prompt copy around lines 1060/1089/1095 still references old "ask user about encryption" flow — follow-up PR)