### PR TITLE
Update installation docs to uv tool install and bump version to 0.5.0b1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ MCP server and CLI for managing **Bitcoin** and **Liquid Network** wallets throu
 > **Quickest way:** just ask your AI agent directly:
 >
 > ```
-> Install this MCP server: https://github.com/jan3dev/agentic-aqua
+> Install this MCP server: https://pypi.org/project/agentic-aqua/
 > ```
 
-### Recommended (uvx)
+> **Python 3.13 required.**
 
-If you don't have `uvx` installed:
+### Recommended (uv tool install)
+
+If you don't have `uv` installed:
 
 ```bash
 # macOS/Linux
@@ -33,27 +35,35 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
-Configure Claude Desktop (`~/.claude/claude_desktop_config.json`):
+Install Agentic AQUA:
+
+```bash
+uv tool install --python 3.13 agentic-aqua
+```
+
+This creates a permanent `agentic-aqua` executable. Find its full path with:
+
+```bash
+which agentic-aqua
+# Example: /Users/yourname/.local/bin/agentic-aqua
+```
+
+Configure Claude Desktop (`~/.claude/claude_desktop_config.json`) using that path:
 
 ```json
 {
   "mcpServers": {
     "agentic-aqua": {
-      "command": "/full/path/to/uvx",
-      "args": ["agentic-aqua"]
+      "command": "/full/path/to/agentic-aqua",
+      "args": []
     }
   }
 }
 ```
 
-Find the full path to `uvx` with:
-
-```bash
-which uvx
-# Example: /Users/yourname/.local/bin/uvx
-```
-
 Restart Claude Desktop and you're ready to use Bitcoin and Liquid wallets.
+
+> **Updating / removing:** `uv tool upgrade agentic-aqua` to update, `uv tool uninstall agentic-aqua` to remove.
 
 ### For Developers
 
@@ -66,8 +76,6 @@ uv python install 3.13
 uv sync --python 3.13
 ```
 
-> **Why pin Python 3.13?** `bdkpython` currently publishes wheels for CPython 3.13, but not 3.14. If `uv sync` picks 3.14 automatically, installation fails on a clean machine.
-
 Configure Claude Desktop using the full path to `uv` (find with `which uv`):
 
 ```json
@@ -75,7 +83,7 @@ Configure Claude Desktop using the full path to `uv` (find with `which uv`):
   "mcpServers": {
     "agentic-aqua": {
       "command": "/full/path/to/uv",
-      "args": ["run", "--directory", "/absolute/path/to/agentic-aqua", "python", "-m", "aqua.server"]
+      "args": ["run", "--python", "3.13", "--directory", "/absolute/path/to/agentic-aqua", "python", "-m", "aqua.server"]
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.13,<3.14"
 authors = [
-    { name = "Andy", email = "andy@example.com" }
+    { name = "Andy", email = "andy@jan3.com" }
 ]
 keywords = ["liquid", "bitcoin", "wallet", "mcp", "ai", "lwk", "blockstream"]
 classifiers = [

--- a/src/aqua/__init__.py
+++ b/src/aqua/__init__.py
@@ -1,3 +1,3 @@
 """Agentic AQUA - Manage Liquid Network and Bitcoin wallets through AI assistants."""
 
-__version__ = "0.4.2"
+__version__ = "0.5.0b1"


### PR DESCRIPTION
### Purpose

Update the README installation guide to use `uv tool install` instead of the deprecated `uvx` approach, and bump the package version to `0.5.0b1`.

#### Main Changes

- 📝 Replace `uvx`-based install with `uv tool install --python 3.13 agentic-aqua` — cleaner permanent install with explicit Python version
- 📝 Update "quickest way" snippet to point to PyPI (`pypi.org/project/agentic-aqua/`) instead of the GitHub repo
- 📝 Add Python 3.13 required note upfront in the install section
- 📝 Add upgrade/uninstall instructions (`uv tool upgrade` / `uv tool uninstall`)
- 📝 Pin `--python 3.13` in the developer `uv run` Claude Desktop config args
- ✨ Bump version `0.4.2` → `0.5.0b1`

### Checklist

- [ ] No hardcoded values (they should go in constants.py, .env, or our database)
- [ ] Added/updated tests (if necessary)
- [x] Added/updated relevant documentation (if necessary)