### PR TITLE
Disable TON network in Changelly and SideShift swap allowlists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ networks (unified wallet).
 ```
 AI Assistant ──MCP──▶ aqua.server ──▶ tools.py ──▶ wallet.py  (LWK ─ Electrum/Esplora)
                                               └─▶ bitcoin.py (BDK ─ Esplora)
-                                              └─▶ lightning.py / sideswap / sideshift /
+                                              └─▶ lightning.py / sideshift /
                                                   changelly / pix  (third-party clients)
 ```
 
@@ -91,10 +91,10 @@ Use `grep`/`Glob` only for exact strings or config lookups.
 - **MCP tool / prompt / resource schemas** — live in `src/aqua/server.py`. The MCP server is
   self-describing; don't duplicate the schema in markdown.
 - **Third-party protocol semantics** (Boltz status state machines, SideShift wire format,
-  Changelly endpoints, Eulen Pix endpoints, SideSwap mkt::* flow) — captured as docstrings
-  and constants inside the relevant module (e.g. `src/aqua/sideswap.py`).
+  Changelly endpoints, Eulen Pix endpoints) — captured as docstrings
+  and constants inside the relevant module.
 - **On-disk JSON schemas** (wallet file, swap files) — the `@dataclass` definitions in
-  `storage.py`, `lightning.py`, `sideswap.py`, etc. are the source of truth. Read the
+  `storage.py`, `lightning.py`, etc. are the source of truth. Read the
   dataclass to know the shape.
 - **User-facing docs** — `README.md` and the MCP resources under `src/aqua/static/`.
 
@@ -113,3 +113,7 @@ Project-level `CLAUDE.md` is symlinked from this file. Key user rules:
 - `develop` is the integration branch for code that is still pending broader testing.
 - When opening code PRs by default, target `develop`, not `main`, unless the user explicitly asks otherwise.
 - When comparing branch work for PR prep, prefer `git diff develop...HEAD` / `git log develop...HEAD --oneline` unless a different base branch is requested.
+
+## SideSwap
+
+SideSwap is not yet implemented for production use. Do not suggest or offer SideSwap options to users.

--- a/src/aqua/AGENTS.md
+++ b/src/aqua/AGENTS.md
@@ -19,7 +19,7 @@ Python package implementing the MCP server, wallet engines, and third-party swap
 | `boltz.py` | Boltz Exchange client. Submarine swap construction, BOLT11 amount decode, keypair gen. | `BoltzClient`, `generate_keypair` |
 | `ankara.py` | Ankara backend client for Lightning receive (L-BTC). | `AnkaraClient` |
 | `lnurl.py` | LUD-16 Lightning Address resolution → BOLT11. | `is_lightning_address`, `resolve_lightning_address` |
-| `pix.py` | Brazilian Pix → DePix on-ramp via Eulen REST API. | `PixManager` |
+| `pix.py` | Brazilian Pix on-ramp via Eulen REST API. | `PixManager` |
 | `changelly.py` | Custodial USDt cross-chain swaps via AQUA's Ankara proxy. Curated allowlist (mirrors AQUA Flutter). | `ChangellyClient`, `ChangellyManager` |
 | `sideshift.py` | Custodial cross-chain swaps via SideShift.ai. Curated allowlist mirrors AQUA Flutter; affiliate ID `PVmPh4Mp3`. | `SideShiftClient`, `SideShiftManager` |
 | `banner.py` | CLI ASCII banner rendering. | `render_banner` |

--- a/src/aqua/AGENTS.md
+++ b/src/aqua/AGENTS.md
@@ -22,7 +22,6 @@ Python package implementing the MCP server, wallet engines, and third-party swap
 | `pix.py` | Brazilian Pix → DePix on-ramp via Eulen REST API. | `PixManager` |
 | `changelly.py` | Custodial USDt cross-chain swaps via AQUA's Ankara proxy. Curated allowlist (mirrors AQUA Flutter). | `ChangellyClient`, `ChangellyManager` |
 | `sideshift.py` | Custodial cross-chain swaps via SideShift.ai. Curated allowlist mirrors AQUA Flutter; affiliate ID `PVmPh4Mp3`. | `SideShiftClient`, `SideShiftManager` |
-| `sideswap.py` | SideSwap WebSocket JSON-RPC. BTC↔L-BTC pegs and atomic Liquid asset swaps (`mkt::*` flow). | `SideSwapClient`, `PegManager`, `SwapManager`, `verify_pset_balances` |
 | `banner.py` | CLI ASCII banner rendering. | `render_banner` |
 | `cli/` | Click CLI mirroring MCP tools (see `cli/AGENTS.md`). | — |
 | `static/` | MCP resource markdown (quickstart, networks, security). Loaded by `server.py` via `aqua://docs/*`. | — |
