### PR TITLE
Add JWT refresh-token support for AQUA sessions

### DIFF
--- a/src/aqua/ankara.py
+++ b/src/aqua/ankara.py
@@ -12,6 +12,7 @@ Single home for everything that talks to JAN3's backend (AQUA's Ankara host,
       imports ``wapupay`` (one-way dependency).
 """
 
+import base64
 import json
 import os
 import re
@@ -31,8 +32,12 @@ WAPUPAY_ACCOUNT_PATH = "/api/v1/wapupay/account/"
 USER_AGENT = "agentic-aqua"
 HTTP_TIMEOUT_SECONDS = 30.0
 
-# Bank-PII / secret fields that must never reach the logs. Shared by the JAN3
-# auth surface and (via import) WapuPay's business client.
+
+class SessionExpiredError(ValueError):
+    """Access or refresh JWT was rejected by Ankara (HTTP 401);
+    triggers token refresh and subclasses ValueError."""
+
+# Bank-PII / secret fields that must never reach the logs.
 _SENSITIVE_LOG_FIELDS = frozenset(
     {
         "alias",
@@ -176,12 +181,49 @@ def _extract_error_message(body: str) -> str:
             if isinstance(val, str) and val:
                 return _scrub_text(val[:200])
         # Redact nested validation errors before logging.
- 
+
         details = parsed.get("details")
         if details:
             return _scrub_text(json.dumps(_redact(details))[:200])
         return _scrub_text(json.dumps(_redact(parsed))[:200])
     return _scrub_text(str(parsed)[:200])
+
+
+# Treat an access token within this margin of its `exp` as already expired, to
+# cover clock skew and the latency of the call it is about to authorize.
+_JWT_EXP_SKEW_SECONDS = 30
+
+
+def _jwt_exp(token: str) -> Optional[int]:
+    """Best-effort read of a JWT's ``exp`` claim (no signature verification).
+
+    Returns the Unix expiry timestamp, or ``None`` if the token is malformed or
+    carries no ``exp`` (caller should then treat it as needing a live check).
+    """
+    try:
+        payload_b64 = token.split(".")[1]
+        padded = payload_b64 + "=" * (-len(payload_b64) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded))
+    except (AttributeError, IndexError, ValueError, TypeError):
+        return None
+    exp = payload.get("exp") if isinstance(payload, dict) else None
+    try:
+        return int(exp) if exp is not None else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _access_token_expired(token: str, *, now: Optional[float] = None) -> bool:
+    """Whether an access JWT is at/past its ``exp`` (with skew margin).
+
+    An unreadable token (no decodable ``exp``) is treated as expired so the
+    caller falls back to a live refresh rather than trusting it blindly.
+    """
+    exp = _jwt_exp(token)
+    if exp is None:
+        return True
+    current = now if now is not None else datetime.now(UTC).timestamp()
+    return exp <= current + _JWT_EXP_SKEW_SECONDS
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +269,7 @@ class JAN3AuthClient:
         access_token: Optional[str] = None,
     ) -> Any:
         """HTTP request, parse JSON. Raises ValueError on error."""
-   
+
         data = json.dumps(json_body).encode() if json_body is not None else None
         headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
         if data is not None:
@@ -255,6 +297,13 @@ class JAN3AuthClient:
             except Exception:
                 pass
             detail = _extract_error_message(body)
+            if e.code == 401:
+                # Token rejected — recoverable via refresh; raise the neutral
+                # signal so the manager can refresh-then-retry.
+                msg = "AQUA session token rejected (401)"
+                if detail:
+                    msg += f": {detail}"
+                raise SessionExpiredError(msg) from e
             msg = f"AQUA backend request failed ({e.code} {method})"
             if detail:
                 msg += f": {detail}"
@@ -280,12 +329,26 @@ class JAN3AuthClient:
             json_body={"email": email, "otp_code": otp_code},
         ) or {}
 
+    def refresh_token(self, refresh: str) -> dict:
+        """POST /auth/refresh/ — exchange a refresh JWT for a fresh ``{access}``.
+
+        Returns the backend payload, which always carries a new ``access`` and,
+        when token rotation is enabled, a new ``refresh``. A rejected/expired
+        refresh token surfaces as ``SessionExpiredError`` (401) from
+        ``_api_request``.
+        """
+        return self._api_request(
+            "POST",
+            f"{self.auth_base_url}/refresh/",
+            json_body={"refresh": refresh},
+        ) or {}
+
     def provision_wapupay_account(self, access_token: str) -> dict:
         """
         POST /api/v1/wapupay/account/ — creates a WapuPay user and returns its API key.
         Authenticates with AQUA JWT. Raises ValueError on error or unreachable backend.
         """
-   
+
         url = f"{self.aqua_backend_url}{WAPUPAY_ACCOUNT_PATH}"
         headers = {
             "User-Agent": USER_AGENT,
@@ -306,7 +369,11 @@ class JAN3AuthClient:
                     ) from e
         except urllib.error.HTTPError as e:
             if e.code == 401:
-                raise ValueError(
+                # Recoverable via refresh; raise the neutral signal so the
+                # manager can refresh-then-retry before telling the user to
+                # log in again. The message is only seen on a direct client
+                # call (no manager wrapping it).
+                raise SessionExpiredError(
                     "AQUA session invalid or expired — run aqua_login / aqua_verify again."
                 ) from e
             if e.code == 403:
@@ -396,15 +463,46 @@ class JAN3AccountManager:
         return {"logged_out": existed}
 
     def session_status(self) -> dict:
-        """Report whether a local AQUA session exists (no secrets returned)."""
+        """Report the AQUA session and its validity (no secrets returned).
+
+        Checks the access token's ``exp`` locally first; only if it has expired
+        does it hit the network to renew via the refresh token (which also
+        persists the fresh access). This keeps a status check cheap and avoids
+        minting a new access token on every call while the current one is still
+        good. ``valid``:
+
+        * ``True``  — access token still valid, or successfully refreshed.
+        * ``False`` — access expired and the refresh token was rejected; the
+          user must log in again.
+        * ``None``  — access expired but the backend was unreachable, so
+          validity could not be confirmed.
+        """
         session = self.storage.load_jan3_session()
         if not session:
             return {"logged_in": False}
-        return {
+        base = {
             "logged_in": True,
             "email": session.email,
             "created_at": session.created_at,
         }
+        if not _access_token_expired(session.access):
+            # Still valid — no network call, no token rotation.
+            return {**base, "valid": True}
+        # Access expired (or unreadable) — confirm the session can be renewed.
+        try:
+            self._refresh_session(session)
+            return {**base, "valid": True}
+        except SessionExpiredError:
+            return {
+                **base,
+                "valid": False,
+                "message": (
+                    "AQUA session expired — run aqua_login then aqua_verify again."
+                ),
+            }
+        except ValueError as e:
+            # Network/backend failure — don't claim the session is invalid.
+            return {**base, "valid": None, "message": f"Could not verify session: {e}"}
 
     def require_session(self) -> JAN3Session:
         """Return the stored AQUA session, or raise if the user is not logged in."""
@@ -415,15 +513,73 @@ class JAN3AccountManager:
             )
         return session
 
+    def _refresh_session(self, session: JAN3Session) -> JAN3Session:
+        """Mint a new access token from the stored refresh token; persist + return.
+
+        Rotation-aware: persists a new ``refresh`` token if the backend returns
+        one, otherwise keeps the existing one. Raises ``SessionExpiredError`` if
+        no refresh token is stored or the backend rejects it (so the caller can
+        fall through to a "log in again" message).
+        """
+        if not session.refresh:
+            raise SessionExpiredError("No refresh token stored for this AQUA session.")
+        tokens = self.client.refresh_token(session.refresh) or {}
+        new_access = tokens.get("access")
+        if not new_access or not str(new_access).strip():
+            raise SessionExpiredError(
+                "AQUA refresh did not return a new access token."
+            )
+        updated = JAN3Session(
+            email=session.email,
+            access=str(new_access).strip(),
+            # ROTATE_REFRESH_TOKENS may hand back a fresh refresh token; if not,
+            # the existing one stays valid.
+            refresh=str(tokens.get("refresh") or session.refresh),
+            created_at=session.created_at,
+        )
+        self.storage.save_jan3_session(updated)
+        return updated
+
+    def _with_auth_retry(self, call):
+        """Run ``call(access_token)``; on a 401, refresh once and retry once.
+
+        Centralizes the access-token fallback for every authenticated AQUA call:
+        attempt with the current access token, and if it is rejected
+        (``SessionExpiredError``) transparently refresh the JWT and retry a
+        single time. Only if the refresh itself fails (or the retry is still
+        rejected) does the user get a clear "log in again" ``ValueError``.
+        """
+        session = self.require_session()
+        try:
+            return call(session.access)
+        except SessionExpiredError:
+            try:
+                session = self._refresh_session(session)
+            except SessionExpiredError as e:
+                raise ValueError(
+                    "AQUA session expired and could not be refreshed — "
+                    "run aqua_login then aqua_verify again."
+                ) from e
+            try:
+                return call(session.access)
+            except SessionExpiredError as e:
+                raise ValueError(
+                    "AQUA session still invalid after refresh — "
+                    "run aqua_login then aqua_verify again."
+                ) from e
+
     def provision_wapupay_token(self) -> str:
         """Provision a fresh WapuPay API key from the AQUA backend and return it.
 
         Requires a prior AQUA login (``aqua_login`` → ``aqua_verify``): the call
