### PR TITLE
Fix dust generation on Sideswap + lw_sweep and btc_sweep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "pillow>=10.0",
     "zxing-cpp>=2.2",
     "qrcode[pil]>=7.0",
-    "wallycore>=1.5.3",
+    "wallycore>=1.5.4",
 ]
 
 [project.optional-dependencies]

--- a/src/aqua/bitcoin.py
+++ b/src/aqua/bitcoin.py
@@ -501,3 +501,67 @@ class BitcoinWalletManager:
         client = self._get_clients(network)[0]
         _retry_on_network_error(lambda: client.broadcast(tx))
         return tx.compute_txid().serialize()[::-1].hex()
+
+    def sweep(
+        self,
+        wallet_name: str,
+        address: str,
+        fee_rate: Optional[int] = None,
+        password: Optional[str] = None,
+    ) -> str:
+        """Sweep the entire Bitcoin balance to ``address``. Returns txid.
+
+        Wraps BDK's ``drain_to`` + ``drain_wallet`` to consume every available
+        UTXO and route the remainder to the destination, with the on-chain
+        fee deducted from the inputs — 0 sats remain in the wallet.
+
+        ``password`` decrypts the at-rest mnemonic when the wallet was
+        imported with one. NOT a BIP39 passphrase.
+        """
+        wallet_data = self.storage.load_wallet(wallet_name)
+        if not wallet_data:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+        if wallet_data.watch_only:
+            raise ValueError("Cannot sign with watch-only wallet")
+        if fee_rate is not None and fee_rate <= 0:
+            raise ValueError("Fee rate must be positive")
+        if not wallet_data.encrypted_mnemonic:
+            raise ValueError(
+                "No mnemonic available for signing (import wallet with mnemonic to enable sending)"
+            )
+        needs_password = self.storage.requires_user_password(wallet_data.encrypted_mnemonic)
+        if needs_password and not password:
+            raise ValueError("Password required to decrypt mnemonic")
+        mnemonic = self.storage.read_and_migrate_mnemonic(wallet_data, password)
+        wallet, network = self._get_wallet_with_signer(wallet_name, mnemonic)
+        self.sync_wallet(wallet_name)
+
+        if wallet.balance().total.to_sat() <= 0:
+            raise ValueError("No BTC to sweep")
+
+        net = _network_bdk(network)
+        bdk_address = bdk.Address(address, net)
+        spk = bdk_address.script_pubkey()
+
+        builder = bdk.TxBuilder()
+        builder = builder.drain_to(spk)
+        builder = builder.drain_wallet()
+        if fee_rate is not None:
+            builder = builder.fee_rate(bdk.FeeRate.from_sat_per_vb(fee_rate))
+
+        psbt = builder.finish(wallet)
+        sign_opts = bdk.SignOptions(
+            trust_witness_utxo=True,
+            assume_height=None,
+            allow_all_sighashes=False,
+            try_finalize=True,
+            sign_with_tap_internal_key=True,
+            allow_grinding=True,
+        )
+        finalized = wallet.sign(psbt, sign_opts)
+        if not finalized:
+            raise RuntimeError("Failed to finalize PSBT")
+        tx = psbt.extract_tx()
+        client = self._get_clients(network)[0]
+        _retry_on_network_error(lambda: client.broadcast(tx))
+        return tx.compute_txid().serialize()[::-1].hex()

--- a/src/aqua/cli/btc.py
+++ b/src/aqua/cli/btc.py
@@ -8,6 +8,7 @@ from ..tools import (
     btc_export_descriptor,
     btc_import_descriptor,
     btc_send,
+    btc_sweep,
     btc_transactions,
 )
 from .output import run_tool
@@ -76,6 +77,44 @@ def send(ctx, wallet_name, address, amount, fee_rate, password_stdin):
                 "wallet_name": wallet_name,
                 "address": address,
                 "amount": amount,
