### PR TITLE
WapuPay: add agent context 

### DIFF
--- a/src/aqua/cli/wapupay.py
+++ b/src/aqua/cli/wapupay.py
@@ -22,7 +22,7 @@ from ..tools import (
     wapupay_transaction,
     wapupay_transactions,
 )
-from ..wapupay import validate_liquid_refund_address
+from ..wapupay import WAPUPAY_ABOUT, validate_liquid_refund_address
 from .output import run_tool
 
 _TRANSFER_TYPE = click.Choice(["fiat_transfer", "fast_fiat_transfer"])
@@ -36,6 +36,12 @@ def wapupay():
     `create-order` returns a Liquid USDT address to fund — pay it with
     `aqua liquid send-asset` and WapuPay settles the pesos.
     """
+
+
+@wapupay.command("about")
+def about():
+    """Explain what WapuPay is and what you can do with it."""
+    click.echo(WAPUPAY_ABOUT)
 
 
 @wapupay.command("rates")

--- a/src/aqua/cli/wapupay.py
+++ b/src/aqua/cli/wapupay.py
@@ -49,7 +49,9 @@ def rates(ctx):
 @click.option("--amount-ars", required=True, help="Amount in Argentine pesos (e.g. '10000').")
 @click.option(
     "--type", "transfer_type", type=_TRANSFER_TYPE,
-    default="fiat_transfer", show_default=True,
+    default="fast_fiat_transfer", show_default=True,
+    help="fast_fiat_transfer show as 'Fast Transfer' for the user (default, prioritized, ~10 min–1 h daytime, higher "
+         "fee) or fiat_transfer show as 'Normal Transfer' (standard, 3–12 h, lower fee).",
 )
 @click.option(
     "--alias", default=None,
@@ -69,7 +71,9 @@ def quote(ctx, amount_ars, transfer_type, alias):
 @click.option("--alias", required=True, help="Recipient bank alias / CBU / CVU.")
 @click.option(
     "--type", "transfer_type", type=_TRANSFER_TYPE,
-    default="fiat_transfer", show_default=True,
+    default="fast_fiat_transfer", show_default=True,
+    help="fast_fiat_transfer show as 'Fast Transfer' for the user (default, prioritized, ~10 min–1 h daytime, higher "
+         "fee) or fiat_transfer show as 'Normal Transfer' (standard, 3–12 h, lower fee).",
 )
 @click.option("--receiver-name", default=None, help="Recipient name (optional).")
 @click.option(

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1193,8 +1193,15 @@ TOOL_SCHEMAS = {
                 "type": {
                     "type": "string",
                     "enum": ["fiat_transfer", "fast_fiat_transfer"],
-                    "default": "fiat_transfer",
-                    "description": "Standard or instant (higher fee) transfer",
+                    "default": "fast_fiat_transfer",
+                    "description": (
+                        "Transfer speed. 'fast_fiat_transfer' show as 'Fast Transfer' for the user (default, higher fee): "
+                        "prioritized, completes in ~10 min to 1 hour during daytime "
+                        "(not instant). 'fiat_transfer' show as 'Normal Transfer' for the user (standard, lower fee): takes "
+                        "3 to 12 hours; recommend only when there is no rush, or when "
+                        "paying at night/weekends since usually a payer picks it up the next "
+                        "day. Explain this trade-off to the user."
+                    ),
                 },
                 "alias": {"type": "string", "description": "Recipient bank alias / CBU / CVU (optional; enables validation)"},
             },
@@ -1203,13 +1210,13 @@ TOOL_SCHEMAS = {
     },
     "wapupay_create_order": {
         "description": (
-            "Create a WapuPay direct-fiat order and get a Liquid USDT funding "
-            "address. Creates the tentative (freezing the quote) and issues "
+            "Create a WapuPay order and get a Liquid USDT funding address. "
+            "Creates the tentative (freezing the quote) and issues "
             "funding instructions. Returns address_destination (Liquid), asset_id "
             "(USDT), funding_amount_usdt, total_amount_usdt, "
             "total_funding_amount_base_units, funding_expires_at and a QR. Pay the "
             "TOTAL with lw_send_asset (amount = total_funding_amount_base_units); "
-            "WapuPay then settles ARS to the bank account. Does NOT broadcast the "
+            "WapuPay then makes a P2P payer settle ARS to the bank account. Does NOT broadcast the "
             "payment itself — confirm the quote with the user first via wapupay_quote."
         ),
         "inputSchema": {
@@ -1220,7 +1227,15 @@ TOOL_SCHEMAS = {
                 "type": {
                     "type": "string",
                     "enum": ["fiat_transfer", "fast_fiat_transfer"],
-                    "default": "fiat_transfer",
+                    "default": "fast_fiat_transfer",
+                    "description": (
+                        "Transfer speed. 'fast_fiat_transfer' name it 'Fast Transfer' for the user (default, higher fee): "
+                        "prioritized, completes in ~10 min to 1 hour during daytime "
+                        "(not instant). 'fiat_transfer' name it 'Normal Transfer' for the user (standard, lower fee): takes "
+                        "3 to 12 hours; recommend only when there is no rush, or when "
+                        "paying at night/weekends since usually a payer picks it up the next "
+                        "day. Explain this trade-off to the user."
+                    ),
                 },
                 "receiver_name": {"type": "string", "description": "Recipient name (optional)"},
                 "refund_address": {"type": "string", "description": "Liquid mainnet refund address (lq1…/ex1…) if funding cannot execute (optional); validated before the order is created"},
@@ -1245,9 +1260,10 @@ TOOL_SCHEMAS = {
     },
     "wapupay_order_status": {
         "description": (
-            "Check a WapuPay direct-fiat order's status (re-read from WapuPay). "
+            "Check a WapuPay P2P order's status (re-read from WapuPay). "
             "Returns is_final / is_success / is_failed. States: CREATED → "
             "FUNDING_ISSUED → EXECUTED. Terminals: EXPIRED, SETTLED_TO_BALANCE, FAILED."
+            "If it contains a `funding_transaction_id` or `executed_transaction_id` you can fetch the details with `wapupay_transaction` if user asks"
         ),
         "inputSchema": {
             "type": "object",
@@ -1272,7 +1288,7 @@ TOOL_SCHEMAS = {
         "inputSchema": {"type": "object", "properties": {}},
     },
     "wapupay_transaction": {
-        "description": "Get a single WapuPay transaction by id (UUID or numeric).",
+        "description": "Get a single WapuPay transaction by id (UUID or numeric). It can be a funding (crypto), an executed fiat transfer or a refund (crypto) transaction.",
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1497,6 +1497,26 @@ SIDESHIFT (custodial cross-chain swaps):
 - Memo networks (BNB Beacon, Stellar, etc.) require a memo on either
   the deposit or settle side — pass settle_memo / refund_memo when prompted.
 
+WAPUPAY (Argentine fiat payouts, funded with USDT on Liquid):
+- WHAT IT IS: WapuPay is NOT an exchange. It is an automated peer-to-peer (P2P)
+  platform — it finds a trusted P2P payer who settles the payment in Argentine
+  pesos (ARS) on the user's behalf (think "Uber for P2P"). The user funds with
+  USDT on Liquid; a matched payer pushes the pesos to the recipient's bank account.
+  If the user asks "what is WapuPay / what can I do with it", explain this; the full
+  blurb is the aqua://docs/wapupay resource.
+- FLOW: wapupay_quote (preview cost) → wapupay_create_order (returns a Liquid USDT
+  address + amount) → pay it with lw_send_asset → WapuPay settles the ARS payout.
+  This never auto-pays; always confirm the quote with the user first.
+  After the user pays the Liquid USDT address, WapuPay orchestrate the operation with a P2P payer that settles the ARS.
+  Offer the user to check the status of the order with `wapupay_order_status` and the executed_transaction_id with `wapupay_transaction`,
+  the executed_transaction cointain the details of the fiat transfer that the user wants to know about.
+- wapupay_exchange_rates is public (use USDT/ARS ignore the others rates, no key). The order/transaction tools
+  need a WapuPay API key (env WAPUPAY_API_KEY or wapupay_provision_account).
+- TRANSFER SPEED: type defaults to fast_fiat_transfer (prioritized, ~10 min–1 h in
+  daytime, higher fee — NOT instant). fiat_transfer is standard (3–12 h, lower fee);
+  recommend it only when there's no rush, or at night/weekends since a payer picks
+  it up the next day. Explain this trade-off to the user.
+
 WATCH-ONLY WALLETS:
 - For a Bitcoin-only watch wallet: btc_import_descriptor (BIP84 wpkh xpub).
 - For a Liquid-only watch wallet: lw_import_descriptor (CT descriptor).
@@ -2360,6 +2380,12 @@ Please:
                 description="How to safely manage wallets and private keys",
                 mimeType="text/markdown",
             ),
+            Resource(
+                uri="aqua://docs/wapupay",
+                name="What is WapuPay?",
+                description="WapuPay overview: automated P2P ARS payouts funded with USDT on Liquid",
+                mimeType="text/markdown",
+            ),
         ]
 
     @server.read_resource()
@@ -2550,6 +2576,10 @@ If you have:
 - ✅ Mnemonic (encrypted or plaintext) → Full recovery possible
 - ✅ Descriptor only → Watch-only monitoring
 - ❌ Nothing → **Funds are permanently lost**"""