-        is authorized with that JWT. The AQUA backend issues a fresh key on EVERY
-        call and invalidates any key previously issued for the account.
+        is authorized with that JWT, and a rejected access token is refreshed
+        transparently (see ``_with_auth_retry``). The AQUA backend issues a fresh
+        key on EVERY call and invalidates any key previously issued for the
+        account.
         """
-        session = self.require_session()
-        resp = self.client.provision_wapupay_account(session.access)
+        resp = self._with_auth_retry(
+            lambda access: self.client.provision_wapupay_account(access)
+        )
         token = (resp or {}).get("token")
         if not token or not str(token).strip():
             raise ValueError(

--- a/src/aqua/ankara.py
+++ b/src/aqua/ankara.py
@@ -195,11 +195,8 @@ _JWT_EXP_SKEW_SECONDS = 30
 
 
 def _jwt_exp(token: str) -> Optional[int]:
-    """Best-effort read of a JWT's ``exp`` claim (no signature verification).
-
-    Returns the Unix expiry timestamp, or ``None`` if the token is malformed or
-    carries no ``exp`` (caller should then treat it as needing a live check).
-    """
+    """Best-effort decode of a JWT's ``exp`` claim (no signature check).
+    Returns the timestamp, or ``None`` if the token is malformed or missing ``exp``."""
     try:
         payload_b64 = token.split(".")[1]
         padded = payload_b64 + "=" * (-len(payload_b64) % 4)
@@ -214,11 +211,7 @@ def _jwt_exp(token: str) -> Optional[int]:
 
 
 def _access_token_expired(token: str, *, now: Optional[float] = None) -> bool:
-    """Whether an access JWT is at/past its ``exp`` (with skew margin).
-
-    An unreadable token (no decodable ``exp``) is treated as expired so the
-    caller falls back to a live refresh rather than trusting it blindly.
-    """
+    """True if the access JWT is expired or unreadable (forces a live refresh)."""
     exp = _jwt_exp(token)
     if exp is None:
         return True
@@ -298,8 +291,7 @@ class JAN3AuthClient:
                 pass
             detail = _extract_error_message(body)
             if e.code == 401:
-                # Token rejected — recoverable via refresh; raise the neutral
-                # signal so the manager can refresh-then-retry.
+                # Recoverable — raise the typed signal so the manager can refresh-then-retry.
                 msg = "AQUA session token rejected (401)"
                 if detail:
                     msg += f": {detail}"
@@ -331,12 +323,7 @@ class JAN3AuthClient:
 
     def refresh_token(self, refresh: str) -> dict:
         """POST /auth/refresh/ — exchange a refresh JWT for a fresh ``{access}``.