+                "fee_rate": fee_rate,
+                "password": password,
+            },
+        ),
+    )
+
+
+@btc.command("sweep")
+@click.option("--wallet-name", required=True, help="Name of the wallet.")
+@click.option("--address", required=True, help="Destination Bitcoin address (bc1...).")
+@click.option("--fee-rate", type=int, default=None, help="Fee rate in sat/vB.")
+@click.option(
+    "--password-stdin",
+    "password_stdin",
+    is_flag=True,
+    default=False,
+    help=(
+        "Read wallet password from stdin (piped) or prompt interactively. "
+        "Without this flag, falls back to the AQUA_PASSWORD environment variable, "
+        "then to no password."
+    ),
+)
+@click.pass_obj
+def sweep(ctx, wallet_name, address, fee_rate, password_stdin):
+    """Sweep the entire Bitcoin balance to one address.
+
+    Fee is deducted from the inputs — 0 sats remain after broadcast.
+    """
+    password = resolve_secret(
+        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
+    )
+    run_tool(
+        ctx,
+        lambda: handle_password_retry(
+            btc_sweep,
+            {
+                "wallet_name": wallet_name,
+                "address": address,
                 "fee_rate": fee_rate,
                 "password": password,
             },

--- a/src/aqua/cli/liquid.py
+++ b/src/aqua/cli/liquid.py
@@ -7,6 +7,7 @@ from ..tools import (
     get_manager,
     lw_address,
     lw_balance,
+    lw_sweep,
     lw_export_descriptor,
     lw_import_descriptor,
     lw_send,
@@ -158,6 +159,68 @@ def send_asset(ctx, wallet_name, address, amount, asset_id, asset_ticker, passwo
                 "wallet_name": wallet_name,
                 "address": address,
                 "amount": amount,
+                "asset_id": asset_id,
+                "password": password,
+            },
+        ),
+    )
+
+
+@liquid.command("sweep")
+@click.option("--wallet-name", required=True, help="Name of the wallet.")
+@click.option("--address", required=True, help="Destination Liquid address.")
+@click.option(
+    "--asset-id",
+    default=None,
+    help="Asset ID (hex). Omit for an L-BTC sweep.",
+)
+@click.option(
+    "--asset-ticker",
+    default=None,
+    help="Asset ticker (resolved via the registry). Omit for L-BTC.",
+)
+@click.option(
+    "--password-stdin",
+    "password_stdin",
+    is_flag=True,
+    default=False,
+    help=(
+        "Read wallet password from stdin (piped) or prompt interactively. "
+        "Without this flag, falls back to the AQUA_PASSWORD environment variable, "
+        "then to no password."
+    ),
+)
+@click.pass_obj
+def sweep(ctx, wallet_name, address, asset_id, asset_ticker, password_stdin):
+    """Sweep the entire L-BTC balance (or full asset balance) to one address.
+
+    Fee is deducted from the inputs — 0 sats of the targeted balance remain
+    after broadcast. Asset sweeps leave L-BTC change in the wallet; run again
+    without --asset-id / --asset-ticker to also empty L-BTC.
+    """
+    if asset_id and asset_ticker:
+        raise click.UsageError("Provide at most one of --asset-id or --asset-ticker.")
+    if asset_ticker:
+        wallet_data = get_manager().storage.load_wallet(wallet_name)
+        if wallet_data is None:
+            raise click.UsageError(f"Wallet '{wallet_name}' not found.")
+        info = lookup_asset_by_ticker(asset_ticker, wallet_data.network)
+        if info is None:
+            raise click.UsageError(
+                f"Unknown ticker '{asset_ticker}' on {wallet_data.network}. "
+                "Run 'aqua-cli liquid assets' to list known tickers."
+            )
+        asset_id = info.asset_id
+    password = resolve_secret(
+        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
+    )
+    run_tool(
+        ctx,
+        lambda: handle_password_retry(
+            lw_sweep,
+            {
+                "wallet_name": wallet_name,
+                "address": address,
                 "asset_id": asset_id,
                 "password": password,
             },

--- a/src/aqua/features.py
+++ b/src/aqua/features.py
@@ -66,6 +66,7 @@ CLI_COMMAND_TO_MCP_TOOL: dict[tuple[str, str], str] = {
     ("liquid", "transactions"): "lw_transactions",
     ("liquid", "send"): "lw_send",
     ("liquid", "send-asset"): "lw_send_asset",
+    ("liquid", "sweep"): "lw_sweep",
     ("liquid", "assets"): "lw_list_assets",
     ("liquid", "tx-status"): "lw_tx_status",
     ("liquid", "import-descriptor"): "lw_import_descriptor",
@@ -76,6 +77,7 @@ CLI_COMMAND_TO_MCP_TOOL: dict[tuple[str, str], str] = {
     ("btc", "address"): "btc_address",
     ("btc", "transactions"): "btc_transactions",
     ("btc", "send"): "btc_send",
+    ("btc", "sweep"): "btc_sweep",
     ("btc", "import-descriptor"): "btc_import_descriptor",
     ("btc", "export-descriptor"): "btc_export_descriptor",
 

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -209,6 +209,43 @@ TOOL_SCHEMAS = {
             "required": ["wallet_name", "address", "amount", "asset_id"],
         },
     },
+    "lw_sweep": {
+        "description": (
+            "Sweep the entire L-BTC balance (or full balance of a specific Liquid "
+            "asset) to one address. Fee is deducted from the inputs — leaves 0 "
+            "sats of the targeted balance in the wallet. Use this whenever the "
+            "user says 'send all', 'sweep', 'drain', 'empty wallet', or 'move "
+            "everything' on Liquid. Asset sweep note: with `asset_id` set, the "
+            "asset balance goes to 0 in one tx but L-BTC change may remain "
+            "because the fee was paid in L-BTC — call `lw_sweep` again without "
+            "`asset_id` to also empty L-BTC."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "wallet_name": {
+                    "type": "string",
+                    "description": "Name of the wallet",
+                },
+                "address": {
+                    "type": "string",
+                    "description": "Destination Liquid address",
+                },
+                "asset_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional asset ID (hex). Omit for an L-BTC sweep. "
+                        "Passing the L-BTC policy asset id is equivalent to omitting."
+                    ),
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password to decrypt mnemonic (if encrypted at rest)",
+                },
+            },
+            "required": ["wallet_name", "address"],
+        },
+    },
     "lw_tx_status": {
         "description": "Get the status of a Liquid transaction. Accepts a txid or a Blockstream explorer URL (e.g. https://blockstream.info/liquid/tx/abc123...)",
         "inputSchema": {
@@ -337,6 +374,36 @@ TOOL_SCHEMAS = {
                 },
             },
             "required": ["wallet_name", "address", "amount"],
+        },
+    },
+    "btc_sweep": {
+        "description": (
+            "Sweep the entire Bitcoin balance to one address. Fee is deducted "
+            "from the inputs — leaves 0 sats in the wallet. Use this whenever "
+            "the user says 'send all', 'sweep', 'drain', 'empty wallet', or "
+            "'move everything' on Bitcoin."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "wallet_name": {
+                    "type": "string",
+                    "description": "Name of the wallet",
+                },
+                "address": {
+                    "type": "string",
+                    "description": "Destination Bitcoin address (bc1...)",
+                },
+                "fee_rate": {
+                    "type": "integer",
+                    "description": "Optional fee rate in Sat/vB",
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password to decrypt mnemonic (if encrypted at rest)",
+                },
+            },
+            "required": ["wallet_name", "address"],
         },
     },
     "btc_import_descriptor": {

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -94,14 +94,14 @@ QUOTE_WAIT_SECONDS = 10.0
 
 # Reserved for the Liquid network fee on a peg-out broadcast. Liquid runs at a
 # fixed 0.1 sat/vB; a standard L-BTC send is ~260–600 vB → ~26–60 sats on-chain
-# in practice (empirically confirmed). 100 sats is a comfortable upper bound
-# that absorbs occasional fee variance without locking up multiples of the
-# typical fee. Used by the peg-out preflight balance check and as the L-BTC-fee
-# headroom added on top of DUST_THRESHOLD_SATS when selecting coins for an
-# L-BTC swap send (the dealer subtracts the on-chain fee from change, so we
-# need an extra cushion above the dust threshold so the post-fee change still
-# clears dust).
-LIQUID_FEE_RESERVE_SATS = 100
+# in practice, but atomic swap txs are larger (extra inputs/outputs from the
+# dealer) and can reach the ~200-sat range. 200 sats is a comfortable upper
+# bound that prevents balance-check pass / broadcast-fail races and gives the
+# swap-side selector enough headroom that the dealer's fee subtraction can't
+# push our change below DUST_THRESHOLD_SATS. Used by the peg-out preflight
+# balance check and as the L-BTC-fee headroom added on top of
+# DUST_THRESHOLD_SATS when selecting coins for an L-BTC swap send.
+LIQUID_FEE_RESERVE_SATS = 200
 
 # Minimum value (in sats) we'll accept on a change output coming back from the
 # SideSwap dealer. The economic break-even on Liquid is ~25 sats: a confidential

--- a/src/aqua/sideswap.py
+++ b/src/aqua/sideswap.py
@@ -92,11 +92,28 @@ PEG_RECOMMENDATION_THRESHOLD_SATS = 1_000_000
 WS_TIMEOUT_SECONDS = 30.0
 QUOTE_WAIT_SECONDS = 10.0
 
-# Reserved for the Liquid network fee on a peg-out broadcast. Liquid fees are
-# fixed-rate and tiny (~50–100 sats in practice); 200 sats is a comfortable
-# upper bound that prevents balance-check pass / broadcast-fail races without
-# blocking realistic peg-outs.
-LIQUID_FEE_RESERVE_SATS = 200
+# Reserved for the Liquid network fee on a peg-out broadcast. Liquid runs at a
+# fixed 0.1 sat/vB; a standard L-BTC send is ~260–600 vB → ~26–60 sats on-chain
+# in practice (empirically confirmed). 100 sats is a comfortable upper bound
+# that absorbs occasional fee variance without locking up multiples of the
+# typical fee. Used by the peg-out preflight balance check and as the L-BTC-fee
+# headroom added on top of DUST_THRESHOLD_SATS when selecting coins for an
+# L-BTC swap send (the dealer subtracts the on-chain fee from change, so we
+# need an extra cushion above the dust threshold so the post-fee change still
+# clears dust).
+LIQUID_FEE_RESERVE_SATS = 100
+
+# Minimum value (in sats) we'll accept on a change output coming back from the
+# SideSwap dealer. The economic break-even on Liquid is ~25 sats: a confidential
+# input is ~250 vB and Liquid's fixed 0.1 sat/vB fee rate gives a ~25-sat cost
+# to spend it. 50 sats is ~2× that break-even — comfortable safety margin while
+# still freeing up sub-50-sat slivers as fair-game change. NOT anchored to
+# Bitcoin's 546-sat dust policy (Bitcoin fee rates are 10–100× Liquid's, so
+# 546 was an order of magnitude too conservative here and was producing the
+# very dust it was meant to prevent). The coin-selector dodges this zone by
+# auto-bumping send_amount to consume the would-be-dust leftover, and the
+# verifier double-checks the dealer's PSET to catch anything that slips through.
+DUST_THRESHOLD_SATS = 50
 
 
 def _validate_btc_address(address: str, network: str) -> None:
@@ -383,7 +400,7 @@ def unblind_dealer_outputs(
     receive_ephemeral_sk: Optional[str],
     change_ephemeral_sk: Optional[str],
     addr_family: str = "lq",
-) -> None:
+) -> dict[str, int]:
     """Cryptographically verify dealer-paid outputs against the on-chain commitments.
 
     SideSwap's `mkt::*` dealer pays the taker via outputs blinded with
@@ -395,10 +412,17 @@ def unblind_dealer_outputs(
     than what the PSET's explicit fields claim. `PsetVerificationError` is
     raised on any mismatch.
 
-    This function exists purely for that security side-effect — its caller
-    relies on `wollet.pset_details(pset).balance()` (after `add_details`) as
-    the source of truth for the balances dict. Wally's job is to ensure
+    The primary purpose is this security side-effect — the caller relies on
+    `wollet.pset_details(pset).balance()` (after `add_details`) as the source
+    of truth for the aggregated balances dict. Wally's job is to ensure
     LWK's explicit-value reading reflects the cryptographic reality.
+
+    Returns a mapping from output role to the unblinded sats value, so
+    callers can enforce policy (e.g. dust check) on a per-output value that
+    has been confirmed honest by the commitment recomputation below. Keys:
+        - "recv": the dealer's receive-side output to the taker
+        - "change": the dealer's change-side output back to the taker
+    Only the roles actually present in the PSET appear in the returned dict.
 
     Implementation mirrors `sideswap_common::pset::swap_amount::get_swap_amount`
     in Rust: for each PSET output whose scriptPubKey matches our recv/change
@@ -411,11 +435,11 @@ def unblind_dealer_outputs(
     SideSwap's protocol needs `ECDH(dealer_ephemeral_sk, recv_addr_blinding_pk)`,
     which only libwally exposes at this layer.
 
-    No-op when no ephemeral keys are supplied (peg flows / legacy orderbook
-    flows that don't use ephemeral blinding).
+    Returns an empty dict when no ephemeral keys are supplied (peg flows /
+    legacy orderbook flows that don't use ephemeral blinding).
     """
     if not receive_ephemeral_sk and not change_ephemeral_sk:
-        return
+        return {}
 
     # Decode addresses up front so we can match by scriptPubKey bytes.
     def _addr_spk_and_bpk(addr: Optional[str]) -> tuple[Optional[bytes], Optional[bytes]]:
