### PR TITLE
Bump version to 0.4.1b1

### DIFF
--- a/src/aqua/__init__.py
+++ b/src/aqua/__init__.py
@@ -1,3 +1,3 @@
 """Agentic AQUA - Manage Liquid Network and Bitcoin wallets through AI assistants."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1b1"


### PR DESCRIPTION
### Purpose

Bump package version from `0.4.0` to `0.4.1b1` to allow publishing a new release to TestPyPI.
The previous `0.4.0` upload cannot be overwritten (PyPI policy); a new version number is required to trigger a fresh TestPyPI publish on the next merge to `main`.

#### Main Changes

- 📦️ Bump `__version__` in `src/aqua/__init__.py` from `0.4.0` → `0.4.1b1`

### Checklist

- [ ] No hardcoded values (they should go in constants.py, .env, or our database)
- [ ] Added/updated tests (if necessary)
- [ ] Added/updated relevant documentation (if necessary)