-
-        Returns the backend payload, which always carries a new ``access`` and,
-        when token rotation is enabled, a new ``refresh``. A rejected/expired
-        refresh token surfaces as ``SessionExpiredError`` (401) from
-        ``_api_request``.
-        """
+        May also return a rotated ``refresh``; raises ``SessionExpiredError`` on 401."""
         return self._api_request(
             "POST",
             f"{self.auth_base_url}/refresh/",
@@ -369,10 +356,7 @@ class JAN3AuthClient:
                     ) from e
         except urllib.error.HTTPError as e:
             if e.code == 401:
-                # Recoverable via refresh; raise the neutral signal so the
-                # manager can refresh-then-retry before telling the user to
-                # log in again. The message is only seen on a direct client
-                # call (no manager wrapping it).
+                # Recoverable — manager wraps this via _with_auth_retry and retries before re-login.
                 raise SessionExpiredError(
                     "AQUA session invalid or expired — run aqua_login / aqua_verify again."
                 ) from e
@@ -463,20 +447,10 @@ class JAN3AccountManager:
         return {"logged_out": existed}
 
     def session_status(self) -> dict:
-        """Report the AQUA session and its validity (no secrets returned).
+        """Report AQUA session status without leaking secrets.
 
-        Checks the access token's ``exp`` locally first; only if it has expired
-        does it hit the network to renew via the refresh token (which also
-        persists the fresh access). This keeps a status check cheap and avoids
-        minting a new access token on every call while the current one is still
-        good. ``valid``:
-
-        * ``True``  — access token still valid, or successfully refreshed.
-        * ``False`` — access expired and the refresh token was rejected; the
-          user must log in again.
-        * ``None``  — access expired but the backend was unreachable, so
-          validity could not be confirmed.
-        """
+        Validates ``exp`` locally; refreshes via stored token if expired.
+        Returns ``valid``: True=ok, False=re-login needed, None=network error."""
         session = self.storage.load_jan3_session()
         if not session:
             return {"logged_in": False}