@@ -34,14 +33,8 @@ Python package implementing the MCP server, wallet engines, and third-party swap
   mnemonic. Don't introduce a shared abstract base; the APIs diverge (LWK uses `Wollet` +
   `ElectrumClient`; BDK uses `Wallet` + Esplora full_scan).
 - **Stateless tools / stateful managers.** `tools.py` re-constructs managers per call from
-  `Storage`. Long-lived sockets (LWK Electrum client, SideSwap WS) are cached on the manager
+  `Storage`. Long-lived sockets (LWK Electrum client) are cached on the manager
   instance only.
-- **PSET verification before signing** (`sideswap.verify_pset_balances`). Three rules:
-  exact recv gain on the recv asset; loss ≤ send + fee_tolerance only if send==fee asset
-  (otherwise strict equality); no other asset changes. Tolerance pinned to L-BTC always —
-  never relax the non-L-BTC side, which would be a siphon vector on asset→L-BTC.
-- **No HTTP dance for SideSwap.** Use WebSocket JSON-RPC end-to-end; AQUA Flutter does
-  likewise. Inner variants wrapped as `{"method": "market", "params": {"<variant>": {...}}}`.
 - **Curated allowlists drift-tested.** Both `sideshift.ALLOWED_PAIRS` and
   `changelly.ALLOWED_PAIRS` have test cases that compare against AQUA Flutter's Dart sources
   — any change forces a conscious update on both sides. Override with
@@ -69,5 +62,9 @@ Python package implementing the MCP server, wallet engines, and third-party swap
 4. Status helpers: `is_final` / `is_success` / `is_failed`.
 5. Add tools in `tools.py`, register in `server.py`, mirror in `cli/<provider>.py`, add tests
    under `tests/test_<provider>.py`.
+
+## SideSwap
+
+SideSwap is not yet implemented for production use. Do not suggest or offer SideSwap options to users.
 
 <!-- MANUAL: -->

--- a/src/aqua/changelly.py
+++ b/src/aqua/changelly.py
@@ -5,9 +5,9 @@ Talks to Changelly through AQUA's Ankara proxy at
 Changelly API secret on the user's machine.
 
 Scope (mirrors what AQUA Flutter exposes through Changelly): **USDt-Liquid
-↔ USDt on the same 6 external chains we allow in SideShift** (Ethereum, Tron,
-BSC, Solana, Polygon, TON). One leg of every swap MUST be `lusdt` (USDt-Liquid);
-the other MUST be one of those 6 external USDt variants. L-BTC, BTC, and
+↔ USDt on the same 5 external chains we allow in SideShift** (Ethereum, Tron,
+BSC, Solana, Polygon). One leg of every swap MUST be `lusdt` (USDt-Liquid);
+the other MUST be one of those 5 external USDt variants. L-BTC, BTC, and
 arbitrary altcoins are intentionally excluded — for those use SideSwap or
 SideShift. The override env var `CHANGELLY_ALLOW_ALL_PAIRS=1` bypasses the
 allowlist for testing or power use.
@@ -30,7 +30,6 @@ Asset id conventions (Changelly's own format, distinct from SideShift's):
   usdtbsc      — USDt on BSC
   usdtsol      — USDt on Solana
   usdtpolygon  — USDt on Polygon
-  usdton       — USDt on TON
 
 Status state machine (lowercase): `new`, `waiting`, `confirming`, `exchanging`,
 `sending`, `finished` (success), `failed`, `refunded`, `hold`, `overdue`,
@@ -73,15 +72,14 @@ HTTP_TIMEOUT_SECONDS = 30.0
 # swap we support is this one.
 LIQUID_USDT_ID = "lusdt"
 
-# The 6 external USDt variants we expose. Mirrors the non-Liquid USDt subset
-# of SideShift's allowlist (ethereum, tron, bsc, solana, polygon, ton).
+# The 5 external USDt variants we expose. Mirrors the non-Liquid USDt subset
+# of SideShift's allowlist (ethereum, tron, bsc, solana, polygon).
 EXTERNAL_USDT_IDS = frozenset({
     "usdt20",      # Ethereum (ERC-20)
     "usdtrx",      # Tron (TRC-20)
     "usdtbsc",     # BSC
     "usdtsol",     # Solana
     "usdtpolygon", # Polygon
-    "usdton",      # TON
 })
 
 # Curated pair allowlist: one leg must be lusdt, the other must be in
@@ -103,7 +101,6 @@ NETWORK_TO_USDT_ID = {
     "bsc": "usdtbsc",
     "solana": "usdtsol",
     "polygon": "usdtpolygon",
-    "ton": "usdton",
 }
 USDT_ID_TO_NETWORK = {v: k for k, v in NETWORK_TO_USDT_ID.items()}
 
@@ -146,7 +143,6 @@ _ADDRESS_PATTERNS: dict[str, re.Pattern[str]] = {
     "bsc":      re.compile(r"^0x[0-9a-fA-F]{40}$"),
     "polygon":  re.compile(r"^0x[0-9a-fA-F]{40}$"),
     "solana":   re.compile(r"^[1-9A-HJ-NP-Za-km-z]{43,44}$"),
-    "ton":      re.compile(r"^[EU][Qq][0-9A-Za-z_\-]{46}$"),
 }
 
 