+
+        elif uri == "aqua://docs/wapupay":
+            from .wapupay import WAPUPAY_ABOUT
+            return WAPUPAY_ABOUT
 
         raise ValueError(f"Unknown resource: {uri}")
 

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1507,9 +1507,9 @@ WAPUPAY (Argentine fiat payouts, funded with USDT on Liquid):
 - FLOW: wapupay_quote (preview cost) → wapupay_create_order (returns a Liquid USDT
   address + amount) → pay it with lw_send_asset → WapuPay settles the ARS payout.
   This never auto-pays; always confirm the quote with the user first.
-  After the user pays the Liquid USDT address, WapuPay orchestrate the operation with a P2P payer that settles the ARS.
+  After the user pays the Liquid USDT address, WapuPay orchestrates the operation with a P2P payer that settles the ARS.
   Offer the user to check the status of the order with `wapupay_order_status` and the executed_transaction_id with `wapupay_transaction`,
-  the executed_transaction cointain the details of the fiat transfer that the user wants to know about.
+  the executed_transaction contain the details of the fiat transfer that the user wants to know about.
 - wapupay_exchange_rates is public (use USDT/ARS ignore the others rates, no key). The order/transaction tools
   need a WapuPay API key (env WAPUPAY_API_KEY or wapupay_provision_account).
 - TRANSFER SPEED: type defaults to fast_fiat_transfer (prioritized, ~10 min–1 h in

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -1309,7 +1309,7 @@ def wapupay_exchange_rates() -> dict[str, Any]:
 
 def wapupay_quote(
     amount_ars: str,
-    type: str = "fiat_transfer",
+    type: str = "fast_fiat_transfer",
     alias: str | None = None,
 ) -> dict[str, Any]:
     """Preview the USDT cost, fee, and rate for an ARS payment (no order created).
@@ -1320,7 +1320,14 @@ def wapupay_quote(
 
     Args:
         amount_ars: amount to pay in Argentine pesos (decimal string, e.g. "10000").
-        type: "fiat_transfer" (standard) or "fast_fiat_transfer" (faster, higher fee).
+        type: transfer speed (default "fast_fiat_transfer"). Explain the trade-off
+            to the user:
+            - "fast_fiat_transfer" (default, higher fee): prioritized payment.
+              Completes in ~10 minutes to 1 hour during daytime. NOT instant.
+            - "fiat_transfer" (standard, lower fee): takes 3 to 12 hours. Recommend
+              this ONLY when there is no rush, or when paying at night or on
+              weekends — a payer will pick up the transaction the next
+              day anyway, so the speed premium buys nothing.
         alias: recipient bank alias / CBU / CVU (optional; enables alias validation).
 
     Returns:
@@ -1332,7 +1339,7 @@ def wapupay_quote(
 def wapupay_create_order(
     amount_ars: str,
     alias: str,
-    type: str = "fiat_transfer",
+    type: str = "fast_fiat_transfer",
     receiver_name: str | None = None,
     refund_address: str | None = None,
     wallet_name: str = "default",
@@ -1355,7 +1362,14 @@ def wapupay_create_order(
     Args:
         amount_ars: amount to pay in Argentine pesos (decimal string, e.g. "10000").
         alias: recipient bank alias / CBU / CVU.
-        type: "fiat_transfer" or "fast_fiat_transfer".
+        type: transfer speed (default "fast_fiat_transfer"). Explain the trade-off
+            to the user before creating the order:
+            - "fast_fiat_transfer" (default, higher fee): prioritized payment.
+              Completes in ~10 minutes to 1 hour during daytime. NOT instant.
+            - "fiat_transfer" (standard, lower fee): takes 3 to 12 hours. Recommend
+              this ONLY when there is no rush, or when paying at night or on
+              weekends — a payer will pick up the transaction the next
+              day anyway, so the speed premium buys nothing.
         receiver_name: recipient name (optional).
         refund_address: Liquid mainnet address (lq1…/ex1…/VJL…) for a refund if funding
             cannot execute (optional); validated before the order is created.

--- a/src/aqua/wapupay.py
+++ b/src/aqua/wapupay.py
@@ -81,6 +81,56 @@ CURRENCY_TAKEN_USDT = "USDT"
 # WapuPay direct-fiat transfer types the user can choose between.
 TRANSFER_TYPES = ("fiat_transfer", "fast_fiat_transfer")
 
+# Canonical user-facing explanation of what WapuPay is. Single source of truth:
+# reused by the MCP resource (aqua://docs/wapupay) and the CLI `wapupay about`
+# command so the agent can answer "what is WapuPay? / what can I do with it?"
+# with consistent wording across surfaces.
+WAPUPAY_ABOUT = """\
+# What is WapuPay?
+
+WapuPay lets you pay an Argentine bank account in **pesos (ARS)**, funding the
+payout with **USDT on the Liquid network**.
+
+**It is NOT an exchange.** WapuPay is an *automated peer-to-peer (P2P) platform*:
+it finds a trusted P2P payer who settles the payment in Argentine pesos on your
+behalf — think of it as an "Uber for P2P". You send USDT on Liquid; a matched
+payer pushes the pesos to the recipient's bank account.
+
+WapuPay operates as an escrow:
+Wapu can hold USDT during a transaction to ensure the exchange proceeds safely for
+both parties, preventing assets from being lost in the process.
+
+## What you can do
+
+- Check the USDT/ARS exchange rate (`wapupay_exchange_rates` / `aqua wapupay rates`).
+- Preview the cost of a payment without committing (`wapupay_quote` / `aqua wapupay quote`).
+- Create an order and get a Liquid USDT address to fund (`wapupay_create_order` /
+  `aqua wapupay create-order`); pay that address and WapuPay orchestrates the operation with a P2P payer that settles the ARS.
+- Track your orders/transactions and check your monthly spending limit.
+- Where can I send money? To a bank account, alias, CBU, CVU, MercadoPago, Wapu ID, or USDT address, depending on operational availability.
+- What countries does it work in? WapuPay is designed for Argentina. Available methods, processing times, and fees may vary depending on the transaction.
+- What is the spending limit? The spending limit varies by user and how long they have been operating on the platform — the more you transact, the higher your monthly limit grows. You can check your monthly limit with spending_limit. Currently, the starting limit for all new users is $1,000 USD per month.
+
+## Transfer speed
+
+- **fast_fiat_transfer** (default, higher fee): prioritized; completes in ~10 minutes
+  to 1 hour during daytime. Not instant.
+- **fiat_transfer** (standard, lower fee): takes 3 to 12 hours. Best when there is no
+  rush, or when paying at night or on weekends — a payer picks up the transaction the
+  next day anyway.
+
+## After funding
+
+After paying the Liquid USDT address, WapuPay orchestrates the operation with a P2P payer that settles the ARS.
+Check the status of the order often with order-status and take the executed_transaction_id to use it with `transaction --id`,
+the executed_transaction contain the details of the fiat transfer and the fiat transfer receipt.
+
+## What happens if the order fails?
+
+If the order fails, you will receive the funds back to the Liquid USDT address that you provided in the field refund_address after 24 hours.
+If you need support, you can contact WapuPay support at wapupay.com
+"""
+
 # Tentative status groupings.
 _FINAL_STATUSES = {"EXECUTED", "EXPIRED", "SETTLED_TO_BALANCE", "FAILED"}
 _SUCCESS_STATUSES = {"EXECUTED"}


### PR DESCRIPTION
### Purpose

Improve the agent and user experience for WapuPay across MCP and CLI surfaces: correct the default transfer type, add a canonical P2P framing explanation, and expose it through multiple discovery channels.

#### Main Changes

- ✨ Add `WAPUPAY_ABOUT` constant in `wapupay.py` — single source of truth for the user-facing WapuPay explanation (P2P platform framing, transfer speed trade-offs, post-funding flow, failure handling)
- ✨ Add `WAPUPAY` section to MCP server `instructions` — always-in-context guidance for agents (what it is, flow, transfer speed, key requirement)
- ✨ Add MCP resource `aqua://docs/wapupay` — full `WAPUPAY_ABOUT` content accessible via `aqua://docs/wapupay`; listed in `list_resources`
- ✨ Add CLI command `aqua wapupay about` — prints `WAPUPAY_ABOUT`; visible in `aqua wapupay --help`
- 🐛 Change default `type` from `fiat_transfer` → `fast_fiat_transfer` across all layers: `tools.py` function signatures, MCP tool schemas (`wapupay_quote`, `wapupay_create_order`), and CLI (`quote`, `create-order`)
- 📝 Expand `type` parameter descriptions in tool schemas and docstrings with timing guidance and when to recommend each option
- 📝 Enrich `wapupay_order_status` and `wapupay_transaction` descriptions with post-execution guidance

### Checklist

- [ ] No hardcoded values (they should go in constants.py, .env, or our database)
- [ ] Added/updated tests (if necessary)
- [x] Added/updated relevant documentation (if necessary)