@@ -514,13 +488,8 @@ class JAN3AccountManager:
         return session
 
     def _refresh_session(self, session: JAN3Session) -> JAN3Session:
-        """Mint a new access token from the stored refresh token; persist + return.
-
-        Rotation-aware: persists a new ``refresh`` token if the backend returns
-        one, otherwise keeps the existing one. Raises ``SessionExpiredError`` if
-        no refresh token is stored or the backend rejects it (so the caller can
-        fall through to a "log in again" message).
-        """
+        """Exchange the stored refresh token for a new access token and persist it.
+        Rotation-aware; raises ``SessionExpiredError`` if no refresh is stored or rejected."""
         if not session.refresh:
             raise SessionExpiredError("No refresh token stored for this AQUA session.")
         tokens = self.client.refresh_token(session.refresh) or {}
@@ -541,14 +510,8 @@ class JAN3AccountManager:
         return updated
 
     def _with_auth_retry(self, call):
-        """Run ``call(access_token)``; on a 401, refresh once and retry once.
-
-        Centralizes the access-token fallback for every authenticated AQUA call:
-        attempt with the current access token, and if it is rejected
-        (``SessionExpiredError``) transparently refresh the JWT and retry a
-        single time. Only if the refresh itself fails (or the retry is still
-        rejected) does the user get a clear "log in again" ``ValueError``.
-        """
+        """Call ``call(access_token)``; on ``SessionExpiredError`` refresh once and retry.
+        Raises ``ValueError`` only when refresh itself fails or the retry is still rejected."""
         session = self.require_session()
         try:
             return call(session.access)