--- a/src/aqua/changelly.py
+++ b/src/aqua/changelly.py
@@ -119,7 +119,7 @@ def _check_pair_allowed(from_id: str, to_id: str) -> None:
     """Raise ValueError if the (from, to) pair isn't on the allowlist.
 
     Both legs combined must form a curated pair: exactly one leg is `lusdt`,
-    the other is one of the 6 external USDt variants. The override env var
+    the other is one of the 5 external USDt variants. The override env var
     bypasses the check entirely.
     """
     if _allow_all_pairs():

--- a/src/aqua/cli/AGENTS.md
+++ b/src/aqua/cli/AGENTS.md
@@ -16,7 +16,6 @@ rendered to terminal/JSON instead of MCP responses.
 | `liquid.py` | `aqua liquid` | Liquid balance, address, send, transactions. |
 | `btc.py` | `aqua btc` | Bitcoin equivalents. |
 | `lightning.py` | `aqua lightning` | Receive (Ankara), send (Boltz), status. |
-| `sideswap.py` | `aqua sideswap` | Server status, peg quote/in/out, asset quote/swap, status. |
 | `sideshift.py` | `aqua sideshift` | Cross-chain quote, send, receive, status. |
 | `changelly.py` | `aqua changelly` | USDt cross-chain quote, send, receive, status. |
 | `serve.py` | `aqua serve` | Run the MCP stdio server from the CLI. |
@@ -49,5 +48,9 @@ Use this pattern for any new command that signs transactions.
 - Errors: catch `ValueError` at the command boundary and render via the error envelope.
   Do not let raw tracebacks reach the user unless `--verbose`.
 - New CLI command → register in `commands.py`, add a smoke test in `tests/test_cli.py`.
+
+## SideSwap
+
+SideSwap is not yet implemented for production use. Do not suggest or offer SideSwap options to users.
 
 <!-- MANUAL: -->

