### PR TITLE
Fix for QR code generation on Windows

### DIFF
--- a/src/aqua/qr.py
+++ b/src/aqua/qr.py
@@ -7,14 +7,17 @@ import qrcode
 import zxingcpp
 from PIL import Image
 
+from .storage import restrict_permissions
+
 
 def generate_qr(data: str, output_dir: str | Path, filename: str | None = None) -> str:
     """Generate a PNG QR code for ``data`` and return the saved file path.
 
     Used to render deposit addresses, Lightning invoices and swap deposit
     addresses as scannable QR images. The file is written atomically (temp
-    file + ``os.replace``) with ``0o600`` permissions, mirroring the rest of
-    the on-disk ``~/.aqua`` layout.
+    file + ``os.replace``) with ``0o600`` permissions on Unix, mirroring the
+    rest of the on-disk ``~/.aqua`` layout. On Windows, permission bits are
+    left to inherited NTFS ACLs because ``os.chmod`` strips user access there.
 
     Args:
         data: The string to encode (address, BOLT11 invoice, etc.).
@@ -48,7 +51,7 @@ def generate_qr(data: str, output_dir: str | Path, filename: str | None = None) 
             img.save(fh, format="PNG")
             fh.flush()
             os.fsync(fh.fileno())
-        os.chmod(tmp_path, 0o600)
+        restrict_permissions(tmp_path, 0o600)
         os.replace(tmp_path, path)
     except BaseException:
         tmp_path.unlink(missing_ok=True)

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import shutil
+import sys
 from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -18,6 +19,16 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 logger = logging.getLogger(__name__)
 
 SALT_LENGTH = 16
+
+
+def restrict_permissions(path: Path | str, mode: int) -> None:
+    """Apply Unix permission bits. No-op on Windows where chmod strips inherited ACLs."""
+    if sys.platform == "win32":
+        return
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        pass
 
 
 DEFAULT_DIR = Path.home() / ".aqua"
@@ -131,29 +142,29 @@ class Storage:
     def _ensure_dirs(self):
         """Create necessary directories with restricted permissions."""
         self.base_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-        os.chmod(self.base_dir, 0o700)
+        restrict_permissions(self.base_dir, 0o700)
         self.wallets_dir.mkdir(exist_ok=True, mode=0o700)
-        os.chmod(self.wallets_dir, 0o700)
+        restrict_permissions(self.wallets_dir, 0o700)
         self.cache_dir.mkdir(exist_ok=True, mode=0o700)
-        os.chmod(self.cache_dir, 0o700)
+        restrict_permissions(self.cache_dir, 0o700)
         self.swaps_dir.mkdir(exist_ok=True, mode=0o700)
-        os.chmod(self.swaps_dir, 0o700)
+        restrict_permissions(self.swaps_dir, 0o700)
         self.ankara_swaps_dir.mkdir(exist_ok=True, mode=0o700)
-        os.chmod(self.ankara_swaps_dir, 0o700)
+        restrict_permissions(self.ankara_swaps_dir, 0o700)
         self.lightning_swaps_dir.mkdir(exist_ok=True, mode=0o700)
-        os.chmod(self.lightning_swaps_dir, 0o700)
+        restrict_permissions(self.lightning_swaps_dir, 0o700)
         self.pix_swaps_dir.mkdir(exist_ok=True, mode=0o700)
-        os.chmod(self.pix_swaps_dir, 0o700)
+        restrict_permissions(self.pix_swaps_dir, 0o700)
         self.changelly_swaps_dir.mkdir(exist_ok=True, mode=0o700)
-        os.chmod(self.changelly_swaps_dir, 0o700)
+        restrict_permissions(self.changelly_swaps_dir, 0o700)
         self.sideshift_shifts_dir.mkdir(exist_ok=True, mode=0o700)
-        os.chmod(self.sideshift_shifts_dir, 0o700)
+        restrict_permissions(self.sideshift_shifts_dir, 0o700)
         self.sideswap_pegs_dir.mkdir(exist_ok=True, mode=0o700)
-        os.chmod(self.sideswap_pegs_dir, 0o700)
+        restrict_permissions(self.sideswap_pegs_dir, 0o700)
         self.sideswap_swaps_dir.mkdir(exist_ok=True, mode=0o700)
-        os.chmod(self.sideswap_swaps_dir, 0o700)
+        restrict_permissions(self.sideswap_swaps_dir, 0o700)
         self.qr_dir.mkdir(exist_ok=True, mode=0o700)
-        os.chmod(self.qr_dir, 0o700)
+        restrict_permissions(self.qr_dir, 0o700)
 
     def _derive_key(self, password: str, salt: bytes) -> bytes:
         """Derive encryption key from password."""
@@ -303,17 +314,9 @@ class Storage:
                 json.dump(data, f, indent=2)
                 f.flush()
                 os.fsync(f.fileno())
-            if hasattr(os, "chmod"):
-                try:
-                    os.chmod(tmp_path, 0o600)
-                except OSError:
-                    pass
+            restrict_permissions(tmp_path, 0o600)
             os.replace(tmp_path, path)
-            if hasattr(os, "chmod"):
-                try:
-                    os.chmod(path, 0o600)
-                except OSError:
-                    pass
+            restrict_permissions(path, 0o600)
         except Exception:
             if tmp_path.exists():
                 try:

--- a/tests/test_qr.py
+++ b/tests/test_qr.py
@@ -1,4 +1,6 @@
+import os
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -114,10 +116,21 @@ def test_generate_qr_returns_absolute_png_path(tmp_path):
     assert p.parent == tmp_path.resolve()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix mode bits")
 def test_generate_qr_file_is_0600(tmp_path):
     path = generate_qr("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq", tmp_path)
     mode = stat.S_IMODE(Path(path).stat().st_mode)
     assert mode == 0o600
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows ACL regression")
+def test_generate_qr_readable_on_windows(tmp_path):
+    """chmod(0o600) on Windows strips inherited user ACLs; QR must stay readable."""
+    path = generate_qr("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq", tmp_path)
+    p = Path(path)
+    assert p.is_file()
+    assert os.access(p, os.R_OK)
+    assert decode_qr(path) == "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
 
 
 def test_generate_qr_creates_missing_output_dir(tmp_path):


### PR DESCRIPTION
<img width="1296" height="459" alt="image" src="https://github.com/user-attachments/assets/289450f0-4480-49d1-8390-799d1421b2a6" />

QR codes wouldn't open on Windows due to the permissions scheme when using Cursor