@@ -569,14 +532,8 @@ class JAN3AccountManager:
                 ) from e
 
     def provision_wapupay_token(self) -> str:
-        """Provision a fresh WapuPay API key from the AQUA backend and return it.
-
-        Requires a prior AQUA login (``aqua_login`` → ``aqua_verify``): the call
-        is authorized with that JWT, and a rejected access token is refreshed
-        transparently (see ``_with_auth_retry``). The AQUA backend issues a fresh
-        key on EVERY call and invalidates any key previously issued for the
-        account.
-        """
+        """Provision a fresh WapuPay API key via the AQUA backend (requires prior login).
+        Uses ``_with_auth_retry``; the backend invalidates any previous key on each call."""
         resp = self._with_auth_retry(
             lambda access: self.client.provision_wapupay_account(access)
         )

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1172,7 +1172,11 @@ TOOL_SCHEMAS = {
         "inputSchema": {"type": "object", "properties": {}},
     },
     "aqua_session": {
-        "description": "Report whether an AQUA session is active (no secrets returned).",
+        "description": (
+            "Report whether an AQUA session is active and still valid (no secrets "
+            "returned). Checks the token expiry locally and only renews against "
+            "Jan3 if it has expired."
+        ),
         "inputSchema": {"type": "object", "properties": {}},
     },
     "wapupay_exchange_rates": {

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -1294,7 +1294,9 @@ def aqua_logout() -> dict[str, Any]:
 
 
 def aqua_session() -> dict[str, Any]:
-    """Report whether an AQUA session is active (no secrets returned)."""
+    """Check if AQUA session is active and valid.
+
+    Refreshes token if needed. Returns login and validity status."""
     return get_jan3_manager().session_status()
 
 

--- a/tests/test_ankara.py
+++ b/tests/test_ankara.py
@@ -18,6 +18,9 @@ from aqua.ankara import (
     JAN3AccountManager,
     JAN3AuthClient,
     JAN3Session,
+    SessionExpiredError,
+    _access_token_expired,
+    _jwt_exp,
 )
 from aqua.storage import Storage
 from aqua.wallet import WalletManager
@@ -330,6 +333,10 @@ class FakeAuthClient:
     def _yield(self, name, *args):
         self.calls.append((name, args))
         val = self.responses.get(name)
+        # A list scripts a sequence of results across repeated calls (e.g. a 401
+        # then a success after refresh).
+        if isinstance(val, list):
+            val = val.pop(0)
         if isinstance(val, Exception):
             raise val
         return val if val is not None else {}
@@ -339,6 +346,9 @@ class FakeAuthClient:
 
     def verify(self, email, otp_code):
         return self._yield("verify", email, otp_code)
+
+    def refresh_token(self, refresh):
+        return self._yield("refresh_token", refresh)
 
     def provision_wapupay_account(self, access_token):
         return self._yield("provision_wapupay_account", access_token)
@@ -354,6 +364,16 @@ def logged_in(storage, email="user@example.com", access="acc.tok", refresh="ref.
     storage.save_jan3_session(
         JAN3Session(email=email, access=access, refresh=refresh, created_at="t0")
     )
+
+
+def _jwt_with_exp(exp):
+    """Build an unsigned JWT carrying the given ``exp`` claim (test fixture)."""
+    import base64
+
+    def seg(obj):
+        return base64.urlsafe_b64encode(json.dumps(obj).encode()).rstrip(b"=").decode()
+
+    return f"{seg({'alg': 'HS256', 'typ': 'JWT'})}.{seg({'exp': exp})}.sig"
 
 
 # ---------------------------------------------------------------------------
@@ -420,14 +440,81 @@ def test_verify_without_tokens_raises_and_saves_nothing(jan3_storage):
 
 
 def test_logout_and_session_status(jan3_storage):
-    m = make_jan3(jan3_storage, FakeAuthClient())
+    # session_status is a live check: it refreshes to confirm the session works.
+    fake = FakeAuthClient({"refresh_token": {"access": "fresh.acc"}})
+    m = make_jan3(jan3_storage, fake)
     assert m.session_status() == {"logged_in": False}
     logged_in(jan3_storage, email="x@y.com")
     st = m.session_status()
     assert st["logged_in"] is True and st["email"] == "x@y.com"
+    assert st["valid"] is True
     assert "access" not in st and "refresh" not in st  # no secrets leaked
     assert m.logout()["logged_out"] is True
     assert jan3_storage.load_jan3_session() is None
+
+
+def test_session_status_live_valid_persists_rotated_tokens(jan3_storage):
+    # A successful live check persists the rotated access/refresh.
+    fake = FakeAuthClient(
+        {"refresh_token": {"access": "rot.acc", "refresh": "rot.ref"}}
+    )
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage, access="old.acc", refresh="old.ref")
+    st = m.session_status()
+    assert st["valid"] is True
+    sess = jan3_storage.load_jan3_session()
+    assert sess.access == "rot.acc" and sess.refresh == "rot.ref"
+    assert fake.calls == [("refresh_token", ("old.ref",))]
+
+
+def test_session_status_expired_when_refresh_rejected(jan3_storage):
+    fake = FakeAuthClient({"refresh_token": SessionExpiredError("401")})
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    st = m.session_status()
+    assert st["logged_in"] is True and st["valid"] is False
+    assert "aqua_login" in st["message"]
+
+
+def test_session_status_unknown_on_network_error(jan3_storage):
+    fake = FakeAuthClient({"refresh_token": ValueError("AQUA backend unreachable")})
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage, access=_jwt_with_exp(1_000_000_000))  # long expired
+    st = m.session_status()
+    assert st["logged_in"] is True and st["valid"] is None
+    assert "Could not verify" in st["message"]
+
+
+def test_session_status_valid_access_skips_refresh(jan3_storage):
+    # A still-valid access token reports valid WITHOUT any network call/rotation.
+    fake = FakeAuthClient({"refresh_token": {"access": "should.not.be.used"}})
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage, access=_jwt_with_exp(9_999_999_999))  # far future
+    st = m.session_status()
+    assert st["valid"] is True
+    assert fake.calls == []  # exp checked locally, refresh never called
+
+
+# ---------------------------------------------------------------------------
+# JWT expiry helpers
+# ---------------------------------------------------------------------------
+
+
+def test_jwt_exp_reads_claim_and_handles_garbage():
+    assert _jwt_exp(_jwt_with_exp(1782677992)) == 1782677992
+    assert _jwt_exp("not-a-jwt") is None
+    assert _jwt_exp("only.two") is None  # missing payload segment is unreadable
+    assert _jwt_exp("") is None
+
+
+def test_access_token_expired_uses_skew():
+    now = 1_000_000.0
+    # Past exp -> expired; comfortably future -> not; within skew window -> expired.
+    assert _access_token_expired(_jwt_with_exp(999_000), now=now) is True
+    assert _access_token_expired(_jwt_with_exp(2_000_000), now=now) is False
+    assert _access_token_expired(_jwt_with_exp(int(now) + 10), now=now) is True
+    # Unreadable token is treated as expired (fall back to live refresh).
+    assert _access_token_expired("garbage", now=now) is True
 
 
 # ---------------------------------------------------------------------------