--- a/src/aqua/cli/changelly.py
+++ b/src/aqua/cli/changelly.py
@@ -20,7 +20,7 @@ from .password import handle_password_retry, resolve_secret
 
 
 _EXTERNAL_NETWORK = click.Choice([
-    "ethereum", "tron", "bsc", "solana", "polygon", "ton",
+    "ethereum", "tron", "bsc", "solana", "polygon",
 ])
 _DIRECTION = click.Choice(["send", "receive"])
 _PASSWORD_HELP = (
@@ -32,12 +32,12 @@ _PASSWORD_HELP = (
 
 @click.group()
 def changelly():
-    """Changelly — USDt cross-chain swaps (Liquid ↔ ETH/Tron/BSC/Solana/Polygon/TON).
+    """Changelly — USDt cross-chain swaps (Liquid ↔ ETH/Tron/BSC/Solana/Polygon).
 
     Routed through AQUA's Ankara backend proxy. For Liquid-only swaps
     (e.g. L-BTC ↔ USDt-Liquid) prefer `aqua sideswap` (atomic on Liquid).
 
-    Scope: USDt-Liquid ↔ USDt on the 6 supported external chains. For BTC,
+    Scope: USDt-Liquid ↔ USDt on the 5 supported external chains. For BTC,
     L-BTC, or non-USDt swaps, use `aqua sideswap` or `aqua sideshift`.
     """
 

--- a/src/aqua/cli/sideshift.py
+++ b/src/aqua/cli/sideshift.py
@@ -36,7 +36,7 @@ def sideshift():
     Liquid, or Liquid Federation peg).
 
     Curated pair allowlist (mirrors AQUA Flutter):
-      USDt on ethereum / tron / bsc / solana / polygon / ton / liquid
+      USDt on ethereum / tron / bsc / solana / polygon / liquid
       BTC on bitcoin
 
     Off-allowlist pairs raise an error from `send` and `receive`. Set
@@ -143,7 +143,7 @@ def recommend(ctx, from_coin, from_network, to_coin, to_network):
     "--liquid-asset-id", default=None,
     help="Hex asset id; required when deposit-coin is a non-L-BTC Liquid asset.",
 )
-@click.option("--settle-memo", default=None, help="Required for memo networks (TON, BNB, etc.).")
+@click.option("--settle-memo", default=None, help="Required for memo networks (BNB, etc.).")
 @click.option("--refund-memo", default=None)
 @click.option(
     "--yes", "-y", "skip_confirm", is_flag=True, default=False,

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -498,7 +498,7 @@ TOOL_SCHEMAS = {
         "description": (
             "List the currencies Changelly supports (Changelly's own asset id format). "
             "Useful for discovery; the agentic-aqua surface only enables the curated "
-            "USDt-Liquid ↔ USDt-on-{ethereum,tron,bsc,solana,polygon,ton} pairs for "
+            "USDt-Liquid ↔ USDt-on-{ethereum,tron,bsc,solana,polygon} pairs for "
             "actual swaps."
         ),
         "inputSchema": {"type": "object", "properties": {}},
@@ -514,7 +514,7 @@ TOOL_SCHEMAS = {
             "properties": {
                 "external_network": {
                     "type": "string",
-                    "enum": ["ethereum", "tron", "bsc", "solana", "polygon", "ton"],
+                    "enum": ["ethereum", "tron", "bsc", "solana", "polygon"],
                     "description": "USDt network on the non-Liquid side",
                 },
                 "direction": {
@@ -541,7 +541,7 @@ TOOL_SCHEMAS = {
             "properties": {
                 "external_network": {
                     "type": "string",
-                    "enum": ["ethereum", "tron", "bsc", "solana", "polygon", "ton"],
+                    "enum": ["ethereum", "tron", "bsc", "solana", "polygon"],
                     "description": "Target USDt network",
                 },
                 "settle_address": {"type": "string", "description": "External chain address to receive USDt at"},
@@ -566,7 +566,7 @@ TOOL_SCHEMAS = {
             "properties": {
                 "external_network": {
                     "type": "string",
-                    "enum": ["ethereum", "tron", "bsc", "solana", "polygon", "ton"],
+                    "enum": ["ethereum", "tron", "bsc", "solana", "polygon"],
                     "description": "Source USDt network the external sender pays from",
                 },
                 "wallet_name": {"type": "string", "default": "default"},
@@ -930,7 +930,7 @@ TOOL_SCHEMAS = {
             "Send funds out via SideShift. Gets a fixed-rate quote, creates the shift, "
             "and broadcasts the deposit from the local wallet. Deposit chain MUST be "
             "'bitcoin' or 'liquid'. Both legs must be in the curated allowlist (USDt on "
-            "ethereum/tron/bsc/solana/polygon/ton/liquid, or BTC on bitcoin) — mirrors "
+            "ethereum/tron/bsc/solana/polygon/liquid, or BTC on bitcoin) — mirrors "
             "AQUA Flutter's supported pairs. Set SIDESHIFT_ALLOW_ALL_NETWORKS=1 to bypass. "
             "A refund address is set automatically (the wallet's own deposit-chain "
             "address). For non-L-BTC Liquid assets (e.g. USDt-Liquid), pass liquid_asset_id. "
@@ -956,7 +956,7 @@ TOOL_SCHEMAS = {
                     "type": "string",
                     "description": "Hex asset id; required when sending a non-L-BTC Liquid asset",
                 },
-                "settle_memo": {"type": "string", "description": "Required for memo networks (TON, BNB, etc.)"},
+                "settle_memo": {"type": "string", "description": "Required for memo networks (BNB, etc.)"},
                 "refund_memo": {"type": "string"},
                 "quote_id": {
                     "type": "string",
@@ -980,7 +980,7 @@ TOOL_SCHEMAS = {
             "Returns a deposit address on the deposit chain — the user (or external "
             "sender) sends to it from any wallet. Settle chain MUST be 'bitcoin' or "
             "'liquid'. Both legs must be in the curated allowlist (USDt on "
-            "ethereum/tron/bsc/solana/polygon/ton/liquid, or BTC on bitcoin) — mirrors "
+            "ethereum/tron/bsc/solana/polygon/liquid, or BTC on bitcoin) — mirrors "
             "AQUA Flutter's supported pairs. Set SIDESHIFT_ALLOW_ALL_NETWORKS=1 to bypass. "
             "STRONGLY RECOMMEND passing external_refund_address (the deposit-side "
             "sender's address) so a stuck shift can refund automatically."
@@ -1127,7 +1127,7 @@ PIX → DEPIX (Brazilian Real on-ramp via Eulen):
 
 CHANGELLY (custodial USDt cross-chain swaps via AQUA's Ankara proxy):
 - Use changelly_send when the user wants to send USDt-Liquid OUT to USDt on
-  another chain (Ethereum, Tron, BSC, Solana, Polygon, TON).
+  another chain (Ethereum, Tron, BSC, Solana, Polygon).
 - Use changelly_receive when the user wants to receive USDt-Liquid IN from
   USDt on another chain. Returns a deposit address on the source chain.
 - ALWAYS call changelly_quote first for sends so the user can confirm the
@@ -1188,7 +1188,7 @@ SIDESHIFT (custodial cross-chain swaps):
 - TRUST MODEL: SideShift is custodial. They take the deposit and send from
   their hot wallet. This is different from SideSwap (atomic on Liquid) and
   Lightning (Boltz submarine, atomic). Communicate this trade-off to the user.
-- Memo networks (TON, BNB Beacon, Stellar, etc.) require a memo on either
+- Memo networks (BNB Beacon, Stellar, etc.) require a memo on either
   the deposit or settle side — pass settle_memo / refund_memo when prompted.
 
 WATCH-ONLY WALLETS:
@@ -1889,7 +1889,7 @@ on-chain — make sure I understand this trade-off.
 
 Please:
 1. Show my Liquid balance (lw_balance) so I can see how much USDt-Liquid I have
-2. Ask me which target USDt chain (ethereum, tron, bsc, solana, polygon, ton)
+2. Ask me which target USDt chain (ethereum, tron, bsc, solana, polygon)
 3. Ask me for:
    - The destination address on that chain
    - The amount of USDt-Liquid to send (decimal, e.g. "100")
@@ -1925,7 +1925,7 @@ Liquid address from their hot wallet. Trust model: trust the company.
 
 Please:
 1. Ask me which source USDt chain the external sender will pay from
-   (ethereum, tron, bsc, solana, polygon, ton)
+   (ethereum, tron, bsc, solana, polygon)
 2. STRONGLY recommend providing an external_refund_address — the source
    chain address the external sender controls. Without it, a stuck order
    requires manual web UI intervention. Ask for it.
@@ -2021,7 +2021,7 @@ Please:
    - The deposit address on the source chain (this is what the external
      sender pays to)
    - deposit_min and deposit_max
-   - deposit_memo IF PRESENT (the source chain requires a memo, e.g. TON,
+   - deposit_memo IF PRESENT (the source chain requires a memo, e.g.
      Stellar, BNB Beacon — the sender MUST include it)
    - Where the funds will arrive in my wallet
 6. Tell me to use sideshift_status with the shift_id to poll progress""",

--- a/src/aqua/sideshift.py
+++ b/src/aqua/sideshift.py
@@ -80,7 +80,6 @@ ALLOWED_PAIRS: frozenset[tuple[str, str]] = frozenset({
     ("usdt", "bsc"),
     ("usdt", "solana"),
     ("usdt", "polygon"),
-    ("usdt", "ton"),
     ("usdt", "liquid"),
     ("btc", "bitcoin"),
 })
@@ -240,7 +239,7 @@ class SideShiftShift:
     deposit_max: Optional[str] = None  # variable shifts only
     rate: Optional[str] = None
     quote_id: Optional[str] = None  # fixed shifts only
-    deposit_memo: Optional[str] = None  # for memo-required networks (TON, BNB, etc.)
+    deposit_memo: Optional[str] = None  # for memo-required networks (BNB, etc.)
     deposit_hash: Optional[str] = None  # txid where the deposit landed
     settle_hash: Optional[str] = None  # txid where the settlement landed
     last_checked_at: Optional[str] = None
@@ -692,7 +691,7 @@ class SideShiftManager:
             liquid_asset_id: hex asset id, required when the Liquid asset
                 is not L-BTC (e.g. USDt-Liquid).
             settle_memo / refund_memo: required for memo networks
-                (TON, BNB Beacon, etc.) on either side.
+                (BNB Beacon, etc.) on either side.
             quote_id: an existing fixed-rate quote id (from a prior
                 `quote()` call). When provided, skip the internal
                 `request_quote` call so the executed shift uses the same

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -934,8 +934,8 @@ def changelly_list_currencies() -> dict[str, Any]:
     """List the Changelly currencies enabled for swaps in agentic-aqua.
 
     Filtered server-side to the curated USDt-Liquid ↔ USDt-on-external-chain
-    set: `lusdt` (Liquid) plus the 6 external USDt variants (usdt20/usdtrx/
-    usdtbsc/usdtsol/usdtpolygon/usdton). Other Changelly assets aren't
+    set: `lusdt` (Liquid) plus the 5 external USDt variants (usdt20/usdtrx/
+    usdtbsc/usdtsol/usdtpolygon). Other Changelly assets aren't
     exposed because we don't offer swaps for them. Set
     `CHANGELLY_ALLOW_ALL_PAIRS=1` to bypass the filter.
 
@@ -962,7 +962,7 @@ def changelly_quote(
 
     Args:
         external_network: USDt network (one of: ethereum, tron, bsc, solana,
-            polygon, ton).
+            polygon).
         direction: "send" or "receive". Default: "send".
         amount_from: amount the deposit side sends (decimal string).
         amount_to: amount the settle side receives (decimal string).
@@ -1015,7 +1015,7 @@ def changelly_send(
 
     Args:
         external_network: target USDt network (ethereum, tron, bsc, solana,
-            polygon, ton).
+            polygon).
         settle_address: external chain address where the user receives.
         amount_from: USDt-Liquid to send (decimal string, e.g. "100").
         amount_to: amount recipient receives (decimal string). Mutually exclusive
@@ -1069,7 +1069,7 @@ def changelly_receive(
 
     Args:
         external_network: source USDt network (ethereum, tron, bsc, solana,
-            polygon, ton).
+            polygon).
         wallet_name: Liquid wallet to receive into.
         external_refund_address: STRONGLY RECOMMENDED — the deposit-chain
             address to refund to if the order fails. Without one a stuck
@@ -1122,7 +1122,7 @@ def sideshift_list_coins() -> dict[str, Any]:
     """List the SideShift coin/network identifiers enabled for swaps.
 
     Filtered server-side to the curated allowlist (USDt across
-    ethereum/tron/bsc/solana/polygon/ton/liquid, plus mainchain BTC) so the
+    ethereum/tron/bsc/solana/polygon/liquid, plus mainchain BTC) so the
     response stays small and only surfaces pairs we actually support. Each
     kept entry has `coin`, `name`, `networks` (intersected with the
     allowlist), `hasMemo`, `fixedOnly`/`variableOnly`, and a pruned
@@ -1218,7 +1218,7 @@ def sideshift_send(
     The deposit chain MUST be one of {bitcoin, liquid} — those are the only
     chains we can sign on. Both legs (deposit + settle) must also be in the
     curated pair allowlist mirroring AQUA Flutter: USDt on
-    {ethereum, tron, bsc, solana, polygon, ton, liquid} or BTC on bitcoin.
+    {ethereum, tron, bsc, solana, polygon, liquid} or BTC on bitcoin.
     L-BTC (btc-liquid) is excluded — use SideSwap for L-BTC ↔ external.
     Set `SIDESHIFT_ALLOW_ALL_NETWORKS=1` to bypass.
 
@@ -1236,7 +1236,7 @@ def sideshift_send(
         password: mnemonic decryption password (if encrypted)
         liquid_asset_id: required when deposit is a non-L-BTC Liquid asset
             (e.g. USDt-Liquid: pass the asset id hex)
-        settle_memo / refund_memo: required for memo networks (TON, BNB, etc.)
+        settle_memo / refund_memo: required for memo networks (BNB, etc.)
         quote_id: optional fixed-rate quote id from a prior `sideshift_quote`
             call. Pass `preview["id"]` after the user confirms the preview to
             ensure the shift executes at the rate the user just saw. Without
@@ -1285,7 +1285,7 @@ def sideshift_receive(
     The settle chain MUST be one of {bitcoin, liquid} — those are the only
     chains we hold addresses for. Both legs (deposit + settle) must also be
     in the curated pair allowlist mirroring AQUA Flutter: USDt on
-    {ethereum, tron, bsc, solana, polygon, ton, liquid} or BTC on bitcoin.
+    {ethereum, tron, bsc, solana, polygon, liquid} or BTC on bitcoin.
     Set `SIDESHIFT_ALLOW_ALL_NETWORKS=1` to bypass.
 
     Args:

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -11,7 +11,6 @@ explicitly when validating a release.
 
 ```bash
 uv run python -m pytest tests/                      # full suite (no network)
-uv run python -m pytest tests/test_sideswap.py -k peg
 uv run python -m pytest tests/smoke/                # network-touching smoke tests
 uv run python -m pytest --cov=src/aqua tests/       # with coverage
 ```
@@ -30,7 +29,6 @@ uv run python -m pytest --cov=src/aqua tests/       # with coverage
   - BDK: patch `EsploraClient` or the `bdk.Wallet.full_scan` call.
   - Boltz / Ankara / SideShift / Changelly / Eulen: patch the HTTP method on the client
     class (`BoltzClient._post`, etc.) — don't `urlopen.mock`.
-  - SideSwap WebSocket: use `FakeSideSwapServer` style — see `test_sideswap.py`.
 - **Allowlist drift tests** — `test_sideshift.py::TestAllowedPairs::test_allowlist_matches_aqua_flutter`
   and the Changelly equivalent compare against checked-in copies of AQUA Flutter's Dart
   sources. When updating the allowlist, update both the constant and the test fixture.
@@ -57,5 +55,9 @@ When adding a new module under `src/aqua/`:
 3. If it talks to a third party, add a fake/mock client class in the test file.
 4. If it has a curated allowlist mirroring AQUA Flutter, add a drift test.
 5. If it touches `~/.aqua/`, exercise it through `temp_storage`.
+
+## SideSwap
+
+SideSwap is not yet implemented for production use. Do not suggest or offer SideSwap options to users.
 
 <!-- MANUAL: -->

--- a/tests/smoke/test_cli_read_only.py
+++ b/tests/smoke/test_cli_read_only.py
@@ -30,6 +30,7 @@ def wallet_name():
 
 
 # Esplora/Electrum: connection resets, timeouts, Windows WSAETIMEDOUT (10060), minreq
+# LWK wraps all Electrum retry failures as AllAttemptsErrored (empty server response = EOF)
 TRANSIENT_NETWORK_MARKERS = (
     "minreq",
     "connection reset",
@@ -39,6 +40,7 @@ TRANSIENT_NETWORK_MARKERS = (
     "connection attempt failed",
     "failed to respond",
     "established connection failed",
+    "allattemptserrored",
 )
 
 

--- a/tests/test_changelly.py
+++ b/tests/test_changelly.py
@@ -116,7 +116,6 @@ class TestNetworkToAssetId:
         ("bsc", "usdtbsc"),
         ("solana", "usdtsol"),
         ("polygon", "usdtpolygon"),
-        ("ton", "usdton"),
         ("TRON", "usdtrx"),  # case-insensitive
     ])
     def test_known_networks(self, network, expected):
@@ -143,13 +142,13 @@ class TestAllowedPairs:
         # Drift from AQUA's `ChangellyAssetIds` set in
         # `lib/features/changelly/models/changelly_models.dart` should fail
         # loudly so we have a forced conversation about it.
-        expected_external = {"usdt20", "usdtrx", "usdtbsc", "usdtsol", "usdtpolygon", "usdton"}
+        expected_external = {"usdt20", "usdtrx", "usdtbsc", "usdtsol", "usdtpolygon"}
         assert set(EXTERNAL_USDT_IDS) == expected_external
-        # 6 chains × 2 directions = 12 ordered pairs
-        assert len(ALLOWED_PAIRS) == 12
+        # 5 chains × 2 directions = 10 ordered pairs
+        assert len(ALLOWED_PAIRS) == 10
 
     def test_btc_lbtc_usdc_etc_NOT_in_allowlist(self):
-        # Explicitly: only USDt, only the 6 external chains, only paired
+        # Explicitly: only USDt, only the 5 external chains, only paired
         # with USDt-Liquid.
         assert ("btc", "lusdt") not in ALLOWED_PAIRS
         assert ("lbtc", "usdtrx") not in ALLOWED_PAIRS
@@ -206,7 +205,7 @@ class TestAllowedPairs:
 
 class TestListCurrenciesFilter:
     """Changelly's raw `getCurrencies` returns 764 tickers. We only expose
-    the curated USDt set (lusdt + 6 external variants)."""
+    the curated USDt set (lusdt + 5 external variants)."""
 
     _RAW = [
         "btc", "eth", "ltc", "doge", "shib", "lusdt", "usdc",
@@ -221,7 +220,7 @@ class TestListCurrenciesFilter:
         result = mgr.list_currencies()
         assert set(result) == {
             "lusdt", "usdt20", "usdtrx", "usdtbsc",
-            "usdtsol", "usdtpolygon", "usdton",
+            "usdtsol", "usdtpolygon",
         }
 
     def test_preserves_provider_ordering(self):
@@ -232,7 +231,7 @@ class TestListCurrenciesFilter:
         # Ordering follows the raw list, not alphabetic.
         assert result == [
             "lusdt", "usdt20", "usdtrx", "usdtbsc",
-            "usdtsol", "usdtpolygon", "usdton",
+            "usdtsol", "usdtpolygon",
         ]
 
     def test_unrelated_assets_dropped(self):
@@ -240,7 +239,7 @@ class TestListCurrenciesFilter:
         mgr._client = MagicMock()
         mgr._client.get_currencies.return_value = list(self._RAW)
         result = mgr.list_currencies()
-        for unrelated in ("btc", "eth", "ltc", "shib", "usdc", "xrp", "ada"):
+        for unrelated in ("btc", "eth", "ltc", "shib", "usdc", "xrp", "ada", "usdton"):
             assert unrelated not in result
 
     def test_override_env_var_returns_raw(self, monkeypatch):
@@ -264,8 +263,6 @@ class TestValidateSettleAddress:
         ("bsc",      "0xAbCdEf1234567890abcdef1234567890abCdEf12"),
         ("polygon",  "0xAbCdEf1234567890abcdef1234567890abCdEf12"),
         ("solana",   "So11111111111111111111111111111111111111112"),  # 44-char wrapped SOL mint
-        ("ton",      "EQ" + "D" * 46),                          # EQ + 46 base64url = 48
-        ("ton",      "UQ" + "D" * 46),                          # UQ + 46 base64url = 48
     ])
     def test_valid_addresses_pass(self, network, address):
         _validate_settle_address(network, address)
@@ -277,7 +274,6 @@ class TestValidateSettleAddress:
         ("ethereum", "TXYZabc123456789012", "valid ethereum"),  # Tron addr on ETH
         ("ethereum", "0xShort",            "valid ethereum"),
         ("solana",   "0x1234",             "valid solana"),
-        ("ton",      "0x1234",             "valid ton"),
     ])
     def test_invalid_addresses_raise(self, network, address, match):
         with pytest.raises(ValueError, match=match):

--- a/tests/test_sideshift.py
+++ b/tests/test_sideshift.py
@@ -172,7 +172,7 @@ class TestRecommendation:
 
 class TestAllowedPairs:
     """Encodes the contract that we expose the same SideShift surface as AQUA
-    Flutter: USDt across 7 chains + BTC mainchain. L-BTC and arbitrary altcoins
+    Flutter: USDt across 6 chains + BTC mainchain. L-BTC and arbitrary altcoins
     are not in the allowlist; users hit the override env var if they want them.
     """
 

--- a/tests/test_sideshift.py
+++ b/tests/test_sideshift.py
@@ -185,7 +185,6 @@ class TestAllowedPairs:
             ("usdt", "bsc"),
             ("usdt", "solana"),
             ("usdt", "polygon"),
-            ("usdt", "ton"),
             ("usdt", "liquid"),
             ("btc", "bitcoin"),
         }
@@ -312,11 +311,12 @@ class TestFilterCoinsToAllowlist:
         filtered = _filter_coins_to_allowlist(_SAMPLE_COINS)
         usdt = next(c for c in filtered if c["coin"] == "USDT")
         assert set(usdt["networks"]) == {
-            "ethereum", "tron", "bsc", "solana", "polygon", "ton", "liquid",
+            "ethereum", "tron", "bsc", "solana", "polygon", "liquid",
         }
-        # Stellar / aptos / sui / etc are dropped
+        # Stellar / aptos / sui / ton / etc are dropped
         assert "stellar" not in usdt["networks"]
         assert "aptos" not in usdt["networks"]
+        assert "ton" not in usdt["networks"]
 
     def test_btc_only_keeps_mainchain_network(self):
         filtered = _filter_coins_to_allowlist(_SAMPLE_COINS)
@@ -329,11 +329,12 @@ class TestFilterCoinsToAllowlist:
         usdt = next(c for c in filtered if c["coin"] == "USDT")
         details = usdt["tokenDetails"]
         assert set(details) == {
-            "ethereum", "tron", "solana", "polygon", "bsc", "ton",
+            "ethereum", "tron", "solana", "polygon", "bsc",
         }
-        # Stellar token details dropped along with the network.
+        # Stellar / TON / avax token details dropped along with the network.
         assert "stellar" not in details
         assert "avax" not in details
+        assert "ton" not in details
 
     def test_networks_with_memo_pruned(self):
         filtered = _filter_coins_to_allowlist(_SAMPLE_COINS)


### PR DESCRIPTION
### Purpose

Remove TON from the curated swap allowlists in both Changelly and SideShift integrations. New TON swap orders are rejected at the tool/CLI/MCP layer; existing TON swaps already on disk remain pollable via \`*_status\` until they reach a terminal state.

#### Description

Soft-disable approach: TON is removed from the source-of-truth data structures (\`EXTERNAL_USDT_IDS\`, \`NETWORK_TO_USDT_ID\`, \`_ADDRESS_PATTERNS\`, \`ALLOWED_PAIRS\`). The existing \`CHANGELLY_ALLOW_ALL_PAIRS=1\` / \`SIDESHIFT_ALLOW_ALL_NETWORKS=1\` env-var overrides remain the escape hatch for debugging or power users.

#### Main Changes

- ♻️ Remove \`"usdton"\` from \`EXTERNAL_USDT_IDS\`, \`NETWORK_TO_USDT_ID\`, and \`_ADDRESS_PATTERNS\` in \`changelly.py\`
- ♻️ Remove \`("usdt", "ton")\` from \`ALLOWED_PAIRS\` in \`sideshift.py\`
- ♻️ Remove \`"ton"\` from \`click.Choice\` in \`cli/changelly.py\` and docstrings in \`cli/sideshift.py\`
- ♻️ Remove \`"ton"\` from the three \`external_network\` MCP enums in \`server.py\` (changelly_quote / changelly_send / changelly_receive)
- 📝 Update all prose references ("6 chains" → "5", "7 chains" → "6", TON removed from memo-network examples) across \`server.py\`, \`tools.py\`, \`cli/\`
- ✅ \`tests/test_changelly.py\`: \`ALLOWED_PAIRS\` size 12 → 10, drop TON parametrize rows, add \`"usdton"\` to the filter-drain assertion
- ✅ \`tests/test_sideshift.py\`: drop \`("usdt","ton")\` from allowlist parametrize; add \`assert "ton" not in\` for both filtered networks and tokenDetails (raw fixture keeps TON to validate the filter)
- 📝 Fix two stale numeric comments missed in first pass (\`changelly.py\` docstring "6 variants" → "5", \`test_sideshift.py\` class docstring "7 chains" → "6")

#### ⚠️ Breaking Changes

- Calling \`changelly_send\`, \`changelly_receive\`, or \`changelly_quote\` with \`external_network="ton"\` now raises \`ValueError\` / CLI \`UsageError\`.
- \`network_to_asset_id("ton")\` raises \`ValueError\`.
- SideShift send/receive with \`deposit_network="ton"\` or \`settle_network="ton"\` raises \`ValueError\`.
- In-flight TON swaps already on disk are **not** affected — \`changelly_status\` / \`sideshift_status\` do not re-validate the allowlist.

### Checklist

- [x] Added/updated tests (if necessary)
- [ ] Added/updated relevant documentation (if necessary)