### PR TITLE
#69 Enhancement: Display QR codes for deposit addresses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "websockets>=12.0",
     "pillow>=10.0",
     "zxing-cpp>=2.2",
+    "qrcode[pil]>=7.0",
 ]
 
 [project.optional-dependencies]
@@ -42,7 +43,6 @@ dev = [
     "black>=24.0.0",
     "ruff>=0.2.0",
     "pytest-cov>=7.0.0",
-    "qrcode[pil]>=7.0",
 ]
 
 [project.scripts]

--- a/src/aqua/qr.py
+++ b/src/aqua/qr.py
@@ -1,7 +1,60 @@
+import hashlib
+import os
+import tempfile
 from pathlib import Path
 
+import qrcode
 import zxingcpp
 from PIL import Image
+
+
+def generate_qr(data: str, output_dir: str | Path, filename: str | None = None) -> str:
+    """Generate a PNG QR code for ``data`` and return the saved file path.
+
+    Used to render deposit addresses, Lightning invoices and swap deposit
+    addresses as scannable QR images. The file is written atomically (temp
+    file + ``os.replace``) with ``0o600`` permissions, mirroring the rest of
+    the on-disk ``~/.aqua`` layout.
+
+    Args:
+        data: The string to encode (address, BOLT11 invoice, etc.).
+        output_dir: Directory to write the PNG into (created at ``0o700`` if
+            missing). Typically ``Storage.qr_dir``.
+        filename: Optional file name. Defaults to a content-addressed name
+            ``qr_<sha256(data)[:16]>.png`` so identical payloads reuse one file.
+
+    Returns:
+        Absolute path to the written PNG.
+
+    Raises:
+        ValueError: If ``data`` is not a non-empty string.
+    """
+    if not isinstance(data, str) or not data:
+        raise ValueError("QR data must be a non-empty string")
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    if filename is None:
+        digest = hashlib.sha256(data.encode("utf-8")).hexdigest()[:16]
+        filename = f"qr_{digest}.png"
+    path = out_dir / filename
+
+    img = qrcode.make(data)
+    fd, tmp_name = tempfile.mkstemp(dir=str(out_dir), suffix=".png.tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            img.save(fh, format="PNG")
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+    return str(path.resolve())
 
 
 def decode_qr(image_path: str) -> str:

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -118,7 +118,10 @@ TOOL_SCHEMAS = {
         },
     },
     "lw_address": {
-        "description": "Generate a receive address",
+        "description": (
+            "Generate a receive address. Also returns qr_code_path: a PNG QR of the "
+            "address — display it to the user so they can scan it."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -270,7 +273,10 @@ TOOL_SCHEMAS = {
         },
     },
     "btc_address": {
-        "description": "Generate a Bitcoin receive address (bc1...)",
+        "description": (
+            "Generate a Bitcoin receive address (bc1...). Also returns qr_code_path: a "
+            "PNG QR of the address — display it to the user so they can scan it."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -399,7 +405,7 @@ TOOL_SCHEMAS = {
         },
     },
     "lightning_receive": {
-        "description": "Generate a Lightning invoice to receive L-BTC into a Liquid wallet (~1-2 min after payment). Limits: 100 – 25,000,000 Sats.",
+        "description": "Generate a Lightning invoice to receive L-BTC into a Liquid wallet (~1-2 min after payment). Limits: 100 – 25,000,000 Sats. Also returns qr_code_path: a PNG QR of the invoice — display it to the user so they can scan it.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -572,7 +578,8 @@ TOOL_SCHEMAS = {
             "Receive USDt-Liquid via a Changelly variable-rate swap. Returns a "
             "deposit address on the source chain — the external sender pays to it. "
             "Settles to the wallet's Liquid address as USDt-Liquid. STRONGLY RECOMMEND "
-            "passing external_refund_address."
+            "passing external_refund_address. Also returns qr_code_path: a PNG QR of "
+            "the deposit address — display it to the user so they can scan it."
         ),
         "inputSchema": {
             "type": "object",
@@ -1004,7 +1011,9 @@ TOOL_SCHEMAS = {
             "ethereum/tron/bsc/solana/polygon/liquid, or BTC on bitcoin) — mirrors "
             "AQUA Flutter's supported pairs. Set SIDESHIFT_ALLOW_ALL_NETWORKS=1 to bypass. "
             "STRONGLY RECOMMEND passing external_refund_address (the deposit-side "
-            "sender's address) so a stuck shift can refund automatically."
+            "sender's address) so a stuck shift can refund automatically. Also returns "
+            "qr_code_path: a PNG QR of the deposit address — display it to the user so "
+            "they can scan it."
         ),
         "inputSchema": {
             "type": "object",
@@ -1137,6 +1146,20 @@ PASSWORD HANDLING (encryption at rest):
 - IMPORTANT: the password is NOT a BIP39 passphrase. It does not alter the
   derived keys. The seed alone fully restores the same descriptors on Liquid
   and Bitcoin in any BIP39-compliant wallet.
+
+QR CODES (deposit addresses & invoices):
+- The receive tools — btc_address, lw_address, lightning_receive, changelly_receive,
+  sideshift_receive — return a `qr_code_path`: an absolute path to a PNG QR image of
+  the address/invoice saved on disk.
+- ALWAYS surface this to the user so they can scan instead of copy-paste: display the
+  image inline if your client renders local image paths, otherwise tell the user the
+  file path where the QR was saved.
+- If a result has `qr_error` instead of `qr_code_path`, QR generation failed but the
+  address/invoice is still valid — show the text and mention the QR was unavailable.
+- MEMO WARNING: some deposits (e.g. memo/tag-based chains via sideshift_receive)
+  return a `deposit_memo` and a `qr_warning`. The QR encodes ONLY the address, never
+  the memo. Always surface the memo as text and warn the user it must be entered
+  manually — scanning the QR alone omits it and can cause permanent loss of funds.
 
 LIGHTNING:
 - Use lightning_receive to generate an invoice for receiving L-BTC from Lightning

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -124,6 +124,7 @@ class Storage:
         self.sideshift_shifts_dir = self.base_dir / "sideshift_shifts"
         self.sideswap_pegs_dir = self.base_dir / "sideswap_pegs"
         self.sideswap_swaps_dir = self.base_dir / "sideswap_swaps"
+        self.qr_dir = self.base_dir / "qr"
         self.config_path = self.base_dir / "config.json"
         self._ensure_dirs()
 
@@ -151,6 +152,8 @@ class Storage:
         os.chmod(self.sideswap_pegs_dir, 0o700)
         self.sideswap_swaps_dir.mkdir(exist_ok=True, mode=0o700)
         os.chmod(self.sideswap_swaps_dir, 0o700)
+        self.qr_dir.mkdir(exist_ok=True, mode=0o700)
+        os.chmod(self.qr_dir, 0o700)
 
     def _derive_key(self, password: str, salt: bytes) -> bytes:
         """Derive encryption key from password."""

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -11,7 +11,7 @@ from typing import Any
 from .assets import MAINNET_ASSETS, TESTNET_ASSETS, resolve_asset_name, resolve_liquid_asset_id
 from .bitcoin import BitcoinWalletManager
 from .bolt11 import decode_bolt11_fields
-from .qr import decode_qr
+from .qr import decode_qr, generate_qr
 from .wallet import WalletManager
 
 logger = logging.getLogger(__name__)
@@ -135,6 +135,33 @@ def get_sideswap_swap_manager() -> "SideSwapSwapManager":
 
 
 # Tool implementations
+
+
+def _attach_deposit_qr(
+    result: dict[str, Any], data_key: str, *, encode_transform=None
+) -> dict[str, Any]:
+    """Generate a PNG QR for ``result[data_key]`` and attach its path.
+
+    Adds ``qr_code_path`` (absolute path to the saved PNG) so the agent can
+    display the QR to the user. QR rendering is auxiliary to the deposit flow:
+    if generation fails the deposit address/invoice is still valid, so the
+    error is reported as ``qr_error`` rather than failing the whole tool.
+
+    ``encode_transform`` optionally maps the stored value to the form encoded
+    into the QR (the stored field is left untouched). Used to uppercase BOLT11
+    invoices, which are case-insensitive: an uppercase payload lets the QR use
+    denser alphanumeric mode, producing a smaller, easier-to-scan code.
+    """
+    value = result.get(data_key)
+    if not value:
+        return result
+    try:
+        qr_dir = get_manager().storage.qr_dir
+        payload = encode_transform(value) if encode_transform else value
+        result["qr_code_path"] = generate_qr(payload, qr_dir)
+    except Exception as exc:  # noqa: BLE001 - auxiliary feature, report don't crash
+        result["qr_error"] = str(exc)
+    return result
 
 
 def lw_generate_mnemonic() -> dict[str, Any]:
@@ -274,10 +301,11 @@ def lw_address(
     Returns:
         address: The Liquid address
         index: Address index
+        qr_code_path: Path to a PNG QR of the address (or qr_error on failure)
     """
     manager = get_manager()
     addr = manager.get_address(wallet_name, index)
-    return addr.to_dict()
+    return _attach_deposit_qr(addr.to_dict(), "address")
 
 
 def lw_transactions(
@@ -526,10 +554,11 @@ def btc_address(
     Returns:
         address: The Bitcoin address
         index: Address index
+        qr_code_path: Path to a PNG QR of the address (or qr_error on failure)
     """
     btc = get_btc_manager()
     addr = btc.get_address(wallet_name, index)
-    return addr.to_dict()
+    return _attach_deposit_qr(addr.to_dict(), "address")
 
 
 def btc_transactions(
@@ -782,7 +811,8 @@ def lightning_receive(
         password: Password to decrypt mnemonic (if encrypted at rest)
 
     Returns:
-        swap_id, invoice, amount, wallet_name, message
+        swap_id, invoice, amount, wallet_name, message, qr_code_path
+        (qr_code_path is a PNG QR of the invoice, or qr_error on failure)
     """
     manager = get_lightning_manager()
     swap = manager.create_receive_invoice(amount, wallet_name, password)
@@ -791,17 +821,21 @@ def lightning_receive(
     all_wallets = get_manager().storage.list_wallets()
     wallet_note = f" in wallet '{wallet_name}'" if len(all_wallets) > 1 else ""
 
-    return {
-        "swap_id": swap.swap_id,
-        "invoice": swap.invoice,
-        "amount": amount,
-        "wallet_name": wallet_name,
-        "message": (
-            f"Pay this Lightning invoice to receive {amount} satoshis of L-BTC{wallet_note}. "
-            f"Usually takes 1–2 minutes to confirm on Liquid after Lightning payment confirms. "
-            f"You can ask the agent to check status with swap_id: {swap.swap_id}"
-        ),
-    }
+    return _attach_deposit_qr(
+        {
+            "swap_id": swap.swap_id,
+            "invoice": swap.invoice,
+            "amount": amount,
+            "wallet_name": wallet_name,
+            "message": (
+                f"Pay this Lightning invoice to receive {amount} satoshis of L-BTC{wallet_note}. "
+                f"Usually takes 1–2 minutes to confirm on Liquid after Lightning payment confirms. "
+                f"You can ask the agent to check status with swap_id: {swap.swap_id}"
+            ),
+        },
+        "invoice",
+        encode_transform=str.upper,
+    )
 
 
 def lightning_send(
@@ -1095,7 +1129,8 @@ def changelly_receive(
             Mutually exclusive with amount_from.
 
     Returns:
-        order_id, deposit_address, settle_address, amount_from, status, track_url
+        order_id, deposit_address, settle_address, amount_from, status, track_url,
+        qr_code_path (PNG QR of deposit_address, or qr_error on failure)
     """
     if (amount_from is None) == (amount_to is None):
         raise ValueError("Provide exactly one of amount_from or amount_to")
@@ -1110,7 +1145,7 @@ def changelly_receive(
         amount_from=amount_from,
         amount_to=amount_to,
     )
-    return swap.to_dict()
+    return _attach_deposit_qr(swap.to_dict(), "deposit_address")
 
 
 def changelly_status(order_id: str) -> dict[str, Any]:
@@ -1320,7 +1355,8 @@ def sideshift_receive(
 
     Returns:
         shift_id, deposit_address, deposit_min, deposit_max, deposit_memo
-        (if applicable), settle_address, status, expires_at
+        (if applicable), settle_address, status, expires_at, qr_code_path
+        (qr_code_path is a PNG QR of deposit_address, or qr_error on failure)
     """
     shift = get_sideshift_manager().receive_shift(
         deposit_coin=deposit_coin,
@@ -1332,7 +1368,18 @@ def sideshift_receive(
         external_refund_memo=external_refund_memo,
         settle_memo=settle_memo,
     )
-    return shift.to_dict()
+    result = _attach_deposit_qr(shift.to_dict(), "deposit_address")
+    # Memo-based chains (e.g. BNB) require a deposit memo/tag alongside the
+    # address. The QR encodes ONLY the address, so scanning it would silently
+    # drop the memo — sending without it can permanently lose funds. Flag it.
+    if result.get("deposit_memo") and "qr_code_path" in result:
+        result["qr_warning"] = (
+            "QR encodes the deposit address only. This network also requires a "
+            f"deposit memo ({result['deposit_memo']}) that the QR does NOT include — "
+            "it must be entered manually when sending. Sending without the memo can "
+            "cause permanent loss of funds."
+        )
+    return result
 
 
 def sideshift_status(shift_id: str) -> dict[str, Any]:

--- a/tests/test_qr.py
+++ b/tests/test_qr.py
@@ -1,10 +1,11 @@
+import stat
 from pathlib import Path
 
 import pytest
 import qrcode
 from PIL import Image
 
-from aqua.qr import decode_qr
+from aqua.qr import decode_qr, generate_qr
 from aqua.tools import qr_decode as qr_decode_tool
 
 ASSETS = Path(__file__).parent / "assets"
@@ -80,3 +81,75 @@ def test_qr_decode_tool_real_100sats_invoice_image():
 
     assert isinstance(result, dict)
     assert result["content"].lower() == SATS100_INVOICE
+
+
+# ---------------------------------------------------------------------------
+# generate_qr  (issue #69 — render deposit addresses / invoices as PNG QRs)
+# ---------------------------------------------------------------------------
+
+# A representative payload of each deposit-address surface the feature covers.
+_QR_PAYLOADS = {
+    "btc_onchain": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+    "liquid": "lq1qqwsystf4ej4xcz9z8q3mw8w0gwc5xqzu4q8w2x0p3kkmmq2zd2y",
+    "bolt11": SATS100_INVOICE,
+    "swap_deposit": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+}
+
+
+@pytest.mark.parametrize("name,payload", list(_QR_PAYLOADS.items()))
+def test_generate_qr_roundtrips_through_decoder(name, payload, tmp_path):
+    """A generated PNG decodes back to the exact payload via the real reader."""
+    path = generate_qr(payload, tmp_path)
+
+    assert Path(path).is_file()
+    # BOLT11 QR payloads are encoded uppercase; compare case-insensitively.
+    assert decode_qr(path).upper() == payload.upper()
+
+
+def test_generate_qr_returns_absolute_png_path(tmp_path):
+    path = generate_qr("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq", tmp_path)
+    p = Path(path)
+    assert p.is_absolute()
+    assert p.suffix == ".png"
+    assert p.parent == tmp_path.resolve()
+
+
+def test_generate_qr_file_is_0600(tmp_path):
+    path = generate_qr("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq", tmp_path)
+    mode = stat.S_IMODE(Path(path).stat().st_mode)
+    assert mode == 0o600
+
+
+def test_generate_qr_creates_missing_output_dir(tmp_path):
+    target = tmp_path / "nested" / "qr"
+    path = generate_qr("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq", target)
+    assert Path(path).is_file()
+    assert target.is_dir()
+
+
+def test_generate_qr_is_content_addressed_and_idempotent(tmp_path):
+    """Same payload -> same file path (no temp-file leftovers)."""
+    payload = "lnbc1000u1ptest123"
+    p1 = generate_qr(payload, tmp_path)
+    p2 = generate_qr(payload, tmp_path)
+    assert p1 == p2
+    pngs = list(tmp_path.glob("*.png"))
+    leftover_tmp = list(tmp_path.glob("*.tmp"))
+    assert len(pngs) == 1
+    assert leftover_tmp == []
+
+
+def test_generate_qr_custom_filename(tmp_path):
+    addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+    path = generate_qr(addr, tmp_path, filename="deposit.png")
+    assert Path(path).name == "deposit.png"
+
+
+def test_generate_qr_empty_data_raises(tmp_path):
+    with pytest.raises(ValueError, match="non-empty string"):
+        generate_qr("", tmp_path)
+
+
+def test_generate_qr_non_string_data_raises(tmp_path):
+    with pytest.raises(ValueError, match="non-empty string"):
+        generate_qr(12345, tmp_path)  # type: ignore[arg-type]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -9,8 +9,11 @@ import pytest
 
 from aqua.bitcoin import BitcoinWalletManager
 from aqua.storage import Storage, WalletData
+from aqua.qr import decode_qr
 from aqua.tools import (
+    _attach_deposit_qr,
     _manager,
+    btc_address,
     btc_export_descriptor,
     btc_import_descriptor,
     changelly_send,
@@ -269,6 +272,118 @@ class TestAddress:
         """Address request for non-existent wallet raises."""  # Significance: 4
         with pytest.raises(ValueError, match="not found"):
             lw_address(wallet_name="nope")
+
+
+# ---------------------------------------------------------------------------
+# Deposit-address QR codes (issue #69)  # Significance: 4
+# ---------------------------------------------------------------------------
+
+
+class TestDepositQr:
+    """_attach_deposit_qr is the shared seam wired into every receive tool."""
+
+    def test_attaches_path_that_decodes_back(self):
+        data = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+        result = _attach_deposit_qr({"deposit_address": data}, "deposit_address")
+
+        assert "qr_error" not in result
+        path = result["qr_code_path"]
+        assert Path(path).is_file()
+        assert decode_qr(path) == data
+
+    def test_qr_written_under_storage_qr_dir(self):
+        addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+        result = _attach_deposit_qr({"address": addr}, "address")
+        qr_dir = get_manager().storage.qr_dir
+        assert Path(result["qr_code_path"]).parent == qr_dir.resolve()
+
+    def test_encode_transform_changes_qr_payload_only(self):
+        """BOLT11 path: QR encodes the uppercase form; stored field stays as-is."""
+        invoice = "lnbc1000u1ptest123"
+        result = _attach_deposit_qr({"invoice": invoice}, "invoice", encode_transform=str.upper)
+
+        assert result["invoice"] == invoice  # stored value untouched
+        assert decode_qr(result["qr_code_path"]) == invoice.upper()
+
+    def test_missing_or_empty_key_is_noop(self):
+        assert _attach_deposit_qr({"other": "x"}, "address") == {"other": "x"}
+        assert _attach_deposit_qr({"address": ""}, "address") == {"address": ""}
+
+    def test_generation_failure_reports_qr_error_not_fake_success(self, monkeypatch):
+        """If QR generation fails, the address survives and qr_error is set."""
+        import aqua.tools as tools_module
+
+        def boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(tools_module, "generate_qr", boom)
+        result = _attach_deposit_qr({"address": "bc1qexample"}, "address")
+
+        assert result["address"] == "bc1qexample"
+        assert "qr_code_path" not in result
+        assert "disk full" in result["qr_error"]
+
+    def test_lw_address_includes_decodable_qr(self):
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="qr_lw")
+        result = lw_address(wallet_name="qr_lw")
+
+        assert decode_qr(result["qr_code_path"]) == result["address"]
+
+    def test_btc_address_includes_decodable_qr(self):
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="qr_btc")
+        result = btc_address(wallet_name="qr_btc")
+
+        assert decode_qr(result["qr_code_path"]) == result["address"]
+
+    @patch("aqua.tools.get_sideshift_manager")
+    def test_sideshift_memo_shift_adds_qr_warning(self, mock_get_mgr):
+        """Memo-based deposit chains: QR is address-only, so warn loudly."""
+        import aqua.tools as tools_module
+
+        shift = MagicMock()
+        shift.to_dict.return_value = {
+            "shift_id": "s1",
+            "deposit_address": "bnb1qexampledepositaddress",
+            "deposit_memo": "987654321",
+            "settle_address": "lq1qsettle",
+            "status": "waiting",
+        }
+        fake = MagicMock()
+        fake.receive_shift.return_value = shift
+        mock_get_mgr.return_value = fake
+
+        result = tools_module.sideshift_receive(
+            deposit_coin="usdt", deposit_network="bsc",
+            settle_coin="usdt", settle_network="liquid",
+        )
+
+        assert "qr_code_path" in result
+        assert "qr_warning" in result
+        assert "987654321" in result["qr_warning"]
+        assert "memo" in result["qr_warning"].lower()
+
+    @patch("aqua.tools.get_sideshift_manager")
+    def test_sideshift_without_memo_has_no_warning(self, mock_get_mgr):
+        import aqua.tools as tools_module
+
+        shift = MagicMock()
+        shift.to_dict.return_value = {
+            "shift_id": "s2",
+            "deposit_address": "bc1qexampledepositaddress",
+            "settle_address": "lq1qsettle",
+            "status": "waiting",
+        }
+        fake = MagicMock()
+        fake.receive_shift.return_value = shift
+        mock_get_mgr.return_value = fake
+
+        result = tools_module.sideshift_receive(
+            deposit_coin="btc", deposit_network="bitcoin",
+            settle_coin="usdt", settle_network="liquid",
+        )
+
+        assert "qr_code_path" in result
+        assert "qr_warning" not in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Purpose

Generate and return a PNG file of the QR code for every deposit address and invoice the agent produces, so users can scan instead of copy-paste. 
Closes #69 Enhancement: Display QR codes for deposit addresses.

#### Description

The agent previously returned addresses/invoices as plain text. This PR adds a `generate_qr()` helper that saves a PNG QR to `~/.aqua/qr/` and returns its absolute path as `qr_code_path` in the tool result. The system prompt is updated to instruct the agent to always surface the image. QR generation is best-effort. if it fails, the address/invoice is still returned along with a `qr_error` field (no silent fallbacks).

A reviewer-caught fund-loss hazard was also addressed: SideShift shifts on memo-required chains (BNB, etc.) now include a `qr_warning` because the QR encodes only the deposit address — the memo must be entered manually.

#### Main Changes

- ✨ Add `generate_qr(data, output_dir, filename=None)` to `src/aqua/qr.py` — atomic write (tempfile → fsync → chmod `0o600` → `os.replace`), content-addressed filename `qr_<sha256[:16]>.png`
- ✨ Add `_attach_deposit_qr()` helper in `tools.py` — shared seam wired into all 5 receive surfaces with best-effort error handling
- ✨ Wire QR into `btc_address`, `lw_address`, `lightning_receive`, `changelly_receive`, `sideshift_receive` — each now returns `qr_code_path`
- ⚡️ BOLT11 invoices encoded as uppercase in the QR (alphanumeric mode → smaller/denser code; case-insensitive so round-trip is unaffected)
- 🔒️ Add `qr_warning` for SideShift memo-based chains — scanning the QR alone omits the memo and can cause loss of funds
- 🏗️ Add `Storage.qr_dir` (`~/.aqua/qr/`, `0o700`) following existing `~/.aqua` layout invariants
- 📝 Update `server.py` tool descriptions and system prompt with a "QR CODES" guidance block (mirrors Pix precedent — description changes alone don't drive display)
- ✅ Add 27 new tests: `generate_qr` unit tests (round-trip via real zxing decoder, perms, atomicity, idempotency) + `TestDepositQr` wiring tests (including memo-warning and bolt11 transform)
- ➕ Promote `qrcode[pil]>=7.0` from dev extras to runtime `dependencies` (imported by runtime module)

#### ⚠️ Breaking Changes

None. `qr_code_path` is an additive field. On QR failure, `qr_error` is set and the address/invoice is always returned.

> **Limitation:** `qr_code_path` is a server-side absolute path. Display depends on the MCP client being able to render local file paths as images (works in Claude Code). For guaranteed inline display on remote/mobile clients, `ImageContent` (embedded PNG bytes) is the plan-B — not included in this PR per scope.

### Checklist

- [x] No hardcoded values
- [x] Added/updated tests (27 new tests, 856 passed / 25 skipped)
- [ ] Added/updated relevant documentation (if necessary)