@@ -521,5 +608,121 @@ def test_provision_client_unreachable():
         with pytest.raises(ValueError) as ei:
             client.provision_wapupay_account("jwt")
     assert "unreachable" in str(ei.value).lower()
+
+
+def test_provision_client_401_is_session_expired():
+    # A 401 is a recoverable signal (SessionExpiredError), not a generic error,
+    # so the manager can refresh-then-retry. Still a ValueError subclass.
+    client = JAN3AuthClient(aqua_backend_url="http://h")
+    with patch(
+        "aqua.ankara.urllib.request.urlopen",
+        side_effect=_http_error(401, '{"detail": "expired"}'),
+    ):
+        with pytest.raises(SessionExpiredError):
+            client.provision_wapupay_account("expired")
+
+
+# ---------------------------------------------------------------------------
+# JAN3AuthClient: refresh token
+# ---------------------------------------------------------------------------
+
+
+def test_client_refresh_token_target():
+    # refresh hits the custom /api/v1/auth/refresh/ with the refresh token body.
+    client = JAN3AuthClient()
+    seen = {}
+
+    def fake_urlopen(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["body"] = json.loads(req.data)
+        return _mock_resp({"access": "new.acc"})
+
+    with patch("aqua.ankara.urllib.request.urlopen", side_effect=fake_urlopen):
+        out = client.refresh_token("the.refresh.tok")
+    assert out == {"access": "new.acc"}
+    assert seen["url"] == f"{AUTH_BASE_URL}/refresh/"
+    assert seen["body"] == {"refresh": "the.refresh.tok"}
+
+
+def test_client_refresh_token_401_is_session_expired():
+    client = JAN3AuthClient()
+    with patch(
+        "aqua.ankara.urllib.request.urlopen",
+        side_effect=_http_error(401, '{"detail": "token not valid"}'),
+    ):
+        with pytest.raises(SessionExpiredError):
+            client.refresh_token("dead.refresh")
+
+
+# ---------------------------------------------------------------------------
+# JAN3AccountManager: refresh + auth-retry fallback
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_session_keeps_old_refresh_when_not_rotated(jan3_storage):
+    # No rotated refresh in the response -> the stored one is preserved.
+    fake = FakeAuthClient({"refresh_token": {"access": "new.acc"}})
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage, access="old.acc", refresh="keep.ref")
+    updated = m._refresh_session(jan3_storage.load_jan3_session())
+    assert updated.access == "new.acc" and updated.refresh == "keep.ref"
+    assert jan3_storage.load_jan3_session().access == "new.acc"
+
+
+def test_refresh_session_no_refresh_token_raises(jan3_storage):
+    m = make_jan3(jan3_storage, FakeAuthClient())
+    sess = JAN3Session(email="x@y.com", access="a", refresh="", created_at="t0")
+    with pytest.raises(SessionExpiredError):
+        m._refresh_session(sess)
+
+
+def test_provision_token_refreshes_and_retries_on_401(jan3_storage):
+    # First provision call 401s; manager refreshes, then the retry succeeds with
+    # the new access token.
+    fake = FakeAuthClient(
+        {
+            "provision_wapupay_account": [
+                SessionExpiredError("401"),
+                {"token": "WapuKey_after_refresh"},
+            ],
+            "refresh_token": {"access": "fresh.acc", "refresh": "fresh.ref"},
+        }
+    )
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage, access="stale.acc", refresh="good.ref")
+    token = m.provision_wapupay_token()
+    assert token == "WapuKey_after_refresh"
+    # Order: stale access -> refresh -> retry with the fresh access.
+    assert fake.calls == [
+        ("provision_wapupay_account", ("stale.acc",)),
+        ("refresh_token", ("good.ref",)),
+        ("provision_wapupay_account", ("fresh.acc",)),
+    ]
+    # Rotated tokens persisted.
+    assert jan3_storage.load_jan3_session().access == "fresh.acc"
+
+
+def test_provision_token_relogin_when_refresh_fails(jan3_storage):
+    # Access rejected AND refresh rejected -> a clear "log in again" ValueError.
+    fake = FakeAuthClient(
+        {
+            "provision_wapupay_account": SessionExpiredError("401"),
+            "refresh_token": SessionExpiredError("401"),
+        }
+    )
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    with pytest.raises(ValueError) as ei:
+        m.provision_wapupay_token()
+    assert "aqua_login" in str(ei.value)
+
+
+def test_provision_token_no_retry_on_success(jan3_storage):
+    # Happy path never touches refresh.
+    fake = FakeAuthClient({"provision_wapupay_account": {"token": "k"}})
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage, access="good.acc")
+    assert m.provision_wapupay_token() == "k"
+    assert fake.calls == [("provision_wapupay_account", ("good.acc",))]
 
 