@@ -432,6 +456,7 @@ def unblind_dealer_outputs(
 
     psbt = wally.psbt_from_base64(pset_b64)
     num_outputs = wally.psbt_get_num_outputs(psbt)
+    unblinded_by_role: dict[str, int] = {}
 
     for i in range(num_outputs):
         try:
@@ -445,8 +470,10 @@ def unblind_dealer_outputs(
         # calls) — that's harmless because we just try receive first.
         if recv_spk is not None and spk == recv_spk and receive_ephemeral_sk:
             sk_hex, bpk = receive_ephemeral_sk, recv_bpk
+            role = "recv"
         elif change_spk is not None and spk == change_spk and change_ephemeral_sk:
             sk_hex, bpk = change_ephemeral_sk, change_bpk
+            role = "change"
         else:
             continue
 
@@ -512,6 +539,24 @@ def unblind_dealer_outputs(
                 f"rangeproof message decodes to a different value than the "
                 f"on-chain value commitment opens to (script {spk.hex()})"
             )
+
+        # Commitments verified — value_out is the trusted unblinded sats for
+        # this output. Record it so callers can enforce per-output policy
+        # (e.g. dust threshold on the change output) against a value that
+        # cannot have been spoofed by the dealer.
+        #
+        # SideSwap's market protocol creates at most one output per role;
+        # if we ever see two outputs collapsing to the same scriptPubKey we
+        # refuse to sign rather than silently overwrite (which would let a
+        # second, possibly-dust, output hide behind the first).
+        if role in unblinded_by_role:
+            raise PsetVerificationError(
+                f"PSET output {i} is a second {role!r} output (script "
+                f"{spk.hex()}); SideSwap dealer should emit at most one"
+            )
+        unblinded_by_role[role] = int(value_out)
+
+    return unblinded_by_role
 
 
 # ---------------------------------------------------------------------------
@@ -890,7 +935,9 @@ def select_swap_utxos(
     utxos: list,
     send_asset: str,
     send_amount: int,
-) -> list[dict]:
+    *,
+    dust_threshold: int = DUST_THRESHOLD_SATS,
+) -> tuple[list[dict], int]:
     """Pick UTXOs of `send_asset` covering `send_amount`, formatted for SideSwap.
 
     Filters apply per `sideswap_lwk` reference (`sideswap_lwk/src/lib.rs`):
@@ -899,16 +946,38 @@ def select_swap_utxos(
     - We don't filter by script type here because the wallet's descriptor is
       always wpkh (BIP84 m/84'/1776'/0') in agentic-aqua.
 
+    Anti-dust behaviour: SideSwap's dealer creates the change output
+    unilaterally, sized to `accumulated - send_amount` (modulo on-chain fee).
+    If the user's UTXO set produces a sub-`dust_threshold` leftover, the
+    dealer emits a dust change output that costs more to spend than it's
+    worth. To prevent this, when `0 < accumulated - send_amount <
+    dust_threshold`, we return an `effective_send_amount` equal to the full
+    accumulated value — the caller passes the bumped amount to the dealer,
+    no change output is created, and the dust is consumed into the swap.
+    The bump is bounded above by `dust_threshold - 1` sats. Adding more
+    inputs to dodge dust would be strictly worse (each Liquid input is
+    ~250 vB at 0.1 sat/vB ≈ 25 sats, so for any dust_threshold ≥ ~25 the
+    bump is cheaper than an extra input).
+
     Args:
         utxos: List of `lwk.WalletTxOut` (or compatible objects exposing
             `.outpoint`, `.unblinded` with `.asset`, `.value`, `.asset_bf`,
             `.value_bf`).
         send_asset: Asset id to send.
         send_amount: Total sats to cover.
+        dust_threshold: Inclusive lower bound on an acceptable change output
+            value. Defaults to `DUST_THRESHOLD_SATS`.
 
     Returns:
-        List of dicts in the SideSwap `Utxo` shape:
-        {txid, vout, asset, asset_bf, value, value_bf, redeem_script: null}.
+        Tuple of (selected, effective_send_amount):
+        - selected: list of dicts in the SideSwap `Utxo` shape:
+          {txid, vout, asset, asset_bf, value, value_bf, redeem_script: null}.
+        - effective_send_amount: either the original `send_amount` (the
+          common case), or the full `accumulated` value when a bump was
+          required to avoid dust. Callers MUST use this value downstream
+          (passed to the dealer, fed into the PSET verifier, persisted on
+          the swap record) — passing the original send_amount would re-introduce
+          the dust the bump was meant to prevent.
 
     Raises:
         ValueError if there isn't enough confidential balance to cover send_amount.
@@ -949,7 +1018,12 @@ def select_swap_utxos(
         )
         accumulated += int(unblinded.value())
         if accumulated >= send_amount:
-            return selected
+            change = accumulated - send_amount
+            if change == 0 or change >= dust_threshold:
+                return selected, send_amount
+            # 0 < change < dust_threshold: bump send_amount to consume the
+            # would-be-dust leftover. No change output will be created.
+            return selected, accumulated
 
     raise ValueError(
         f"Insufficient confidential balance for {send_asset[:8]}…: "
@@ -1333,9 +1407,10 @@ class SideSwapPegManager:
             logger.warning("Skipping min-amount check: %s", e)
 
         # Balance check: a peg-out broadcast pays a Liquid network fee on top
-        # of `amount`. Liquid fees are tiny and stable (~50–100 sats); use a
-        # small reservation so a wallet whose balance equals `amount` exactly
-        # doesn't fail at broadcast time with the actual-fee error.
+        # of `amount`. Liquid fees are tiny and stable (~26–60 sats for a
+        # standard L-BTC send); LIQUID_FEE_RESERVE_SATS of headroom keeps a
+        # wallet whose balance equals `amount` exactly from failing at
+        # broadcast time with the actual-fee error.
         try:
             balances = self.wallet_manager.get_balance(wallet_name)
             lbtc_balance = next((b.amount for b in balances if b.ticker == "L-BTC"), 0)
@@ -1600,7 +1675,38 @@ class SideSwapSwapManager:
         # Build the inputs/addresses up-front; mkt::* wants them on
         # start_quotes (not as a follow-up call).
         wollet = self.wallet_manager._get_wollet(wallet_name)
-        inputs = select_swap_utxos(wollet.utxos(), send_asset, send_amount)
+        # select_swap_utxos may bump send_amount up to consume a would-be-dust
+        # leftover (see its docstring). The bumped value flows through to the
+        # dealer quote, the verifier, and the persisted SideSwapSwap record
+        # so the user's stored swap accurately reflects what was actually
+        # sent.
+        #
+        # On L-BTC sends the dealer subtracts the on-chain fee from the
+        # change output, so a leftover that looks safe to the bare
+        # DUST_THRESHOLD check can still emerge as sub-dust on-chain.
+        # Reserve LIQUID_FEE_RESERVE_SATS of headroom on the selector's
+        # threshold for that direction; on asset sends the fee lives on the
+        # dealer's L-BTC side and our change is unaffected, so no headroom
+        # is needed.
+        selection_dust_threshold = DUST_THRESHOLD_SATS
+        if send_asset == policy_asset:
+            selection_dust_threshold += LIQUID_FEE_RESERVE_SATS
+        inputs, effective_send_amount = select_swap_utxos(
+            wollet.utxos(),
+            send_asset,
+            send_amount,
+            dust_threshold=selection_dust_threshold,
+        )
+        if effective_send_amount != send_amount:
+            logger.info(
+                "sideswap: bumping send_amount %d → %d sats (+%d) to consume "
+                "would-be-dust change on %s",
+                send_amount,
+                effective_send_amount,
+                effective_send_amount - send_amount,
+                send_asset[:8],
+            )
+            send_amount = effective_send_amount
         # `wollet.address(None)` returns the next-unused index but doesn't
         # consume it, so calling it twice returns the same address. The
         # dealer needs a distinct change scriptPubKey on the reverse-direction
@@ -1819,13 +1925,28 @@ class SideSwapSwapManager:
         # check to ensure those fields are truthful. The helper raises
         # PsetVerificationError on any mismatch; tests stub it out via
         # `_patch_swap_layers`.
-        unblind_dealer_outputs(
+        unblinded_by_role = unblind_dealer_outputs(
             pset_b64,
             recv_addr=recv_addr,
             change_addr=change_addr,
             receive_ephemeral_sk=receive_ephemeral_sk,
             change_ephemeral_sk=change_ephemeral_sk,
         )
+
+        # Defensive dust check: select_swap_utxos avoids picking inputs that
+        # would produce a sub-`DUST_THRESHOLD_SATS` change output, but the
+        # dealer ultimately controls the PSET's output values. Reject any
+        # change output in the dust zone so we never sign a tx that leaves
+        # an unspendable scrap in the user's wallet (the original PR #99
+        # report: a 1-sat L-BTC change output). The unblinded value here is
+        # the value Wally just confirmed matches the on-chain commitment, so
+        # this check is on a trusted number — not on the dealer's PSET claim.
+        change_value = unblinded_by_role.get("change", 0)
+        if 0 < change_value < DUST_THRESHOLD_SATS:
+            raise PsetVerificationError(
+                f"PSET creates dust change output of {change_value} sats "
+                f"(below dust threshold {DUST_THRESHOLD_SATS}); refusing to sign"
+            )
 
         verify_pset_balances(
             balances,

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -407,16 +407,8 @@ def lw_sweep(
     password: str | None = None,
 ) -> dict[str, Any]:
     """
-    Sweep the entire L-BTC balance (or full balance of a specific Liquid asset)
-    to a single address. Call this when the user says "send all", "sweep",
-    "drain", "empty wallet", or "move everything" — the network fee is deducted
-    from the inputs, so 0 sats of the targeted balance remain in the wallet.
-
-    With ``asset_id`` omitted, sweeps every L-BTC input → 0 L-BTC change.
-    With ``asset_id`` set to a non-L-BTC Liquid asset, sends the entire asset
-    balance to ``address`` in one tx; L-BTC change may remain because the fee
-    is paid from L-BTC. Call ``lw_sweep`` again without ``asset_id`` to also
-    empty the L-BTC remainder.
+    Sweep the entire L-BTC balance (or full balance of a Liquid asset) to one
+    address. Fee paid from the inputs; 0 sats of the targeted balance remain.
 
     Args:
         wallet_name: Name of the wallet
@@ -425,7 +417,10 @@ def lw_sweep(
         password: Password to decrypt mnemonic (if encrypted at rest)
 
     Returns:
-        txid, address, and (for asset sweeps) the ticker / asset_id swept.
+        txid: Transaction ID
+        address: Destination address
+        ticker: "L-BTC" or the resolved asset ticker
+        asset_id: Only set for asset sweeps
     """
     manager = get_manager()
     txid = manager.sweep(wallet_name, address, asset_id, password)
@@ -699,10 +694,8 @@ def btc_sweep(
     password: str | None = None,
 ) -> dict[str, Any]:
     """
-    Sweep the entire Bitcoin balance to a single address. Call this when the
-    user says "send all", "sweep", "drain", "empty wallet", or "move
-    everything" — the network fee is deducted from the inputs, so 0 sats
-    remain in the wallet.
+    Sweep the entire Bitcoin balance to one address. Fee paid from the inputs;
+    0 sats remain.
 
     Args:
         wallet_name: Name of the wallet

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -400,6 +400,44 @@ def lw_send_asset(
     }
 
 
+def lw_sweep(
+    wallet_name: str,
+    address: str,
+    asset_id: str | None = None,
+    password: str | None = None,
+) -> dict[str, Any]:
+    """
+    Sweep the entire L-BTC balance (or full balance of a specific Liquid asset)
+    to a single address. Call this when the user says "send all", "sweep",
+    "drain", "empty wallet", or "move everything" — the network fee is deducted
+    from the inputs, so 0 sats of the targeted balance remain in the wallet.
+
+    With ``asset_id`` omitted, sweeps every L-BTC input → 0 L-BTC change.
+    With ``asset_id`` set to a non-L-BTC Liquid asset, sends the entire asset
+    balance to ``address`` in one tx; L-BTC change may remain because the fee
+    is paid from L-BTC. Call ``lw_sweep`` again without ``asset_id`` to also
+    empty the L-BTC remainder.
+
+    Args:
+        wallet_name: Name of the wallet
+        address: Destination Liquid address
+        asset_id: Optional asset id (hex). Omit for an L-BTC sweep.
+        password: Password to decrypt mnemonic (if encrypted at rest)
+
+    Returns:
+        txid, address, and (for asset sweeps) the ticker / asset_id swept.
+    """
+    manager = get_manager()
+    txid = manager.sweep(wallet_name, address, asset_id, password)
+    result: dict[str, Any] = {"txid": txid, "address": address}
+    if asset_id:
+        result["asset_id"] = asset_id
+        result["ticker"] = resolve_asset_name(asset_id)
+    else:
+        result["ticker"] = "L-BTC"
+    return result
+
+
 def _parse_tx_input(tx_input: str) -> tuple[str, str]:
     """Parse a txid or Blockstream URL into (txid, network)."""
     # Try to match a Blockstream URL
@@ -652,6 +690,33 @@ def btc_send(
         "amount": amount,
         "address": address,
     }
+
+
+def btc_sweep(
+    wallet_name: str,
+    address: str,
+    fee_rate: int | None = None,
+    password: str | None = None,
+) -> dict[str, Any]:
+    """
+    Sweep the entire Bitcoin balance to a single address. Call this when the
+    user says "send all", "sweep", "drain", "empty wallet", or "move
+    everything" — the network fee is deducted from the inputs, so 0 sats
+    remain in the wallet.
+
+    Args:
+        wallet_name: Name of the wallet
+        address: Destination Bitcoin address (bc1...)
+        fee_rate: Optional fee rate in sat/vB. Default: let BDK choose.
+        password: Password to decrypt mnemonic (if encrypted at rest)
+
+    Returns:
+        txid: Transaction ID
+        address: Destination address
+    """
+    btc = get_btc_manager()
+    txid = btc.sweep(wallet_name, address, fee_rate, password)
+    return {"txid": txid, "address": address}
 
 
 def unified_balance(wallet_name: str = "default") -> dict[str, Any]:
@@ -1806,6 +1871,7 @@ TOOLS = {
     "lw_transactions": lw_transactions,
     "lw_send": lw_send,
     "lw_send_asset": lw_send_asset,
+    "lw_sweep": lw_sweep,
     "lw_tx_status": lw_tx_status,
     "lw_list_wallets": lw_list_wallets,
     "lw_list_assets": lw_list_assets,
@@ -1814,6 +1880,7 @@ TOOLS = {
     "btc_address": btc_address,
     "btc_transactions": btc_transactions,
     "btc_send": btc_send,
+    "btc_sweep": btc_sweep,
     "btc_import_descriptor": btc_import_descriptor,
     "btc_export_descriptor": btc_export_descriptor,
     "unified_balance": unified_balance,

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -360,3 +360,74 @@ class WalletManager:
         # Broadcast
         txid = client.broadcast(tx)
         return str(txid)
+
+    def sweep(
+        self,
+        wallet_name: str,
+        address: str,
+        asset_id: Optional[str] = None,
+        password: Optional[str] = None,
+    ) -> str:
+        """Sweep a wallet balance to a single address. Returns txid.
+
+        With ``asset_id`` omitted (or set to the network's L-BTC policy asset),
+        spends every L-BTC input and routes the remainder to ``address`` — the
+        on-chain fee is paid from those inputs, so 0 L-BTC remains in the
+        wallet afterwards. (Wraps LWK's ``drain_lbtc_*`` builder API.)
+
+        With ``asset_id`` set to a non-L-BTC asset, sends the entire balance of
+        that asset to ``address``. The on-chain fee is still paid in L-BTC, so
+        L-BTC change may be returned to the wallet — call ``sweep`` again
+        without ``asset_id`` to also sweep the L-BTC remainder.
+        """
+        wallet = self.storage.load_wallet(wallet_name)
+        if not wallet:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+
+        if wallet.watch_only:
+            raise ValueError("Cannot sign with watch-only wallet")
+
+        if wallet_name not in self._signers:
+            if not wallet.encrypted_mnemonic:
+                raise ValueError("No mnemonic available for signing")
+            needs_password = self.storage.requires_user_password(wallet.encrypted_mnemonic)
+            if needs_password and not password:
+                raise ValueError("Password required to decrypt mnemonic")
+            self.load_wallet(wallet_name, password)
+
+        signer = self._signers[wallet_name]
+        wollet = self._get_wollet(wallet_name)
+        net = self._get_network(wallet.network)
+        client = self._get_client(wallet.network)
+        policy_asset = self._get_policy_asset(wallet.network)
+
+        # An explicit policy-asset id is just an L-BTC sweep — collapse to
+        # the L-BTC path so callers can pass either spelling.
+        if asset_id == policy_asset:
+            asset_id = None
+
+        self.sync_wallet(wallet_name)
+        raw_balance = wollet.balance()
+
+        builder = net.tx_builder()
+        lwk_address = lwk.Address(address)
+
+        if asset_id is None:
+            lbtc_balance = int(raw_balance.get(policy_asset, 0))
+            if lbtc_balance <= 0:
+                raise ValueError("No L-BTC to sweep")
+            builder.drain_lbtc_wallet()
+            builder.drain_lbtc_to(lwk_address)
+        else:
+            asset_balance = int(raw_balance.get(asset_id, 0))
+            if asset_balance <= 0:
+                ticker = resolve_asset_name(asset_id, wallet.network)
+                raise ValueError(f"No {ticker} balance to sweep")
+            builder.add_recipient(lwk_address, asset_balance, asset_id)
+
+        unsigned_pset = builder.finish(wollet)
+        signed_pset = signer.sign(unsigned_pset)
+        tx = signed_pset.finalize()
+
+        txid = client.broadcast(tx)
+        return str(txid)

--- a/tests/test_bitcoin.py
+++ b/tests/test_bitcoin.py
@@ -19,6 +19,7 @@ from aqua.storage import Storage, WalletData
 from aqua.tools import (
     btc_address,
     btc_balance,
+    btc_sweep,
     btc_send,
     btc_transactions,
     get_btc_manager,
@@ -165,6 +166,87 @@ class TestBitcoinWalletManager:
                 amount=1000,
                 fee_rate=-5,
             )
+
+    def test_btc_sweep_watch_only_raises(self, isolated_managers):
+        """Cannot sweep a watch-only wallet."""
+        manager, _ = isolated_managers
+        net = lwk.Network.mainnet()
+        m = lwk.Mnemonic(TEST_MNEMONIC)
+        signer = lwk.Signer(m, net)
+        desc = str(signer.wpkh_slip77_descriptor())
+        manager.import_descriptor(desc, "wo_sweep_btc", "mainnet")
+        with pytest.raises(ValueError, match="watch-only|no Bitcoin descriptors|not found"):
+            btc_sweep(
+                wallet_name="wo_sweep_btc",
+                address="bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+            )
+
+    def test_btc_sweep_nonexistent_wallet_raises(self, isolated_managers):
+        """Sweeping a non-existent wallet raises."""
+        with pytest.raises(ValueError, match="not found"):
+            btc_sweep(
+                wallet_name="ghost_btc",
+                address="bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+            )
+
+    def test_btc_sweep_zero_balance_raises(self, isolated_managers):
+        """Empty BTC balance → cannot sweep."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="empty_btc", network="mainnet")
+        with patch.object(get_btc_manager(), "sync_wallet"):
+            with pytest.raises(ValueError, match="No BTC to sweep"):
+                btc_sweep(
+                    wallet_name="empty_btc",
+                    address="bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+                )
+
+    def test_btc_sweep_negative_fee_rate_raises(self, isolated_managers):
+        """Negative fee rate raises before reaching BDK."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="neg_fee_sweep", network="mainnet")
+        with pytest.raises(ValueError, match="Fee rate must be positive"):
+            btc_sweep(
+                wallet_name="neg_fee_sweep",
+                address="bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+                fee_rate=-1,
+            )
+
+    def test_btc_sweep_calls_drain_to_and_drain_wallet(self, isolated_managers):
+        """Critical invariant: sweep() must invoke BDK's drain_to + drain_wallet
+        on the TxBuilder, and must NOT use add_recipient. Patches bdk.TxBuilder
+        so the builder calls are inspectable without a real chain sync."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="sweep_builder", network="mainnet")
+        btc_manager = get_btc_manager()
+
+        # Real wallet path is hit up to the point of building the tx — patch
+        # bdk.TxBuilder so we can introspect the calls without finalizing on
+        # an empty wallet.
+        mock_builder = MagicMock()
+        mock_builder.drain_to.return_value = mock_builder
+        mock_builder.drain_wallet.return_value = mock_builder
+        mock_builder.fee_rate.return_value = mock_builder
+        mock_builder.finish.side_effect = RuntimeError("stop after builder")
+
+        # Fake a non-zero balance so the pre-check passes.
+        mock_balance = MagicMock()
+        mock_balance.total.to_sat.return_value = 100_000
+
+        with (
+            patch.object(btc_manager, "sync_wallet"),
+            patch("aqua.bitcoin.bdk.TxBuilder", return_value=mock_builder),
+            patch("aqua.bitcoin.bdk.Wallet") as mock_wallet_cls,
+        ):
+            mock_wallet = MagicMock()
+            mock_wallet.balance.return_value = mock_balance
+            mock_wallet_cls.load.return_value = mock_wallet
+
+            with pytest.raises(RuntimeError, match="stop after builder"):
+                btc_sweep(
+                    wallet_name="sweep_builder",
+                    address="bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+                )
+
+        mock_builder.drain_to.assert_called_once()
+        mock_builder.drain_wallet.assert_called_once_with()
+        mock_builder.add_recipient.assert_not_called()
 
     def test_get_wallet_with_signer_loads_existing_persisted_wallet(self, isolated_managers):
         """Signer wallet path should load existing DB instead of recreating it."""

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -102,6 +102,8 @@ async def test_disabled_tool_unknown_on_call_tool():
 
 def test_cli_help_omits_disabled(temp_storage):
     """`aqua liquid --help` omits commands whose mapped MCP tool is disabled."""
+    import re
+
     enabled = dict(SHIPPED_DEFAULTS_ENABLED_TOOLS)
     enabled["lw_balance"] = False
     temp_storage.save_config(Config(enabled_tools=enabled))
@@ -113,7 +115,10 @@ def test_cli_help_omits_disabled(temp_storage):
     runner = CliRunner()
     result = runner.invoke(fresh_cli, ["liquid", "--help"])
     assert result.exit_code == 0
-    assert "balance" not in result.output
+    # Match the Click-rendered command listing only (indented + whitespace
+    # after the name), so help text in OTHER commands' descriptions that
+    # happens to contain the word "balance" doesn't trip this check.
+    assert not re.search(r"^\s+balance\s", result.output, re.MULTILINE)
 
 
 def test_cli_disabled_command_exits_2(temp_storage):

--- a/tests/test_sideswap.py
+++ b/tests/test_sideswap.py
@@ -18,6 +18,8 @@ import pytest
 import wallycore as wally
 
 from aqua.sideswap import (
+    DUST_THRESHOLD_SATS,
+    LIQUID_FEE_RESERVE_SATS,
     PEG_RECOMMENDATION_THRESHOLD_SATS,
     PsetVerificationError,
     SideSwapPeg,
@@ -1355,9 +1357,10 @@ class TestSelectSwapUtxos:
             _FakeUtxo("bb" * 32, 1, L_BTC, 200_000),
             _FakeUtxo("cc" * 32, 0, L_BTC, 100_000),
         ]
-        selected = select_swap_utxos(utxos, L_BTC, 150_000)
+        selected, effective_send_amount = select_swap_utxos(utxos, L_BTC, 150_000)
         assert len(selected) == 1
         assert selected[0]["value"] == 200_000
+        assert effective_send_amount == 150_000
 
     def test_accumulates_across_multiple_utxos(self):
         from aqua.sideswap import select_swap_utxos
@@ -1367,11 +1370,12 @@ class TestSelectSwapUtxos:
             _FakeUtxo("bb" * 32, 0, L_BTC, 30_000),
             _FakeUtxo("cc" * 32, 0, L_BTC, 30_000),
         ]
-        selected = select_swap_utxos(utxos, L_BTC, 70_000)
+        selected, effective_send_amount = select_swap_utxos(utxos, L_BTC, 70_000)
         assert len(selected) == 3
         assert sum(s["value"] for s in selected) == 90_000
         for s in selected:
             assert s["redeem_script"] is None
+        assert effective_send_amount == 70_000
 
     def test_skips_other_assets(self):
         from aqua.sideswap import select_swap_utxos
@@ -1380,9 +1384,10 @@ class TestSelectSwapUtxos:
             _FakeUtxo("aa" * 32, 0, USDT, 9_000_000),
             _FakeUtxo("bb" * 32, 0, L_BTC, 100_000),
         ]
-        selected = select_swap_utxos(utxos, L_BTC, 50_000)
+        selected, effective_send_amount = select_swap_utxos(utxos, L_BTC, 50_000)
         assert len(selected) == 1
         assert selected[0]["asset"] == L_BTC
+        assert effective_send_amount == 50_000
 
     def test_skips_non_confidential_utxos(self):
         from aqua.sideswap import select_swap_utxos
@@ -1392,9 +1397,10 @@ class TestSelectSwapUtxos:
             _FakeUtxo("aa" * 32, 0, L_BTC, 100_000, asset_bf="0" * 64, value_bf="0" * 64),
             _FakeUtxo("bb" * 32, 0, L_BTC, 50_000),
         ]
-        selected = select_swap_utxos(utxos, L_BTC, 50_000)
+        selected, effective_send_amount = select_swap_utxos(utxos, L_BTC, 50_000)
         assert len(selected) == 1
         assert selected[0]["txid"] == "bb" * 32
+        assert effective_send_amount == 50_000
 
     def test_insufficient_funds_raises(self):
         from aqua.sideswap import select_swap_utxos
@@ -1402,6 +1408,86 @@ class TestSelectSwapUtxos:
         utxos = [_FakeUtxo("aa" * 32, 0, L_BTC, 10_000)]
         with pytest.raises(ValueError, match="Insufficient confidential balance"):
             select_swap_utxos(utxos, L_BTC, 50_000)
+
+    def test_bumps_send_amount_when_change_would_be_dust(self):
+        """PR #99 reproducer: one UTXO 1 sat larger than send_amount must
+        produce no change output (bump send_amount to consume the dust)."""
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [_FakeUtxo("aa" * 32, 0, L_BTC, 100_001)]
+        selected, effective_send_amount = select_swap_utxos(utxos, L_BTC, 100_000)
+        assert len(selected) == 1
+        # Bumped to the full UTXO value so the dealer creates no change output.
+        assert effective_send_amount == 100_001
+
+    def test_no_bump_when_change_is_above_dust_threshold(self):
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [_FakeUtxo("aa" * 32, 0, L_BTC, 200_000)]
+        selected, effective_send_amount = select_swap_utxos(utxos, L_BTC, 100_000)
+        assert len(selected) == 1
+        # Change = 100_000 sats, well above dust threshold → no bump.
+        assert effective_send_amount == 100_000
+
+    def test_no_bump_on_exact_match(self):
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [_FakeUtxo("aa" * 32, 0, L_BTC, 100_000)]
+        selected, effective_send_amount = select_swap_utxos(utxos, L_BTC, 100_000)
+        assert len(selected) == 1
+        # change == 0 → no change output → no bump.
+        assert effective_send_amount == 100_000
+
+    def test_dust_threshold_boundary(self):
+        """Boundary check at DUST_THRESHOLD_SATS: change of exactly the
+        threshold is acceptable; one sat below triggers a bump."""
+        from aqua.sideswap import select_swap_utxos
+
+        # Change = DUST_THRESHOLD_SATS - 1 (dust) → bump
+        below = 100_000 + DUST_THRESHOLD_SATS - 1
+        utxos = [_FakeUtxo("aa" * 32, 0, L_BTC, below)]
+        selected, effective_send_amount = select_swap_utxos(utxos, L_BTC, 100_000)
+        assert effective_send_amount == below
+
+        # Change = DUST_THRESHOLD_SATS (not dust) → no bump
+        at_threshold = 100_000 + DUST_THRESHOLD_SATS
+        utxos = [_FakeUtxo("bb" * 32, 0, L_BTC, at_threshold)]
+        selected, effective_send_amount = select_swap_utxos(utxos, L_BTC, 100_000)
+        assert effective_send_amount == 100_000
+
+    def test_bumps_when_multi_utxo_combined_change_is_dust(self):
+        """The bump must also fire when greedy needs more than one UTXO and
+        the combined leftover lands in the dust zone — the dust check
+        triggers on the iteration that pushes accumulated >= send_amount,
+        not only on the first input."""
+        from aqua.sideswap import select_swap_utxos
+
+        utxos = [
+            _FakeUtxo("aa" * 32, 0, L_BTC, 50_001),
+            _FakeUtxo("bb" * 32, 0, L_BTC, 50_001),
+        ]
+        selected, effective_send_amount = select_swap_utxos(utxos, L_BTC, 100_000)
+        # Both UTXOs were needed (first alone is 50_001 < 100_000); combined
+        # change is 2 sats → bump.
+        assert len(selected) == 2
+        assert effective_send_amount == 100_002
+
+    def test_custom_dust_threshold_is_respected(self):
+        """execute_swap raises the dust_threshold for L-BTC sends (to
+        reserve fee headroom); verify the parameter actually controls the
+        bump trigger."""
+        from aqua.sideswap import select_swap_utxos
+
+        # change == 700, custom threshold = 1000 → bump
+        utxos = [_FakeUtxo("aa" * 32, 0, L_BTC, 100_700)]
+        _, effective_send_amount = select_swap_utxos(
+            utxos, L_BTC, 100_000, dust_threshold=1000
+        )
+        assert effective_send_amount == 100_700
+
+        # change == 700, default threshold = DUST_THRESHOLD_SATS (≤ 700) → no bump
+        _, effective_send_amount = select_swap_utxos(utxos, L_BTC, 100_000)
+        assert effective_send_amount == 100_000
 
 
 # ---------------------------------------------------------------------------
@@ -1534,8 +1620,15 @@ def swap_manager_setup(storage):
     return mgr, wm, fake_wollet, fake_signer, storage
 
 
-def _patch_swap_layers():
-    """Patch WS + lwk.Pset for the manager flow."""
+def _patch_swap_layers(unblinded_by_role: dict | None = None):
+    """Patch WS + lwk.Pset for the manager flow.
+
+    `unblinded_by_role` controls what the stubbed `unblind_dealer_outputs`
+    returns — defaults to `{}` (no ephemeral keys / no recoverable outputs),
+    which is the right shape for tests that don't exercise the dust check.
+    Pass e.g. `{"recv": 9_500_000, "change": 1}` to drive the verifier's
+    dust check past `unblind_dealer_outputs` with a known unblinded value.
+    """
     from contextlib import ExitStack
 
     stack = ExitStack()
@@ -1550,8 +1643,9 @@ def _patch_swap_layers():
     # The wally-based unblind helper needs a real PSET to parse — short-circuit
     # it in tests; the _FakeWollet supplies the canned balances dict that the
     # tests actually assert against.
+    payload = {} if unblinded_by_role is None else unblinded_by_role
     stack.enter_context(
-        patch("aqua.sideswap.unblind_dealer_outputs", lambda *a, **kw: {})
+        patch("aqua.sideswap.unblind_dealer_outputs", lambda *a, **kw: payload)
     )
     return stack
 
@@ -1740,6 +1834,53 @@ class TestSwapManagerExecute:
                     asset_id=USDT, send_amount=100_000, wallet_name="default"
                 )
         assert len(fake_signer.signed) == 0
+
+    def test_aborts_when_dealer_creates_dust_change_output(self, swap_manager_setup):
+        """Defensive layer (PR #99 follow-up): even if coin selection slipped
+        up — or the dealer's fee handling surprised us — a sub-DUST_THRESHOLD
+        change output must block the sign step."""
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        # Aggregate balances are clean (matches the agreed amounts) but the
+        # change output unblinds to a single sat — the original PR #99 bug.
+        fake_wollet._balances = {L_BTC: -100_000, USDT: 9_500_000}
+
+        with _patch_swap_layers({"recv": 9_500_000, "change": 1}):
+            with pytest.raises(PsetVerificationError, match="dust change output of 1 sats"):
+                mgr.execute_swap(
+                    asset_id=USDT, send_amount=100_000, wallet_name="default"
+                )
+        # Must not have signed or broadcast the dust-producing PSET.
+        assert len(fake_signer.signed) == 0
+        assert not any(m == "mkt.taker_sign" for m, _ in FakeWSClient.calls)
+
+    def test_accepts_change_output_at_dust_threshold_boundary(self, swap_manager_setup):
+        """Change of exactly DUST_THRESHOLD_SATS is the smallest acceptable
+        change — the verifier must not reject it."""
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        fake_wollet._balances = {L_BTC: -100_000, USDT: 9_500_000}
+
+        with _patch_swap_layers({"recv": 9_500_000, "change": DUST_THRESHOLD_SATS}):
+            swap = mgr.execute_swap(
+                asset_id=USDT, send_amount=100_000, wallet_name="default"
+            )
+        assert swap.status == "broadcast"
+        assert len(fake_signer.signed) == 1
+
+    def test_accepts_pset_with_no_change_output(self, swap_manager_setup):
+        """When coin selection bumped send_amount to consume all inputs the
+        dealer creates no change output at all (the unblind helper returns
+        only the recv role). That's the dust-avoidance happy path."""
+        mgr, _, fake_wollet, fake_signer, _ = swap_manager_setup
+        _setup_mkt_responses_forward()
+        fake_wollet._balances = {L_BTC: -100_000, USDT: 9_500_000}
+
+        with _patch_swap_layers({"recv": 9_500_000}):
+            swap = mgr.execute_swap(
+                asset_id=USDT, send_amount=100_000, wallet_name="default"
+            )
+        assert swap.status == "broadcast"
 
     def test_rejects_swap_lbtc_for_lbtc(self, swap_manager_setup):
         mgr, _, _, _, _ = swap_manager_setup
@@ -2172,31 +2313,36 @@ class TestUnblindDealerOutputs:
 
     def test_no_ephemeral_keys_is_noop(self):
         """Peg / legacy-orderbook flows pass no ephemeral keys; the verifier
-        should short-circuit before touching wally at all."""
+        should short-circuit before touching wally at all and return an
+        empty unblinded-values map."""
         from aqua.sideswap import unblind_dealer_outputs
 
         # If anything tries to parse the (deliberately bogus) b64, wally would
-        # raise — reaching the assert means the early-return path fired.
-        unblind_dealer_outputs(
+        # raise — reaching the return means the early-return path fired.
+        result = unblind_dealer_outputs(
             "not-a-real-pset",
             recv_addr="lq1qnotreal",
             change_addr=None,
             receive_ephemeral_sk=None,
             change_ephemeral_sk=None,
         )
+        assert result == {}
 
     def test_honest_pset_passes(self):
         from aqua.sideswap import unblind_dealer_outputs
 
         out = self._synth_blinded_output(L_BTC, value=100_000)
         with self._patch_pset_parser(out):
-            unblind_dealer_outputs(
+            result = unblind_dealer_outputs(
                 "<patched-b64>",
                 recv_addr="lq1qhonest",
                 change_addr=None,
                 receive_ephemeral_sk=out["eph_sk_hex"],
                 change_ephemeral_sk=None,
             )
+        # The cryptographically-verified unblinded value is exposed by role so
+        # the caller can enforce per-output policy (e.g. dust threshold).
+        assert result == {"recv": 100_000}
 
     def test_tampered_value_commitment_raises(self):
         """Flipping a byte in the value commitment must trip the verifier —
@@ -2257,3 +2403,27 @@ class TestUnblindDealerOutputs:
                     receive_ephemeral_sk=out["eph_sk_hex"],
                     change_ephemeral_sk=None,
                 )
+
+    def test_duplicate_role_raises(self):
+        """SideSwap's market protocol emits at most one output per role. If a
+        PSET ever ships two outputs that match the same address — whether
+        from a dealer protocol change or a hostile dealer trying to hide a
+        dust output behind a clean one — we must refuse rather than
+        silently overwrite the first unblinded value."""
+        from aqua.sideswap import unblind_dealer_outputs
+
+        out = self._synth_blinded_output(L_BTC, value=100_000)
+        with self._patch_pset_parser(out):
+            # Override num_outputs to 2 — both outputs share the same spk /
+            # commitments / rangeproof from `out`, so both match the recv
+            # branch. The first should unblind cleanly; the second must
+            # trip the duplicate-role guard.
+            with patch.object(wally, "psbt_get_num_outputs", lambda _p: 2):
+                with pytest.raises(PsetVerificationError, match="second 'recv' output"):
+                    unblind_dealer_outputs(
+                        "<patched-b64>",
+                        recv_addr="lq1qhonest",
+                        change_addr=None,
+                        receive_ephemeral_sk=out["eph_sk_hex"],
+                        change_ephemeral_sk=None,
+                    )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -22,6 +22,7 @@ from aqua.tools import (
     get_manager,
     lw_address,
     lw_balance,
+    lw_sweep,
     lw_export_descriptor,
     lw_generate_mnemonic,
     lw_import_descriptor,
@@ -751,6 +752,178 @@ class TestSendAsset:
 
 
 # ---------------------------------------------------------------------------
+# lw_sweep  # Significance: 5 (Essential — prevents dust generation)
+# ---------------------------------------------------------------------------
+
+
+class TestSweep:
+    DEST_ADDRESS = "lq1qqvxk052kf3qtkxmrakx50a9gc3smqad2ync54hzntjt980kfej9kkfe0247rp5h4yzmdftsahhw64uy8pzfe7cpg4fgykm7cv"
+    FAKE_ASSET_ID = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    # L-BTC policy asset on mainnet (matches WalletManager._get_policy_asset("mainnet"))
+    LBTC_POLICY_ASSET = "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d"
+
+    def _setup_sweep_mocks(self, isolated_manager, wallet_name, balance_map):
+        """Helper: set up mocks for sweep tests.
+
+        ``balance_map`` is the dict returned by the fake wollet.balance() —
+        keys are asset ids (hex), values are sat amounts.
+        """
+        mock_builder = MagicMock()
+        mock_pset = MagicMock()
+        mock_signed = MagicMock()
+        mock_tx = MagicMock()
+        mock_client = MagicMock()
+        mock_net = MagicMock()
+        mock_wollet = MagicMock()
+
+        mock_wollet.balance.return_value = balance_map
+        mock_net.tx_builder.return_value = mock_builder
+        # sweep() calls _get_policy_asset → str(net.policy_asset()); make
+        # str() yield the real L-BTC policy hex so the balance lookup hits.
+        mock_net.policy_asset.return_value = self.LBTC_POLICY_ASSET
+        mock_builder.finish.return_value = mock_pset
+        isolated_manager._signers[wallet_name].sign = MagicMock(return_value=mock_signed)
+        mock_signed.finalize.return_value = mock_tx
+        isolated_manager._wollets[wallet_name] = mock_wollet
+
+        return mock_builder, mock_client, mock_net, mock_wollet
+
+    def test_sweep_lbtc_calls_drain_lbtc_wallet_and_drain_lbtc_to(self, isolated_manager):
+        """L-BTC sweep uses LWK's native drain_lbtc_* APIs (not add_lbtc_recipient)."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="sweep_lbtc")
+        mock_builder, mock_client, mock_net, _ = self._setup_sweep_mocks(
+            isolated_manager, "sweep_lbtc", {self.LBTC_POLICY_ASSET: 50_000}
+        )
+        mock_client.broadcast.return_value = "sweep_lbtc_txid"
+
+        with (
+            patch.object(isolated_manager, "sync_wallet"),
+            patch.object(isolated_manager, "_get_network", return_value=mock_net),
+            patch.object(isolated_manager, "_get_client", return_value=mock_client),
+        ):
+            result = lw_sweep(wallet_name="sweep_lbtc", address=self.DEST_ADDRESS)
+
+        mock_builder.drain_lbtc_wallet.assert_called_once_with()
+        mock_builder.drain_lbtc_to.assert_called_once()
+        address_arg = mock_builder.drain_lbtc_to.call_args[0][0]
+        assert isinstance(address_arg, lwk.Address)
+        mock_builder.add_lbtc_recipient.assert_not_called()
+        mock_builder.add_recipient.assert_not_called()
+        assert result["txid"] == "sweep_lbtc_txid"
+        assert result["ticker"] == "L-BTC"
+        assert "asset_id" not in result
+
+    def test_sweep_asset_calls_add_recipient_with_full_balance(self, isolated_manager):
+        """Asset sweep sends the entire asset balance via add_recipient; the
+        L-BTC drain_lbtc_* primitives must NOT be called (L-BTC change is
+        intentionally left in the wallet for asset sweeps)."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="sweep_asset")
+        mock_builder, mock_client, mock_net, _ = self._setup_sweep_mocks(
+            isolated_manager,
+            "sweep_asset",
+            {self.LBTC_POLICY_ASSET: 5_000, self.FAKE_ASSET_ID: 12_345},
+        )
+        mock_client.broadcast.return_value = "sweep_asset_txid"
+
+        with (
+            patch.object(isolated_manager, "sync_wallet"),
+            patch.object(isolated_manager, "_get_network", return_value=mock_net),
+            patch.object(isolated_manager, "_get_client", return_value=mock_client),
+        ):
+            result = lw_sweep(
+                wallet_name="sweep_asset",
+                address=self.DEST_ADDRESS,
+                asset_id=self.FAKE_ASSET_ID,
+            )
+
+        mock_builder.add_recipient.assert_called_once()
+        call_args = mock_builder.add_recipient.call_args[0]
+        assert isinstance(call_args[0], lwk.Address)
+        assert call_args[1] == 12_345
+        assert call_args[2] == self.FAKE_ASSET_ID
+        mock_builder.drain_lbtc_wallet.assert_not_called()
+        mock_builder.drain_lbtc_to.assert_not_called()
+        assert result["asset_id"] == self.FAKE_ASSET_ID
+        assert result["txid"] == "sweep_asset_txid"
+
+    def test_sweep_normalizes_policy_asset_id_to_lbtc_path(self, isolated_manager):
+        """An explicit policy asset id is collapsed to the L-BTC sweep path."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="sweep_norm")
+        mock_builder, mock_client, mock_net, _ = self._setup_sweep_mocks(
+            isolated_manager, "sweep_norm", {self.LBTC_POLICY_ASSET: 1_000}
+        )
+        mock_client.broadcast.return_value = "ok"
+
+        with (
+            patch.object(isolated_manager, "sync_wallet"),
+            patch.object(isolated_manager, "_get_network", return_value=mock_net),
+            patch.object(isolated_manager, "_get_client", return_value=mock_client),
+        ):
+            lw_sweep(
+                wallet_name="sweep_norm",
+                address=self.DEST_ADDRESS,
+                asset_id=self.LBTC_POLICY_ASSET,
+            )
+
+        mock_builder.drain_lbtc_wallet.assert_called_once_with()
+        mock_builder.drain_lbtc_to.assert_called_once()
+        mock_builder.add_recipient.assert_not_called()
+
+    def test_sweep_zero_lbtc_balance_raises(self, isolated_manager):
+        """Empty L-BTC balance → cannot sweep."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="sweep_empty")
+        self._setup_sweep_mocks(isolated_manager, "sweep_empty", {self.LBTC_POLICY_ASSET: 0})
+
+        with patch.object(isolated_manager, "sync_wallet"):
+            with pytest.raises(ValueError, match="No L-BTC to sweep"):
+                lw_sweep(wallet_name="sweep_empty", address=self.DEST_ADDRESS)
+
+    def test_sweep_zero_asset_balance_raises(self, isolated_manager):
+        """Asset not present in wallet → cannot sweep that asset."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="sweep_no_asset")
+        self._setup_sweep_mocks(
+            isolated_manager, "sweep_no_asset", {self.LBTC_POLICY_ASSET: 10_000}
+        )
+
+        with patch.object(isolated_manager, "sync_wallet"):
+            with pytest.raises(ValueError, match="balance to sweep"):
+                lw_sweep(
+                    wallet_name="sweep_no_asset",
+                    address=self.DEST_ADDRESS,
+                    asset_id=self.FAKE_ASSET_ID,
+                )
+
+    def test_sweep_watch_only_raises(self, isolated_manager):
+        """Cannot sweep a watch-only wallet."""
+        net = lwk.Network.mainnet()
+        m = lwk.Mnemonic(TEST_MNEMONIC)
+        signer = lwk.Signer(m, net)
+        desc = str(signer.wpkh_slip77_descriptor())
+        lw_import_descriptor(descriptor=desc, wallet_name="wo_sweep")
+
+        with pytest.raises(ValueError, match="watch-only"):
+            lw_sweep(wallet_name="wo_sweep", address=self.DEST_ADDRESS)
+
+    def test_sweep_nonexistent_wallet_raises(self):
+        """Sweeping a non-existent wallet raises."""
+        with pytest.raises(ValueError, match="not found"):
+            lw_sweep(wallet_name="ghost", address=self.DEST_ADDRESS)
+
+    def test_sweep_encrypted_without_password_raises(self):
+        """Encrypted wallet without password → fail before reaching LWK."""
+        lw_import_mnemonic(
+            mnemonic=TEST_MNEMONIC,
+            wallet_name="sweep_enc",
+            password="pass123",
+        )
+        manager = get_manager()
+        manager._signers.pop("sweep_enc", None)
+
+        with pytest.raises(ValueError, match="[Pp]assword required"):
+            lw_sweep(wallet_name="sweep_enc", address=self.DEST_ADDRESS)
+
+
+# ---------------------------------------------------------------------------
 # WalletManager internal logic  # Significance: 4 (Important)
 # ---------------------------------------------------------------------------
 
@@ -823,6 +996,7 @@ class TestToolRegistry:
             "lw_transactions",
             "lw_send",
             "lw_send_asset",
+            "lw_sweep",
             "lw_list_wallets",
             "lw_list_assets",
             "lw_tx_status",
@@ -830,6 +1004,7 @@ class TestToolRegistry:
             "btc_address",
             "btc_transactions",
             "btc_send",
+            "btc_sweep",
             "unified_balance",
             "lightning_receive",
             "lightning_send",

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "qrcode", extras = ["pil"], specifier = ">=7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.0" },
-    { name = "wallycore", specifier = ">=1.5.3" },
+    { name = "wallycore", specifier = ">=1.5.4" },
     { name = "websockets", specifier = ">=12.0" },
     { name = "zxing-cpp", specifier = ">=2.2" },
 ]
@@ -793,17 +793,17 @@ wheels = [
 
 [[package]]
 name = "wallycore"
-version = "1.5.3"
+version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/03/907f542ba2db105bba9021099246950f7ade8ac29bba5c2bd87227fba418/wallycore-1.5.3.tar.gz", hash = "sha256:dc2fad7db42482364e558a8c920f9d96879726ebeab8c10daa3a290beec36191", size = 3960658, upload-time = "2026-04-15T22:05:28.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/8b/806dd6b10d91a7ed7d556082ea05eac66c95bf9970705ae2515978dec79e/wallycore-1.5.4.tar.gz", hash = "sha256:bb5e14c4b67acca45969e6beda60f24c0735f289ae0f49751714ba349e5822c2", size = 3339988, upload-time = "2026-06-17T04:09:56.274Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/71/0db986acc752dc43108d1c6a4acd0f9de40cb3a6d73e9c32839893c1c52f/wallycore-1.5.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c00d6784a6328acbcab5ad36b4489976e8a93bbc662686a1eeb5563ba427f61f", size = 3505050, upload-time = "2026-04-15T22:04:39.943Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/8a/5d2d0179cdc8aa2deb414baa6129cc08d6314368cd290a6e9383c9f3c58b/wallycore-1.5.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9ae08d68215d6eb52fa295c632eb2a7f4e08115b6b8dde6d8582813569c04e05", size = 1784406, upload-time = "2026-04-15T22:04:43.125Z" },
-    { url = "https://files.pythonhosted.org/packages/32/7d/cbf7d8e0089ac8032e20e1948e2dd60ed3eddd73742e925e0fa12929428d/wallycore-1.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b689a7e13944acfaf5abe1ab70489a94842832f7043b6efc8f3ecf64da15e145", size = 1741281, upload-time = "2026-04-15T22:04:45.652Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e8/fc274efa70300ea00d9d1643d604fd1d1b940d1d615b699aaa87bb0d7430/wallycore-1.5.3-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e2ac7717c72a121f0c72e06e336b3d50b42bb3df780d0da91ade1958f6f6176b", size = 4229600, upload-time = "2026-04-15T22:04:49.227Z" },
-    { url = "https://files.pythonhosted.org/packages/49/6b/9ff40ec2645c3790519cddf33463f48bddc957a2407843b9add8cedcbdfc/wallycore-1.5.3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5fe110696bbd54c67fdff940d5319fd3b435f4d993969c0eb9dac5d4506933a7", size = 4415149, upload-time = "2026-04-15T22:04:53.812Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/0e/3273663fca4f7d73adaf08ed40595463d28a43562631cc33e39526bb2cb4/wallycore-1.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b5e1831802f6b0b87e2ce150b7e0fc80c5f4e647930f341e7878e66a0d571529", size = 4307656, upload-time = "2026-04-15T22:04:57.762Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/75/1e095c5c8c66166f42cea89fea76083b3b1f97a4cf74e1515c798daeeefb/wallycore-1.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:85ad55687ee09ce64686e9f8a73967736897697b5e3f8ee0c92814cf180325bc", size = 1728042, upload-time = "2026-04-15T22:05:00.559Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ae/045975c7fc7c4ab46a4304f99661932d42c7c65f413c0be246e82b863108/wallycore-1.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d149784f8bdb2c3ad8d52a82a260d14a41f3a8642fb32b2d62cc05d1b74c2cfb", size = 3428433, upload-time = "2026-06-17T04:08:44.644Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/aa6badde3c6094f0209d048a0adb29c8c648901db63cc1b66addba961097/wallycore-1.5.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0aea2e6ab0486e90e5cf801bcafaf36666b30d823d7e8ac04ca1539b9feb9fbc", size = 1747453, upload-time = "2026-06-17T04:08:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/23/e501e428ed67bbcd10e607f12587c1ef790866dfb478f12414a0be331fa8/wallycore-1.5.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6a56d167c26f5a7a03aec81e1fe9cf097a470f432283e68837a15d82e299da99", size = 1703316, upload-time = "2026-06-17T04:08:49.812Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d3/ea79c23b666689a2d5b9c53837227950f14c0dd4f1c7ca4485f6252cb1dd/wallycore-1.5.4-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:88a1e68153f53da2b5421f0e06cc89ab3f61a54f927da35ddab204aad5b89856", size = 4231516, upload-time = "2026-06-17T04:08:54.007Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/98/0fd3819bc4d07ed490eeb5ccdfde87e4e23c8ff768e1b8eddc62f4ea492d/wallycore-1.5.4-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ee70cbc84112989853cb4a49b43db1a1cb8eb09cd061779dbf17b8af1f1bf68d", size = 4387477, upload-time = "2026-06-17T04:08:58.227Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a9/278a2c923ee161b2479a8a1192fffcc37613fe55803bc255c77a7d82c175/wallycore-1.5.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fc47aa771ef325668ca76925d4d5233d304937b1dfedf6e629c27239673371c5", size = 4290713, upload-time = "2026-06-17T04:09:02.347Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/78/8b40c85c45de1ec51b9c618c3392844221b24ea4bc5911cea612fef6fb7e/wallycore-1.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:b46d6b0ac684d1298eb7539cd714ce4abb5cd1d7a8232baefe37aa077f3e0543", size = 1686600, upload-time = "2026-06-17T04:09:07.28Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
It was possible to generate dust when doing a swap through Sideswap. The idea behind this PR is to fix it and provide a way to mend this by adding lw_sweep and btc_sweep.
<details>
<summary><strong>If you want to read specifically about the Sideswap dust generation issue click here</strong></summary>
## SideSwap dust / leftover UTXOs — what happened

Two separate issues were conflated during manual testing. Only one is a SideSwap bug.

### 1. SideSwap 1-sat change output (PR #99 — fixed in SideSwap path)

**Symptom:** After an atomic L-BTC ↔ asset swap, the wallet could be left with a **1-sat L-BTC change UTXO** — too small to ever spend profitably (~25+ sats to spend a confidential Liquid input).

**Cause:** SideSwap builds the transaction via its dealer (`mkt::*` flow), not LWK’s normal `tx_builder`. When coin selection picked a UTXO only slightly larger than the send amount (e.g. 100,001 sats for a 100,000-sat swap), the leftover change was 1 sat. The dealer can also subtract network fees from change, so a leftover that looked safe at selection time could shrink further on-chain.

**Fix (SideSwap only):**

- `select_swap_utxos()` — if `0 < change < DUST_THRESHOLD_SATS` (50), bump `send_amount` to consume the full UTXO (no change output).
- On L-BTC sends, use `DUST_THRESHOLD_SATS + LIQUID_FEE_RESERVE_SATS` (50 + 200) so fee subtraction doesn’t push change below the threshold.
- PSET verifier — refuse to sign if the dealer’s PSET still creates change below 50 sats.

This does **not** apply to ordinary `lw_send` / `btc_send`.

### 2. 174-sat and 24-sat leftovers (manual `lw_send` — not SideSwap)

**Symptom:** After “send all” L-BTC to an external address, the wallet retained **174 sats**, then **24 sats** after a second send attempt.

**Cause:** These came from **`lw_send` with a guessed amount** (`balance − 200`), not from SideSwap. Agentic-aqua has no Liquid send-max/sweep (`drain_lbtc_to`). LWK built normal transactions with change:


</details>

### Other changes

- Update wallycore from 1.5.3 to 1.5.4. This is not an urgent change but it makes sense to include it in the next release whenever it might be

https://pypi.org/project/wallycore/1.5.4/

#### Liquid testing

<details>
<img width="1107" height="898" alt="image" src="https://github.com/user-attachments/assets/f85cb4f8-cfbf-4c15-8c96-56b39312be9e" />
</details>

#### Bitcoin testing

<details>
1) Send to BTC receive address generated by agentic-aqua
<img width="1103" height="979" alt="image" src="https://github.com/user-attachments/assets/25d7478b-eeed-4f36-a65f-f250d6bebd63" />

2) Send BTC again to the same address.
<img width="1110" height="746" alt="image" src="https://github.com/user-attachments/assets/55d43a09-ad30-437f-9254-9f4d4ca7eeea" />

3) Send all the BTC to a different address (sweep)
<img width="837" height="357" alt="image" src="https://github.com/user-attachments/assets/68554f55-657e-48ef-8898-07838e1d917c" />

<img width="1137" height="214" alt="image" src="https://github.com/user-attachments/assets/7fa45da6-5fdd-46cb-b1c2-0c4be4ee2e98" />
</details>