--- a/tests/test_ankara.py
+++ b/tests/test_ankara.py
@@ -333,8 +333,7 @@ class FakeAuthClient:
     def _yield(self, name, *args):
         self.calls.append((name, args))
         val = self.responses.get(name)
-        # A list scripts a sequence of results across repeated calls (e.g. a 401
-        # then a success after refresh).
+        # A list scripts a response sequence, e.g. a 401 then a success after refresh.
         if isinstance(val, list):
             val = val.pop(0)
         if isinstance(val, Exception):
@@ -611,8 +610,7 @@ def test_provision_client_unreachable():
 
 
 def test_provision_client_401_is_session_expired():
-    # A 401 is a recoverable signal (SessionExpiredError), not a generic error,
-    # so the manager can refresh-then-retry. Still a ValueError subclass.
+    # 401 → SessionExpiredError (recoverable, ValueError subclass) so the manager can retry.
     client = JAN3AuthClient(aqua_backend_url="http://h")
     with patch(
         "aqua.ankara.urllib.request.urlopen",
@@ -677,8 +675,7 @@ def test_refresh_session_no_refresh_token_raises(jan3_storage):
 
 
 def test_provision_token_refreshes_and_retries_on_401(jan3_storage):
-    # First provision call 401s; manager refreshes, then the retry succeeds with
-    # the new access token.
+    # First provision 401s; manager refreshes and retries with the fresh token.
     fake = FakeAuthClient(
         {
             "provision_wapupay_account": [

--- a/tests/test_wapupay.py
+++ b/tests/test_wapupay.py
@@ -107,6 +107,9 @@ class FakeClient:
     def verify(self, email, otp_code):
         return self._yield("verify", email, otp_code)
 
+    def refresh_token(self, refresh):
+        return self._yield("refresh_token", refresh)
+
     def provision_wapupay_account(self, access_token):
         return self._yield("provision_wapupay_account", access_token)
 


### PR DESCRIPTION
### Purpose

Implement automatic JWT access-token refresh so AQUA sessions survive token expiry without requiring the user to log in again. When an authenticated call receives a 401, the manager transparently refreshes the access token and retries once.

#### Main Changes

- ✨ Add `SessionExpiredError` — typed `ValueError` subclass for recoverable 401 responses, distinguishable from hard failures
- ✨ Add `_jwt_exp` / `_access_token_expired` helpers — decode JWT `exp` claim locally (no signature check) with a 30-second skew margin
- ✨ Add `JAN3AuthClient.refresh_token()` — POST `/auth/refresh/` to exchange a refresh JWT for a new access token
- ✨ Add `JAN3AccountManager._refresh_session()` — rotation-aware: persists a new `refresh` token if the backend returns one, otherwise keeps the existing one
- ✨ Add `JAN3AccountManager._with_auth_retry()` — centralizes the access-token fallback: attempt call → on `SessionExpiredError` refresh once → retry once → raise clear `ValueError` only on double failure
- ♻️ `session_status()` — now validates `exp` locally first (cheap path), only hits the network when the token is expired; returns `valid: True/False/None`
- ♻️ `provision_wapupay_token()` — delegates auth retry to `_with_auth_retry` instead of calling `require_session()` directly
- 🔧 Updated `aqua_session` MCP tool description and `tools.py` docstring to reflect the new validity check
- ✅ Full test coverage: JWT helpers, refresh client method, session refresh/rotation, auth-retry flow (success, 401→refresh→retry, double-fail), and `session_status` validity states

### Checklist

- [ ] No hardcoded values (they should go in constants.py, .env, or our database)
- [x] Added/updated tests (if necessary)
- [x] Added/updated relevant documentation (if necessary)