### PR TITLE
Implement JAN3 Lightning Addresses (#108) :construction:

### DIFF
--- a/src/aqua/ankara.py
+++ b/src/aqua/ankara.py
@@ -13,13 +13,19 @@ Single home for everything that talks to JAN3's backend (AQUA's Ankara host,
 """
 
 import json
+import logging
 import os
 import re
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import asdict, dataclass, fields
 from datetime import UTC, datetime
-from typing import Any, Optional
+from typing import Any, Callable, Optional
+
+
+class _AuthExpired(Exception):
+    """Signals the access token was rejected (401). Caught by the manager to retry with a refreshed token."""
 
 # API URL with environment variable override
 ANKARA_API_URL = os.environ.get("ANKARA_API_URL", "https://ankara.aquabtc.com")
@@ -30,6 +36,12 @@ WAPUPAY_ACCOUNT_PATH = "/api/v1/wapupay/account/"
 
 USER_AGENT = "agentic-aqua"
 HTTP_TIMEOUT_SECONDS = 30.0
+
+logger = logging.getLogger(__name__)
+
+# Server-side cap on addresses per ``POST /api/v1/auth/user/addresses/`` request
+# (see ``UserLiquidAddressesUpsert.addresses.maxItems`` in the OpenAPI schema).
+MAX_ADDRESSES_PER_REGISTRATION = 15
 
 # Bank-PII / secret fields that must never reach the logs. Shared by the JAN3
 # auth surface and (via import) WapuPay's business client.
@@ -254,6 +266,8 @@ class JAN3AuthClient:
                 body = e.read().decode()
             except Exception:
                 pass
+            if e.code == 401 and access_token:
+                raise _AuthExpired() from e
             detail = _extract_error_message(body)
             msg = f"AQUA backend request failed ({e.code} {method})"
             if detail:
@@ -278,6 +292,71 @@ class JAN3AuthClient:
             "POST",
             f"{self.auth_base_url}/verify/",
             json_body={"email": email, "otp_code": otp_code},
+        ) or {}
+
+    def refresh_access(self, refresh_token: str) -> str:
+        """POST /auth/refresh/ — exchange the refresh JWT for a new access JWT."""
+        resp = self._api_request(
+            "POST",
+            f"{self.auth_base_url}/refresh/",
+            json_body={"refresh": refresh_token},
+        ) or {}
+        access = resp.get("access")
+        if not access:
+            raise ValueError("AQUA refresh did not return a new access token.")
+        return access
+
+    def get_user(self, access_token: str) -> dict:
+        """GET /auth/user/ — current user profile (email, ln_username, fingerprint, …)."""
+        return self._api_request(
+            "GET",
+            f"{self.auth_base_url}/user/",
+            access_token=access_token,
+        ) or {}
+
+    def ln_address_toggle(self, access_token: str, enabled: bool) -> dict:
+        """POST /auth/user/ln-address-toggle/ — opt in/out of the LN-address feature."""
+        return self._api_request(
+            "POST",
+            f"{self.auth_base_url}/user/ln-address-toggle/",
+            json_body={"enabled": bool(enabled)},
+            access_token=access_token,
+        ) or {}
+
+    def ln_username_available(self, username: str, access_token: Optional[str] = None) -> dict:
+        """GET /auth/user/ln-username/{u}/is-available — availability check.
+
+        Schema marks this anonymous, but the live deployment requires a JWT — so
+        we forward ``access_token`` when one is available.
+        """
+        safe = urllib.parse.quote(username, safe="")
+        return self._api_request(
+            "GET",
+            f"{self.auth_base_url}/user/ln-username/{safe}/is-available",
+            access_token=access_token,
+        ) or {}
+
+    def register_addresses(
+        self,
+        access_token: str,
+        fingerprint: str,
+        addresses: list[str],
+        override_fingerprint: bool = False,
+    ) -> dict:
+        """POST /auth/user/addresses/ — upload unused Liquid receive addresses.
+
+        ``override_fingerprint=true`` (query string) makes the server re-bind the
+        account to this wallet's fingerprint and also flips ``ln_address_toggled``
+        back to true.
+        """
+        url = f"{self.auth_base_url}/user/addresses/"
+        if override_fingerprint:
+            url += "?override_fingerprint=true"
+        return self._api_request(
+            "POST",
+            url,
+            json_body={"fingerprint": fingerprint, "addresses": list(addresses)},
+            access_token=access_token,
         ) or {}
 
     def provision_wapupay_account(self, access_token: str) -> dict:
@@ -338,9 +417,16 @@ class JAN3AccountManager:
     Uses Storage for persistence.
     """
 
-    def __init__(self, storage) -> None:
+    def __init__(
+        self,
+        storage,
+        wallet_manager_factory: Optional[Callable[[], Any]] = None,
+    ) -> None:
         self.storage = storage
         self._client: Optional[JAN3AuthClient] = None
+        # Lazy WalletManager accessor. Optional so tests can construct the
+        # manager without wiring up wallet state.
+        self._wallet_manager_factory = wallet_manager_factory
 
     @property
     def client(self) -> JAN3AuthClient:
@@ -414,6 +500,236 @@ class JAN3AccountManager:
                 "Not logged in to your AQUA account. Run aqua_login then aqua_verify."
             )
         return session
+
+    def _authed_call(self, fn: Callable[[str], Any]) -> Any:
+        """Run ``fn(access_token)``; on 401, refresh the access token once and retry.
+
+        Both the refresh and the original error surfaces are mapped to the
+        "session invalid or expired" message so callers see a single recovery
+        hint regardless of which leg failed.
+
+        After a successful refresh, we opportunistically top up the LN-address
+        pool — refresh is the natural "we just touched the session" checkpoint,
+        and the AQUA app's ``LnAddressRegistrationNotifier`` re-runs on the
+        equivalent provider rebuild. The top-up never breaks the caller's call:
+        any error is swallowed and logged at DEBUG.
+        """
+        session = self.require_session()
+        try:
+            return fn(session.access)
+        except _AuthExpired:
+            try:
+                new_access = self.client.refresh_access(session.refresh)
+            except ValueError as refresh_err:
+                raise ValueError(
+                    "AQUA session expired and refresh failed — run aqua_login / aqua_verify again."
+                ) from refresh_err
+            session.access = new_access
+            self.storage.save_jan3_session(session)
+            try:
+                result = fn(new_access)
+            except _AuthExpired as second_401:
+                raise ValueError(
+                    "AQUA session invalid after refresh — run aqua_login / aqua_verify again."
+                ) from second_401
+            self._opportunistic_top_up(new_access)
+            return result
+
+    def _opportunistic_top_up(self, access_token: str) -> None:
+        """Fire-and-forget LN-address pool refill after a successful token refresh.
+
+        Fetches the user profile once with the just-refreshed token and threads
+        it through ``ensure_ln_pool`` → ``register_ln_addresses`` so the whole
+        opportunistic-top-up path costs at most a single ``get_user`` round trip.
+        """
+        if self._wallet_manager_factory is None:
+            return
+        try:
+            wm = self._wallet_manager_factory()
+            profile = self.client.get_user(access_token)
+            self.ensure_ln_pool(wallet_manager=wm, wallet_name="default", profile=profile)
+        except Exception as e:  # noqa: BLE001 — never break the caller's flow
+            logger.debug("Opportunistic LN-address top-up skipped: %s", e)
+
+    def get_user(self) -> dict:
+        """Return the current user profile from /auth/user/."""
+        return self._authed_call(self.client.get_user)
+
+    def ln_address_toggle(self, enabled: bool) -> dict:
+        """Enable or disable the LN-address feature on the account."""
+        return self._authed_call(lambda access: self.client.ln_address_toggle(access, enabled))
+
+    def ln_username_available(self, username: str) -> dict:
+        """Check whether an LN username is free to claim.
+
+        The OpenAPI schema marks this anonymous, but the live AQUA deployment
+        requires a JWT. If a local session exists we forward the token (with
+        auto-refresh on 401); otherwise we fall back to an anonymous request so
+        the schema-documented behavior still works against future deployments.
+        """
+        username = (username or "").strip()
+        if not username:
+            raise ValueError("ln_username is required")
+        session = self.storage.load_jan3_session()
+        if session and session.access:
+            return self._authed_call(
+                lambda access: self.client.ln_username_available(username, access)
+            )
+        return self.client.ln_username_available(username)
+
+    def register_ln_addresses(
+        self,
+        wallet_manager,
+        wallet_name: str,
+        count: Optional[int] = None,
+        override_fingerprint: bool = False,
+        password: Optional[str] = None,
+        profile: Optional[dict] = None,
+    ) -> dict:
+        """Mint a batch of unused Liquid receive addresses and POST them to /auth/user/addresses/.
+
+        Without a healthy pool of unused addresses on the server, inbound LN
+        payments to ``<ln_username>@aquabtc.com`` cannot be delivered — the
+        server hands out one address per invoice. Mirrors the AQUA app's
+        ``LnAddressRegistrationNotifier``.
+
+        Args:
+            wallet_manager: WalletManager instance (passed in to avoid a circular import).
+            wallet_name: Liquid wallet whose receive addresses get uploaded.
+            count: number of addresses to register. If omitted, uses the server's
+                ``new_addresses_needed`` from /auth/user/, falling back to 5
+                (the app's boot constant). Capped at 15 (server limit per call).
+            override_fingerprint: re-bind the account to this wallet's fingerprint.
+                Server-side this also flips ``ln_address_toggled`` to true. Use
+                only when intentionally rebinding (e.g. after a wallet restore).
+            password: decrypts the wallet's mnemonic if it was encrypted at rest.
+            profile: an already-fetched ``aqua_get_user`` profile dict. Callers
+                that just fetched it can pass it in to avoid a second round trip.
+
+        Returns:
+            ``{registered_count, fingerprint, addresses}`` where ``addresses`` is
+            the full active/unused pool the server now knows about.
+        """
+        user = profile if profile is not None else self.get_user()
+        ln_username = user.get("ln_username")
+        if not ln_username:
+            raise ValueError(
+                "This account has no LN username yet — run jan3_purchase_ln_username first."
+            )
+        if not user.get("ln_address_toggled") and not override_fingerprint:
+            raise ValueError(
+                "LN address is currently disabled — call aqua_ln_address_toggle(enabled=true) first, "
+                "or pass override_fingerprint=true to re-enable it as part of this call."
+            )
+
+        server_fp = user.get("fingerprint")
+        local_fp = wallet_manager.fingerprint(wallet_name, password=password)
+        if (
+            server_fp
+            and server_fp != local_fp
+            and not override_fingerprint
+        ):
+            raise ValueError(
+                f"Wallet fingerprint mismatch: account is bound to {server_fp!r}, "
+                f"this wallet is {local_fp!r}. Pass override_fingerprint=true to re-bind "
+                "(this will also disable LN delivery for the previously-bound wallet)."
+            )
+
+        if count is None:
+            needed = user.get("new_addresses_needed") or 0
+            count = needed if needed > 0 else 5
+        if count <= 0:
+            raise ValueError("count must be positive")
+        if count > MAX_ADDRESSES_PER_REGISTRATION:
+            raise ValueError(
+                f"count cannot exceed {MAX_ADDRESSES_PER_REGISTRATION} (server-side per-call limit)"
+            )
+
+        # ``reserve_addresses`` mints all ``count`` fresh addresses in one
+        # batched load+save of the wallet record (vs. ``count`` individual
+        # ``get_address(None)`` calls that each write to disk). The counter
+        # advances past every minted index so no other flow (lw_address,
+        # lightning_receive, …) collides with these.
+        addresses = [a.address for a in wallet_manager.reserve_addresses(wallet_name, count)]
+
+        resp = self._authed_call(
+            lambda access: self.client.register_addresses(
+                access, local_fp, addresses, override_fingerprint=override_fingerprint
+            )
+        )
+        return {
+            "requested_count": len(addresses),
+            "pool_size": len(resp.get("addresses", [])),
+            "fingerprint": local_fp,
+            "addresses": resp.get("addresses", []),
+        }
+
+    def ensure_ln_pool(
+        self,
+        wallet_manager,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+        profile: Optional[dict] = None,
+    ) -> dict:
+        """Idempotent LN-address pool top-up.
+
+        Reads the user's current profile and only POSTs new addresses if the
+        server reports ``new_addresses_needed > 0``. No-ops + returns a status
+        dict when conditions don't allow auto-refill (no LN username, toggle
+        off, fingerprint bound to a different wallet). This is what the
+        post-refresh hook calls, and what the ``aqua_ensure_ln_pool`` MCP tool
+        exposes to agents.
+
+        When ``profile`` is provided (e.g. by ``_opportunistic_top_up`` after a
+        token refresh) it's reused instead of fetching one — saving a round
+        trip on the auto-refill path.
+        """
+        user = profile if profile is not None else self.get_user()
+        ln_username = user.get("ln_username")
+        if not ln_username:
+            return {
+                "refilled": False,
+                "reason": "no_ln_username",
+                "fingerprint": user.get("fingerprint"),
+            }
+        if not user.get("ln_address_toggled"):
+            return {
+                "refilled": False,
+                "reason": "ln_address_disabled",
+                "fingerprint": user.get("fingerprint"),
+            }
+        needed = user.get("new_addresses_needed") or 0
+        if needed <= 0:
+            return {
+                "refilled": False,
+                "reason": "pool_full",
+                "fingerprint": user.get("fingerprint"),
+                "new_addresses_needed": 0,
+            }
+
+        server_fp = user.get("fingerprint")
+        local_fp = wallet_manager.fingerprint(wallet_name, password=password)
+        if server_fp and server_fp != local_fp:
+            return {
+                "refilled": False,
+                "reason": "fingerprint_mismatch",
+                "server_fingerprint": server_fp,
+                "local_fingerprint": local_fp,
+            }
+
+        result = self.register_ln_addresses(
+            wallet_manager=wallet_manager,
+            wallet_name=wallet_name,
+            count=min(needed, MAX_ADDRESSES_PER_REGISTRATION),
+            password=password,
+            profile=user,
+        )
+        return {
+            "refilled": True,
+            "requested_count": result["requested_count"],
+            "pool_size": result["pool_size"],
+            "fingerprint": result["fingerprint"],
+        }
 
     def provision_wapupay_token(self) -> str:
         """Provision a fresh WapuPay API key from the AQUA backend and return it.

--- a/src/aqua/cli/commands.py
+++ b/src/aqua/cli/commands.py
@@ -33,6 +33,7 @@ def register_commands(cli: click.Group, config: Config | None = None) -> None:
     from .auth import auth
     from .btc import btc
     from .changelly import changelly
+    from .jan3 import jan3
     from .lightning import lightning
     from .liquid import liquid
     from .qr import qr
@@ -55,6 +56,7 @@ def register_commands(cli: click.Group, config: Config | None = None) -> None:
         ("sideshift", sideshift),
         ("sideswap", sideswap),
         ("wapupay", wapupay),
+        ("jan3", jan3),
         ("qr", qr),
     ]
 

--- a/src/aqua/cli/jan3.py
+++ b/src/aqua/cli/jan3.py
@@ -1,0 +1,103 @@
+"""JAN3 Accounts CLI — paid captchaless login."""
+
+from __future__ import annotations
+
+import logging
+
+import click
+
+from ..tools import (
+    jan3_list_sessions,
+    jan3_login_complete,
+    jan3_login_start,
+    jan3_logout,
+    jan3_session_info,
+)
+from .output import run_tool
+from .password import handle_password_retry, resolve_secret
+
+logger = logging.getLogger(__name__)
+
+_PASSWORD_HELP = (
+    "Read wallet password from stdin (piped) or prompt interactively. "
+    "Without this flag, falls back to the AQUA_PASSWORD environment variable, "
+    "then to no password."
+)
+
+
+@click.group()
+def jan3():
+    """JAN3 Accounts — paid captchaless login.
+
+    The flow:
+
+      1. `aqua jan3 login-start --email …` pays the captchaless-login fee
+         in L-BTC; the server emails an OTP.
+      2. `aqua jan3 login-complete --email … --otp …` saves the session.
+
+    Base URL is overridable via the AQUA_ANKARA_API_URL env var (default:
+    https://test.aquabtc.com).
+    """
+
+
+@jan3.command("login-start")
+@click.option("--email", required=True, help="JAN3 account email (will receive the OTP).")
+@click.option("--wallet-name", default="default", show_default=True)
+@click.option("--language", default="en", show_default=True, help="OTP email language code.")
+@click.option(
+    "--password-stdin", "password_stdin", is_flag=True, default=False, help=_PASSWORD_HELP
+)
+@click.pass_obj
+def login_start(ctx, email, wallet_name, language, password_stdin):
+    """Pay the captchaless-login fee and trigger the OTP email."""
+    password = resolve_secret(
+        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
+    )
+    run_tool(
+        ctx,
+        lambda: handle_password_retry(
+            jan3_login_start,
+            {
+                "email": email,
+                "wallet_name": wallet_name,
+                "password": password,
+                "language": language,
+            },
+        ),
+    )
+
+
+@jan3.command("login-complete")
+@click.option("--email", required=True)
+@click.option("--otp", "otp_code", required=True, help="OTP code from the verification email.")
+@click.option("--fingerprint", default=None, help="Optional device fingerprint string.")
+@click.pass_obj
+def login_complete(ctx, email, otp_code, fingerprint):
+    """Exchange the OTP for JWT tokens and persist the session."""
+    run_tool(
+        ctx,
+        lambda: jan3_login_complete(email=email, otp_code=otp_code, fingerprint=fingerprint),
+    )
+
+
+@jan3.command("session-info")
+@click.option("--email", required=True)
+@click.pass_obj
+def session_info(ctx, email):
+    """Show non-sensitive metadata for a persisted JAN3 session."""
+    run_tool(ctx, lambda: jan3_session_info(email))
+
+
+@jan3.command("list-sessions")
+@click.pass_obj
+def list_sessions(ctx):
+    """List all persisted JAN3 sessions (no tokens shown)."""
+    run_tool(ctx, lambda: jan3_list_sessions())
+
+
+@jan3.command("logout")
+@click.option("--email", required=True)
+@click.pass_obj
+def logout(ctx, email):
+    """Delete a persisted JAN3 session."""
+    run_tool(ctx, lambda: jan3_logout(email))

--- a/src/aqua/cli/jan3.py
+++ b/src/aqua/cli/jan3.py
@@ -1,4 +1,4 @@
-"""JAN3 Accounts CLI — paid captchaless login."""
+"""JAN3 Accounts CLI — paid captchaless login + on-chain purchases."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from ..tools import (
     jan3_login_complete,
     jan3_login_start,
     jan3_logout,
+    jan3_purchase_ln_username,
     jan3_session_info,
 )
 from .output import run_tool
@@ -27,13 +28,15 @@ _PASSWORD_HELP = (
 
 @click.group()
 def jan3():
-    """JAN3 Accounts — paid captchaless login.
+    """JAN3 Accounts — paid captchaless login + on-chain purchases.
 
     The flow:
 
       1. `aqua jan3 login-start --email …` pays the captchaless-login fee
          in L-BTC; the server emails an OTP.
       2. `aqua jan3 login-complete --email … --otp …` saves the session.
+      3. Authenticated purchases (e.g. `purchase-ln-username`) use that
+         session and pay each purchase on chain.
 
     Base URL is overridable via the AQUA_ANKARA_API_URL env var (default:
     https://test.aquabtc.com).
@@ -101,3 +104,39 @@ def list_sessions(ctx):
 def logout(ctx, email):
     """Delete a persisted JAN3 session."""
     run_tool(ctx, lambda: jan3_logout(email))
+
+
+@jan3.command("purchase-ln-username")
+@click.option("--email", required=True, help="JAN3 account email — session must already exist.")
+@click.option(
+    "--ln-username", "ln_username", required=True,
+    help="Desired Lightning username (4–64 chars, lowercase + digits, at most one dot).",
+)
+@click.option("--wallet-name", default="default", show_default=True)
+@click.option(
+    "--asset", default="L-BTC", show_default=True,
+    type=click.Choice(["L-BTC", "USDt"]),
+    help="Asset used to pay the purchase.",
+)
+@click.option(
+    "--password-stdin", "password_stdin", is_flag=True, default=False, help=_PASSWORD_HELP
+)
+@click.pass_obj
+def purchase_ln_username(ctx, email, ln_username, wallet_name, asset, password_stdin):
+    """Update / purchase the LN username for the logged-in JAN3 account."""
+    password = resolve_secret(
+        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
+    )
+    run_tool(
+        ctx,
+        lambda: handle_password_retry(
+            jan3_purchase_ln_username,
+            {
+                "email": email,
+                "ln_username": ln_username,
+                "wallet_name": wallet_name,
+                "password": password,
+                "asset": asset,
+            },
+        ),
+    )

--- a/src/aqua/features.py
+++ b/src/aqua/features.py
@@ -149,7 +149,15 @@ CLI_COMMAND_TO_MCP_TOOL: dict[tuple[str, str], str] = {
 # Tools available only via MCP — no Click command in `src/aqua/cli/`.
 # The PIX endpoints are agent-only by design (Brazilian instant-pay flows
 # triggered from chat); intentionally not exposed in the CLI.
-MCP_ONLY_TOOLS: frozenset[str] = frozenset({"pix_receive", "pix_status"})
+MCP_ONLY_TOOLS: frozenset[str] = frozenset({
+    "pix_receive",
+    "pix_status",
+    "aqua_get_user",
+    "aqua_ln_address_toggle",
+    "aqua_ln_username_check_available",
+    "aqua_register_ln_addresses",
+    "aqua_ensure_ln_pool",
+})
 
 
 def is_tool_enabled(name: str, config: Config) -> bool:

--- a/src/aqua/features.py
+++ b/src/aqua/features.py
@@ -135,6 +135,13 @@ CLI_COMMAND_TO_MCP_TOOL: dict[tuple[str, str], str] = {
 
     # qr group (cli/qr.py)
     ("qr", "decode"): "qr_decode",
+
+    # jan3 group (cli/jan3.py)
+    ("jan3", "login-start"): "jan3_login_start",
+    ("jan3", "login-complete"): "jan3_login_complete",
+    ("jan3", "session-info"): "jan3_session_info",
+    ("jan3", "list-sessions"): "jan3_list_sessions",
+    ("jan3", "logout"): "jan3_logout",
 }
 
 

--- a/src/aqua/features.py
+++ b/src/aqua/features.py
@@ -142,6 +142,7 @@ CLI_COMMAND_TO_MCP_TOOL: dict[tuple[str, str], str] = {
     ("jan3", "session-info"): "jan3_session_info",
     ("jan3", "list-sessions"): "jan3_list_sessions",
     ("jan3", "logout"): "jan3_logout",
+    ("jan3", "purchase-ln-username"): "jan3_purchase_ln_username",
 }
 
 

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -1,0 +1,463 @@
+"""JAN3 Accounts integration: paid captchaless login.
+
+Talks to the AQUA Ankara backend at AQUA_ANKARA_API_URL. Defaults to
+``https://test.aquabtc.com`` (staging) since the Ankara endpoints aren't
+live on production yet — override via the env var when they ship.
+
+Surface (REST/JSON):
+
+  GET  /api/v1/liquid-wallet/payment/receive-address/
+       → {"address": "lq1..."} — public, no auth.
+
+  GET  /api/v1/liquid-wallet/products/?product_type=...
+       → [{"product_type","lbtc_sats_price","usdt_base_units_price",
+            "usdt_display_price"}] — public.
+
+  POST /api/v2/auth/login/
+       Body: {"email","language","login_challenge":{"raw_tx",
+                "payment_address","captcha_token"}}
+       The paid bypass uses raw_tx + payment_address; server broadcasts
+       the tx, flips UserProfile.captcha_exempt, and emails the OTP.
+
+  POST /api/v1/auth/verify/      {email, otp_code, fingerprint?}
+                                   → {access, refresh}
+
+Sessions persist at ~/.aqua/jan3_accounts/{email}.json (0o600). Only
+``complete_login`` writes the session — ``request_login`` is a
+non-mutating step that just dispatches the OTP email.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from .assets import resolve_liquid_asset_id
+from .storage import Storage
+from .wallet import WalletManager
+
+logger = logging.getLogger(__name__)
+
+
+AQUA_ANKARA_API_URL = os.environ.get(
+    "AQUA_ANKARA_API_URL", "https://test.aquabtc.com"
+)
+USER_AGENT = "agentic-aqua"
+HTTP_TIMEOUT_SECONDS = 30.0
+
+PRODUCT_TYPE_CAPTCHALESS_LOGIN = "CAPTCHALESS_LOGIN"
+
+ASSET_TICKER_LBTC = "L-BTC"
+ASSET_TICKER_USDT = "USDt"
+
+# Minimal email syntax check — the server validates properly; this just
+# catches obvious mistakes before we make a network call.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+class Jan3UnauthorizedError(RuntimeError):
+    """Raised when an authenticated request returns HTTP 401.
+
+    The manager catches this once per call to attempt a refresh-and-retry.
+    A second 401 (or a 401 on the refresh itself) deletes the local session
+    and re-raises so the caller can prompt the user to log in again.
+    """
+
+
+@dataclass
+class Jan3Session:
+    """Persistent record of a JAN3 account login session.
+
+    ``captcha_exempt`` is always True after a successful captchaless login.
+    """
+
+    email: str
+    base_url: str
+    access_token: str
+    refresh_token: str
+    created_at: str
+    refreshed_at: Optional[str] = None
+    captcha_exempt: bool = False
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Jan3Session":
+        data = {**data}
+        data.setdefault("refreshed_at", None)
+        data.setdefault("captcha_exempt", False)
+        return cls(**data)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _token_preview(token: str) -> str:
+    """Return a short, log-safe preview of a token (``abcd…wxyz``).
+
+    Tokens shorter than 12 chars are fully redacted rather than half-shown:
+    a 4-char token printed as ``ab…cd`` reveals the entire secret.
+    """
+    if not token:
+        return ""
+    if len(token) < 12:
+        return "…"
+    return f"{token[:4]}…{token[-4:]}"
+
+
+def _validate_email(email: str) -> str:
+    email = (email or "").strip()
+    if not email or not _EMAIL_RE.match(email):
+        raise ValueError(f"Invalid email address: {email!r}")
+    return email.lower()
+
+
+def _email_to_filename(email: str) -> str:
+    """Convert an email to a safe filename component.
+
+    JSON files are named after the email but we percent-encode any character
+    outside ``[a-z0-9@._-]`` so the filesystem never sees ``..``/``/`` etc.
+    ``@`` is intentionally kept verbatim — it's safe on every supported OS
+    and makes the filenames human-readable.
+    """
+    return re.sub(r"[^a-z0-9@._-]", lambda m: f"%{ord(m.group(0)):02x}", email)
+
+
+# ---------------------------------------------------------------------------
+# HTTP client
+# ---------------------------------------------------------------------------
+
+
+class Jan3AccountsClient:
+    """HTTP client for the AQUA Ankara backend.
+
+    Stateless except for the optional bearer ``access_token`` — pass a new
+    token to retry after a refresh.
+    """
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        access_token: Optional[str] = None,
+    ) -> None:
+        self.base_url = (base_url or AQUA_ANKARA_API_URL).rstrip("/")
+        self.access_token = access_token
+
+    def _api_request(
+        self,
+        method: str,
+        path: str,
+        body: Optional[dict] = None,
+        query: Optional[dict] = None,
+        auth: bool = False,
+    ) -> Any:
+        url = f"{self.base_url}{path}"
+        if query:
+            cleaned = {k: v for k, v in query.items() if v is not None}
+            if cleaned:
+                url += "?" + urllib.parse.urlencode(cleaned)
+        data = json.dumps(body).encode() if body is not None else None
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        }
+        if auth:
+            if not self.access_token:
+                raise ValueError("Authenticated request requires an access_token")
+            headers["Authorization"] = f"Bearer {self.access_token}"
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:
+                raw = resp.read().decode()
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as e:
+            detail = ""
+            try:
+                err_body = json.loads(e.read().decode())
+                detail = (
+                    err_body.get("message")
+                    or err_body.get("error_code")
+                    or err_body.get("error")
+                    or err_body.get("detail")
+                    or ""
+                )
+                if isinstance(detail, dict):
+                    detail = detail.get("message") or detail.get("code") or str(detail)
+            except Exception:
+                pass
+            if e.code == 401:
+                raise Jan3UnauthorizedError(
+                    f"AQUA API unauthorized ({method} {path}): {detail or 'no detail'}"
+                ) from e
+            msg = f"AQUA API error ({e.code} {method} {path})"
+            if detail:
+                msg += f": {detail}"
+            raise RuntimeError(msg) from e
+        except urllib.error.URLError as e:
+            raise RuntimeError(
+                f"AQUA API unreachable ({method} {path}): {e.reason}"
+            ) from e
+
+    # ─── public endpoints ──────────────────────────────────────────────
+
+    def get_vault_payment_address(self) -> str:
+        result = self._api_request(
+            "GET", "/api/v1/liquid-wallet/payment/receive-address/"
+        )
+        address = (result or {}).get("address")
+        if not address:
+            raise RuntimeError(
+                "AQUA payment receive-address endpoint returned no address"
+            )
+        return address
+
+    def get_product_price(self, product_type: str) -> dict:
+        """GET /products/?product_type=... — returns the single matching row.
+
+        Raises if the response is empty or doesn't include the requested
+        product type (server-side default seed should always provide one).
+        """
+        result = self._api_request(
+            "GET",
+            "/api/v1/liquid-wallet/products/",
+            query={"product_type": product_type},
+        )
+        rows = result if isinstance(result, list) else []
+        for row in rows:
+            if row.get("product_type") == product_type:
+                return row
+        raise RuntimeError(
+            f"AQUA products endpoint returned no entry for {product_type!r}"
+        )
+
+    def login_v2(
+        self,
+        email: str,
+        language: str = "en",
+        *,
+        raw_tx: Optional[str] = None,
+        payment_address: Optional[str] = None,
+        captcha_token: Optional[str] = None,
+    ) -> dict:
+        challenge: dict[str, str] = {}
+        if raw_tx is not None:
+            challenge["raw_tx"] = raw_tx
+        if payment_address is not None:
+            challenge["payment_address"] = payment_address
+        if captcha_token is not None:
+            challenge["captcha_token"] = captcha_token
+        body: dict[str, Any] = {"email": email, "language": language}
+        if challenge:
+            body["login_challenge"] = challenge
+        return self._api_request("POST", "/api/v2/auth/login/", body=body) or {}
+
+    def verify_otp(
+        self,
+        email: str,
+        otp_code: str,
+        fingerprint: Optional[str] = None,
+    ) -> dict:
+        body: dict[str, Any] = {"email": email, "otp_code": otp_code}
+        if fingerprint is not None:
+            body["fingerprint"] = fingerprint
+        return self._api_request("POST", "/api/v1/auth/verify/", body=body) or {}
+
+
+# ---------------------------------------------------------------------------
+# Manager (login orchestration)
+# ---------------------------------------------------------------------------
+
+
+class Jan3AccountsManager:
+    """High-level JAN3 Accounts orchestration.
+
+    Owns session persistence and the multi-step login + purchase flows.
+    The underlying :class:`Jan3AccountsClient` is stateless; the manager
+    builds one per call (or per retry) with the current bearer token.
+    """
+
+    def __init__(
+        self,
+        storage: Storage,
+        wallet_manager: WalletManager,
+        base_url: Optional[str] = None,
+    ) -> None:
+        self.storage = storage
+        self.wallet_manager = wallet_manager
+        self.base_url = (base_url or AQUA_ANKARA_API_URL).rstrip("/")
+
+    # ─── session persistence ───────────────────────────────────────────
+
+    def _session_path(self, email: str) -> Path:
+        email = _validate_email(email)
+        return self.storage.jan3_accounts_dir / f"{_email_to_filename(email)}.json"
+
+    def load_session(self, email: str) -> Optional[Jan3Session]:
+        path = self._session_path(email)
+        if not path.exists():
+            return None
+        try:
+            with open(path) as f:
+                return Jan3Session.from_dict(json.load(f))
+        except (OSError, json.JSONDecodeError, TypeError):
+            # Corrupted file shouldn't pin the user out of every JAN3 tool.
+            # Treat as missing and let the caller force a re-login.
+            logger.warning("Unreadable JAN3 session file: %s", path)
+            return None
+
+    def save_session(self, session: Jan3Session) -> None:
+        path = self._session_path(session.email)
+        self.storage._atomic_write_json(path, session.to_dict())
+
+    def delete_session(self, email: str) -> bool:
+        path = self._session_path(email)
+        if not path.exists():
+            return False
+        path.unlink()
+        return True
+
+    def list_sessions(self) -> list[Jan3Session]:
+        sessions: list[Jan3Session] = []
+        for path in self.storage.jan3_accounts_dir.glob("*.json"):
+            try:
+                with open(path) as f:
+                    sessions.append(Jan3Session.from_dict(json.load(f)))
+            except (OSError, json.JSONDecodeError, TypeError):
+                # Skip corrupted files rather than failing the whole list.
+                logger.warning("Skipping unreadable JAN3 session file: %s", path)
+        sessions.sort(key=lambda s: s.created_at, reverse=True)
+        return sessions
+
+    # ─── asset resolution ─────────────────────────────────────────────
+
+    def _resolve_asset_id(self, wallet_name: str, asset_ticker: str) -> str:
+        """Resolve an asset ticker (L-BTC / USDt) to a Liquid asset id."""
+        wallet = self.wallet_manager.storage.load_wallet(wallet_name)
+        if not wallet:
+            raise ValueError(f"Wallet {wallet_name!r} not found")
+        ticker = (asset_ticker or "").strip()
+        if ticker.upper() in ("L-BTC", "LBTC", "BTC"):
+            return self.wallet_manager._get_policy_asset(wallet.network)
+        resolved = resolve_liquid_asset_id(
+            ticker, "liquid", asset_network=wallet.network
+        )
+        if not resolved:
+            raise ValueError(
+                f"Cannot resolve asset_id for ticker {asset_ticker!r} on "
+                f"{wallet.network}."
+            )
+        return resolved
+
+    # ─── login flow ────────────────────────────────────────────────────
+
+    def request_login(
+        self,
+        email: str,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+        language: str = "en",
+    ) -> dict:
+        """Paid captchaless login step 1: dispatch the OTP email.
+
+        Fetches the vault payment address and the CAPTCHALESS_LOGIN price
+        from the AQUA backend, then crafts a signed L-BTC tx that funds
+        that address and POSTs everything to /api/v2/auth/login/. The
+        server broadcasts the tx, sets captcha_exempt on the user, and
+        emails the OTP.
+
+        Returns a dict describing what to do next — the actual session
+        is only persisted by :meth:`complete_login` after the user
+        supplies the OTP.
+        """
+        email = _validate_email(email)
+        client = Jan3AccountsClient(base_url=self.base_url)
+
+        payment_address = client.get_vault_payment_address()
+        price = client.get_product_price(PRODUCT_TYPE_CAPTCHALESS_LOGIN)
+        amount_sats = int(price.get("lbtc_sats_price") or 0)
+        if amount_sats <= 0:
+            raise RuntimeError(
+                f"AQUA CAPTCHALESS_LOGIN price is non-positive ({amount_sats}); "
+                "captchaless login is not configured server-side."
+            )
+        asset_id = self._resolve_asset_id(wallet_name, ASSET_TICKER_LBTC)
+
+        raw_tx = self.wallet_manager.craft_raw_tx(
+            wallet_name=wallet_name,
+            address=payment_address,
+            amount=amount_sats,
+            asset_id=asset_id,
+            password=password,
+        )
+
+        response = client.login_v2(
+            email=email,
+            language=language,
+            raw_tx=raw_tx,
+            payment_address=payment_address,
+        )
+        return {
+            "email": email,
+            "message": response.get("message", "OTP dispatched"),
+            "payment_address": payment_address,
+            "amount_sats": amount_sats,
+            "asset_ticker": ASSET_TICKER_LBTC,
+            "otp_sent_to": email,
+            # When the backend has EMAIL_BASED_OTP disabled (dev/test) it
+            # echoes the OTP in the response — surface it so smoke tests
+            # don't need email access.
+            "otp_code": response.get("otp_code"),
+            "next_step": "Call jan3_login_complete with the OTP code from your email.",
+        }
+
+    def complete_login(
+        self,
+        email: str,
+        otp_code: str,
+        fingerprint: Optional[str] = None,
+    ) -> dict:
+        """Exchange the OTP for JWT tokens and persist the session."""
+        email = _validate_email(email)
+        otp_code = (otp_code or "").strip()
+        if not otp_code:
+            raise ValueError("otp_code is required")
+
+        client = Jan3AccountsClient(base_url=self.base_url)
+        tokens = client.verify_otp(email, otp_code, fingerprint)
+        access = tokens.get("access")
+        refresh = tokens.get("refresh")
+        if not access or not refresh:
+            raise RuntimeError(
+                "AQUA verify endpoint did not return both access and refresh tokens"
+            )
+
+        session = Jan3Session(
+            email=email,
+            base_url=self.base_url,
+            access_token=access,
+            refresh_token=refresh,
+            created_at=_now_iso(),
+            captcha_exempt=True,
+        )
+        self.save_session(session)
+        return {
+            "email": email,
+            "captcha_exempt": True,
+            "message": (
+                f"Session saved at {self._session_path(email)}. "
+                "You can now make authenticated purchases."
+            ),
+            "access_token_preview": _token_preview(access),
+        }

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -1,4 +1,4 @@
-"""JAN3 Accounts integration: paid captchaless login.
+"""JAN3 Accounts integration: login + purchases.
 
 Talks to the AQUA Ankara backend at AQUA_ANKARA_API_URL. Defaults to
 ``https://test.aquabtc.com`` (staging) since the Ankara endpoints aren't
@@ -21,6 +21,17 @@ Surface (REST/JSON):
 
   POST /api/v1/auth/verify/      {email, otp_code, fingerprint?}
                                    → {access, refresh}
+  POST /api/v1/auth/refresh/     {refresh} → {access}
+
+  POST /api/v1/liquid-wallet/payment-request/ln-username/   (JWT)
+       {asset, ln_username}
+       → {payment_id, status, product_type, asset_ticker, amount,
+          amount_base_units, address, expires_at, product_details}
+
+  POST /api/v1/liquid-wallet/payment/submit-raw-tx/         (JWT)
+       {payment_id, raw_tx}
+       → same shape as create; status flips to "ACCEPTED" on success.
+         txid is NOT in the response — compute locally from raw_tx.
 
 Sessions persist at ~/.aqua/jan3_accounts/{email}.json (0o600). Only
 ``complete_login`` writes the session — ``request_login`` is a
@@ -41,6 +52,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Optional
 
+import lwk
+
 from .assets import resolve_liquid_asset_id
 from .storage import Storage
 from .wallet import WalletManager
@@ -54,10 +67,16 @@ AQUA_ANKARA_API_URL = os.environ.get(
 USER_AGENT = "agentic-aqua"
 HTTP_TIMEOUT_SECONDS = 30.0
 
+PRODUCT_TYPE_LN_USERNAME = "LN_USERNAME_UPDATE"
 PRODUCT_TYPE_CAPTCHALESS_LOGIN = "CAPTCHALESS_LOGIN"
 
 ASSET_TICKER_LBTC = "L-BTC"
 ASSET_TICKER_USDT = "USDt"
+
+# 4–64 chars, lowercase letters/digits, at most one dot. Mirrors
+# common.constants.LN_USERNAME_REGEX in aqua-ankara so we fail fast
+# instead of letting the server 400.
+LN_USERNAME_REGEX = re.compile(r"^[a-z0-9]+(\.[a-z0-9]+)?$")
 
 # Minimal email syntax check — the server validates properly; this just
 # catches obvious mistakes before we make a network call.
@@ -121,6 +140,16 @@ def _validate_email(email: str) -> str:
     if not email or not _EMAIL_RE.match(email):
         raise ValueError(f"Invalid email address: {email!r}")
     return email.lower()
+
+
+def _validate_ln_username(username: str) -> str:
+    username = (username or "").strip().lower()
+    if not (4 <= len(username) <= 64) or not LN_USERNAME_REGEX.match(username):
+        raise ValueError(
+            f"Invalid ln_username {username!r}: must be 4–64 chars, "
+            "lowercase letters and digits, with at most one dot."
+        )
+    return username
 
 
 def _email_to_filename(email: str) -> str:
@@ -274,9 +303,38 @@ class Jan3AccountsClient:
             body["fingerprint"] = fingerprint
         return self._api_request("POST", "/api/v1/auth/verify/", body=body) or {}
 
+    def refresh_access_token(self, refresh_token: str) -> str:
+        result = self._api_request(
+            "POST", "/api/v1/auth/refresh/", body={"refresh": refresh_token}
+        ) or {}
+        access = result.get("access")
+        if not access:
+            raise RuntimeError("AQUA refresh endpoint returned no access token")
+        return access
+
+    # ─── authenticated endpoints ───────────────────────────────────────
+
+    def create_ln_username_payment_request(
+        self, asset: str, ln_username: str
+    ) -> dict:
+        return self._api_request(
+            "POST",
+            "/api/v1/liquid-wallet/payment-request/ln-username/",
+            body={"asset": asset, "ln_username": ln_username},
+            auth=True,
+        ) or {}
+
+    def submit_raw_tx(self, payment_id: str, raw_tx: str) -> dict:
+        return self._api_request(
+            "POST",
+            "/api/v1/liquid-wallet/payment/submit-raw-tx/",
+            body={"payment_id": payment_id, "raw_tx": raw_tx},
+            auth=True,
+        ) or {}
+
 
 # ---------------------------------------------------------------------------
-# Manager (login orchestration)
+# Manager (login + purchase orchestration)
 # ---------------------------------------------------------------------------
 
 
@@ -461,3 +519,131 @@ class Jan3AccountsManager:
             ),
             "access_token_preview": _token_preview(access),
         }
+
+    # ─── auth helpers ─────────────────────────────────────────────────
+
+    def _require_session(self, email: str) -> Jan3Session:
+        session = self.load_session(email)
+        if not session:
+            raise ValueError(
+                f"No JAN3 session for {email!r}. "
+                "Run jan3_login_start then jan3_login_complete first."
+            )
+        return session
+
+    def _refresh_access_token(self, session: Jan3Session) -> Jan3Session:
+        """Try to mint a new access token. Deletes the session on failure.
+
+        Mutates ``session`` in place and returns it. Not safe under
+        concurrent calls for the same email (last write wins) — fine for
+        single-user CLI / MCP usage, would need a lock if invoked from
+        parallel workers.
+        """
+        client = Jan3AccountsClient(base_url=session.base_url)
+        try:
+            new_access = client.refresh_access_token(session.refresh_token)
+        except Jan3UnauthorizedError:
+            # Refresh token is gone too — wipe the local session so the
+            # user is forced to re-login rather than retrying forever.
+            self.delete_session(session.email)
+            raise
+        session.access_token = new_access
+        session.refreshed_at = _now_iso()
+        self.save_session(session)
+        return session
+
+    # ─── purchase flow ────────────────────────────────────────────────
+
+    def purchase_ln_username(
+        self,
+        email: str,
+        ln_username: str,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+        asset: str = ASSET_TICKER_LBTC,
+    ) -> dict:
+        """Create + pay an LN_USERNAME_UPDATE payment request.
+
+        On a 401 we refresh the access token once and retry once. A second
+        401 (or a 401 on the refresh) deletes the local session and raises
+        :class:`Jan3UnauthorizedError`.
+        """
+        email = _validate_email(email)
+        ln_username = _validate_ln_username(ln_username)
+        session = self._require_session(email)
+
+        order = self._with_refresh_retry(
+            session,
+            lambda c: c.create_ln_username_payment_request(asset, ln_username),
+        )
+
+        payment_id = order.get("payment_id")
+        address = order.get("address")
+        amount_sats = int(order.get("amount_base_units") or 0)
+        asset_ticker = order.get("asset_ticker") or asset
+        if not payment_id or not address or amount_sats <= 0:
+            raise RuntimeError(
+                "AQUA payment-request response is missing fields "
+                f"(payment_id/address/amount): {order!r}"
+            )
+
+        asset_id = self._resolve_asset_id(wallet_name, asset_ticker)
+        raw_tx = self.wallet_manager.craft_raw_tx(
+            wallet_name=wallet_name,
+            address=address,
+            amount=amount_sats,
+            asset_id=asset_id,
+            password=password,
+        )
+
+        # The API response does not include the txid; compute it locally
+        # from the finalized raw tx so the caller has something to track
+        # on a block explorer.
+        txid = str(lwk.Transaction(raw_tx).txid())
+
+        result = self._with_refresh_retry(
+            session,
+            lambda c: c.submit_raw_tx(payment_id=payment_id, raw_tx=raw_tx),
+        )
+
+        return {
+            "payment_id": payment_id,
+            "status": result.get("status"),
+            "txid": txid,
+            "ln_username": ln_username,
+            "amount_sats": amount_sats,
+            "asset_ticker": asset_ticker,
+            "address": address,
+            "message": (
+                f"Submitted raw_tx for {ln_username!r}. Server reports "
+                f"{result.get('status', 'UNKNOWN')}."
+            ),
+        }
+
+    def _with_refresh_retry(self, session: Jan3Session, call):
+        """Run an authed API call; on 401, refresh access token and retry once.
+
+        If the retry *also* 401s, the session is dead at the server (e.g.,
+        user revoked, account banned) — wipe the local copy so we don't
+        keep a poisoned bearer on disk. ``_refresh_access_token`` already
+        handles the case where the refresh endpoint itself rejects us.
+
+        ``session`` is mutated in place by ``_refresh_access_token``, so
+        callers holding the same reference see the new ``access_token``
+        after this returns.
+        """
+        client = Jan3AccountsClient(
+            base_url=session.base_url, access_token=session.access_token
+        )
+        try:
+            return call(client)
+        except Jan3UnauthorizedError:
+            session = self._refresh_access_token(session)
+            client = Jan3AccountsClient(
+                base_url=session.base_url, access_token=session.access_token
+            )
+            try:
+                return call(client)
+            except Jan3UnauthorizedError:
+                self.delete_session(session.email)
+                raise

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1313,6 +1313,93 @@ TOOL_SCHEMAS = {
             "required": ["image_path"],
         },
     },
+    "jan3_login_start": {
+        "description": (
+            "Step 1 of paid captchaless login into a JAN3 Account. Crafts a "
+            "signed L-BTC tx funding AQUA's vault for the CAPTCHALESS_LOGIN "
+            "price, POSTs it to /api/v2/auth/login/, and the server emails "
+            "an OTP. Then call jan3_login_complete. Base URL overridable via "
+            "AQUA_ANKARA_API_URL (default: https://test.aquabtc.com)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "JAN3 account email — will receive the OTP.",
+                },
+                "wallet_name": {
+                    "type": "string",
+                    "description": "Liquid wallet used to fund the login payment.",
+                    "default": "default",
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Decrypts the wallet mnemonic if encrypted at rest.",
+                },
+                "language": {
+                    "type": "string",
+                    "description": "2-letter language code for the OTP email.",
+                    "default": "en",
+                },
+            },
+            "required": ["email"],
+        },
+    },
+    "jan3_login_complete": {
+        "description": (
+            "Step 2 of JAN3 login. Exchanges the OTP for JWT tokens and saves "
+            "the session to ~/.aqua/jan3_accounts/{email}.json (0o600). Only "
+            "token previews are echoed back — never the full tokens."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Must match the email used in jan3_login_start.",
+                },
+                "otp_code": {
+                    "type": "string",
+                    "description": "OTP code from the verification email.",
+                },
+                "fingerprint": {
+                    "type": "string",
+                    "description": "Optional device fingerprint string.",
+                },
+            },
+            "required": ["email", "otp_code"],
+        },
+    },
+    "jan3_session_info": {
+        "description": (
+            "Return non-sensitive info about a persisted JAN3 session "
+            "(base_url, created_at, captcha_exempt, token previews)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "email": {"type": "string", "format": "email"},
+            },
+            "required": ["email"],
+        },
+    },
+    "jan3_list_sessions": {
+        "description": "List all persisted JAN3 sessions (metadata only, no tokens).",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    "jan3_logout": {
+        "description": "Delete a persisted JAN3 session file. Idempotent.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "email": {"type": "string", "format": "email"},
+            },
+            "required": ["email"],
+        },
+    },
 }
 
 

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1175,6 +1175,88 @@ TOOL_SCHEMAS = {
         "description": "Report whether an AQUA session is active (no secrets returned).",
         "inputSchema": {"type": "object", "properties": {}},
     },
+    "aqua_get_user": {
+        "description": (
+            "Get the AQUA account profile (email, ln_username, fingerprint, "
+            "feature flags). Use this to read the user's Lightning Address "
+            "(<ln_username>@aquabtc.com) and the state the other LN-address "
+            "tools depend on: ln_address_toggled, new_addresses_needed, and "
+            "the server-side wallet fingerprint. Requires aqua_login first."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    "aqua_ln_address_toggle": {
+        "description": (
+            "Enable or disable the LN-address feature on the AQUA account. "
+            "Toggling back on does NOT auto-refill the unused-address pool — "
+            "if aqua_get_user.new_addresses_needed > 0, follow up with "
+            "aqua_register_ln_addresses."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "enabled": {"type": "boolean", "description": "True to enable, false to disable."},
+            },
+            "required": ["enabled"],
+        },
+    },
+    "aqua_ln_username_check_available": {
+        "description": (
+            "Check whether a desired LN username is free to claim. Call BEFORE "
+            "jan3_purchase_ln_username to avoid paying L-BTC on a username that's "
+            "already taken or invalid. Note: the live AQUA deployment requires a "
+            "JWT despite the OpenAPI schema marking this anonymous — if a local "
+            "AQUA session exists, the lookup IS account-linked."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "ln_username": {"type": "string", "description": "Desired LN username (the part before @aquabtc.com)."},
+            },
+            "required": ["ln_username"],
+        },
+    },
+    "aqua_register_ln_addresses": {
+        "description": (
+            "Upload a batch of unused Liquid receive addresses so the AQUA "
+            "backend can deliver inbound LN payments to <ln_username>@aquabtc.com. "
+            "Without a healthy unused-address pool, the LN address feature "
+            "CANNOT receive — the server hands out one address per invoice. "
+            "Call when aqua_get_user.new_addresses_needed > 0. Refuses on "
+            "fingerprint mismatch unless override_fingerprint=true (which "
+            "re-binds the account and disables delivery for the previously-bound wallet). "
+            "Returns {requested_count, pool_size, fingerprint, addresses} — pool_size "
+            "is the server's authoritative post-call unused-pool size (it dedupes "
+            "against existing state, so trust pool_size over requested_count)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "wallet_name": {"type": "string", "default": "default", "description": "Liquid wallet whose addresses get uploaded."},
+                "count": {"type": "integer", "description": "How many addresses to register. Defaults to the server's new_addresses_needed, falling back to 5. Capped at 15."},
+                "override_fingerprint": {"type": "boolean", "default": False, "description": "Re-bind the account to this wallet's fingerprint. Also flips ln_address_toggled to true server-side. Use only for intentional rebind."},
+                "password": {"type": "string", "description": "Decrypts the wallet mnemonic if encrypted at rest."},
+            },
+        },
+    },
+    "aqua_ensure_ln_pool": {
+        "description": (
+            "Idempotent LN-address pool refill — top up only if "
+            "aqua_get_user.new_addresses_needed > 0. Safe to call at any time. "
+            "Skips silently with a reason field when conditions don't allow "
+            "auto-refill (no_ln_username / ln_address_disabled / pool_full / "
+            "fingerprint_mismatch). This is also what runs automatically after "
+            "a JWT refresh — agents don't need to call it explicitly during "
+            "normal operation, but it's exposed for cold-start / recovery flows."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "wallet_name": {"type": "string", "default": "default", "description": "Liquid wallet to source addresses from."},
+                "password": {"type": "string", "description": "Decrypts the wallet mnemonic if encrypted at rest."},
+            },
+        },
+    },
     "wapupay_exchange_rates": {
         "description": "Get WapuPay's current exchange rates (e.g. USDT/ARS). Public — no login or API key.",
         "inputSchema": {"type": "object", "properties": {}},

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1400,6 +1400,48 @@ TOOL_SCHEMAS = {
             "required": ["email"],
         },
     },
+    "jan3_purchase_ln_username": {
+        "description": (
+            "Purchase / update the Lightning username for a JAN3 account. "
+            "Requires an active session (jan3_login_start + jan3_login_complete "
+            "first). Creates a payment-request order, crafts and signs a Liquid "
+            "tx for the exact amount, and submits it. The server applies the "
+            "username update atomically with the broadcast."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "JAN3 account email — session must already exist.",
+                },
+                "ln_username": {
+                    "type": "string",
+                    "description": (
+                        "Desired Lightning username. 4–64 chars, lowercase "
+                        "letters and digits, with at most one dot."
+                    ),
+                },
+                "wallet_name": {
+                    "type": "string",
+                    "description": "Liquid wallet to pay from.",
+                    "default": "default",
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Decrypts the wallet mnemonic if encrypted at rest.",
+                },
+                "asset": {
+                    "type": "string",
+                    "enum": ["L-BTC", "USDt"],
+                    "default": "L-BTC",
+                    "description": "Asset to pay the request with.",
+                },
+            },
+            "required": ["email", "ln_username"],
+        },
+    },
 }
 
 

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -58,16 +58,37 @@ class WalletData:
     encrypted_mnemonic: Optional[str] = None  # Encrypted, if full wallet
     watch_only: bool = False
     created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    # Monotonically-increasing counter of receive addresses handed out via
+    # ``WalletManager.get_address(name, index=None)``. lwk's "next-unused" tip
+    # only advances after the chain observes usage, which doesn't help for
+    # off-chain handouts (LN-address registration, Boltz claim addresses,
+    # Changelly refunds, etc.). Every call to the no-arg ``get_address`` bumps
+    # this counter so two flows never share the same address.
+    #
+    # Single-writer assumption: the MCP server processes one tool call at a
+    # time, so the load → compute → save dance in ``get_address`` is safe
+    # without a lock. Adding a file lock around ``save_wallet`` would be
+    # required if multiple processes (or threads) start mutating this counter
+    # concurrently.
+    next_address_index: int = 0
 
     def to_dict(self) -> dict:
         return asdict(self)
 
     @classmethod
     def from_dict(cls, data: dict) -> "WalletData":
-        # Backward compatibility: old wallet files may not have btc_* fields
         data = {**data}
+        # Backward compatibility: older wallet files may not have btc_* fields.
         data.setdefault("btc_descriptor", None)
         data.setdefault("btc_change_descriptor", None)
+        # The counter used to be named ``ln_addr_next_index`` when it only tracked
+        # LN-address registrations. Migrate the legacy key in-place so existing
+        # wallets keep their burned-index history; the legacy key is dropped on
+        # the next save.
+        legacy = data.pop("ln_addr_next_index", None)
+        if "next_address_index" not in data and legacy is not None:
+            data["next_address_index"] = legacy
+        data.setdefault("next_address_index", 0)
         return cls(**data)
 
 

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -140,6 +140,7 @@ class Storage:
         self.wapupay_api_key_path = self.wapupay_dir / "api_key.json"
         self.jan3_dir = self.base_dir / "jan3"
         self.jan3_session_path = self.jan3_dir / "session.json"
+        self.jan3_accounts_dir = self.base_dir / "jan3_accounts"
         self.qr_dir = self.base_dir / "qr"
         self.config_path = self.base_dir / "config.json"
         self._ensure_dirs()
@@ -174,6 +175,8 @@ class Storage:
         restrict_permissions(self.wapupay_orders_dir, 0o700)
         self.jan3_dir.mkdir(exist_ok=True, mode=0o700)
         restrict_permissions(self.jan3_dir, 0o700)
+        self.jan3_accounts_dir.mkdir(exist_ok=True, mode=0o700)
+        restrict_permissions(self.jan3_accounts_dir, 0o700)
         self.qr_dir.mkdir(exist_ok=True, mode=0o700)
         restrict_permissions(self.qr_dir, 0o700)
 

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -38,6 +38,7 @@ _sideswap_peg_manager: "SideSwapPegManager | None" = None
 _sideswap_swap_manager: "SideSwapSwapManager | None" = None
 _wapupay_manager: "WapuPayManager | None" = None
 _jan3_manager: "JAN3AccountManager | None" = None
+_jan3_accounts_manager: "Jan3AccountsManager | None" = None
 
 
 def get_manager() -> WalletManager:
@@ -162,6 +163,24 @@ def get_wapupay_manager() -> "WapuPayManager":
             jan3_manager=get_jan3_manager(),
         )
     return _wapupay_manager
+
+
+def get_jan3_accounts_manager() -> "Jan3AccountsManager":
+    """Get or create JAN3 Accounts manager (shares storage + wallet manager).
+
+    Owns the paid captchaless-login flow and on-chain LN-username purchases
+    surfaced as the ``jan3_*`` tools (separate from the email-OTP ``aqua_*``
+    surface in [[get_jan3_manager]]).
+    """
+    global _jan3_accounts_manager
+    if _jan3_accounts_manager is None:
+        from .jan3_accounts import Jan3AccountsManager
+
+        _jan3_accounts_manager = Jan3AccountsManager(
+            storage=get_manager().storage,
+            wallet_manager=get_manager(),
+        )
+    return _jan3_accounts_manager
 
 
 # Tool implementations
@@ -2107,6 +2126,119 @@ def qr_decode(image_path: str) -> dict[str, Any]:
     return {"content": content}
 
 
+# ---------------------------------------------------------------------------
+# JAN3 Accounts (login + purchases)
+# ---------------------------------------------------------------------------
+
+
+def jan3_login_start(
+    email: str,
+    wallet_name: str = "default",
+    password: str | None = None,
+    language: str = "en",
+) -> dict[str, Any]:
+    """
+    Step 1 of the JAN3 paid captchaless login.
+
+    Fetches the AQUA vault payment address and the CAPTCHALESS_LOGIN price,
+    crafts a signed L-BTC tx funding the vault for that exact amount, and
+    POSTs it to /api/v2/auth/login/. The server broadcasts the tx and emails
+    an OTP to ``email``. After receiving the OTP, call ``jan3_login_complete``.
+
+    Args:
+        email: JAN3 account email (will receive the OTP).
+        wallet_name: Liquid wallet used to fund the captchaless login payment.
+        password: Decrypts the wallet mnemonic if encrypted at rest.
+        language: 2-letter language code for the OTP email (default "en").
+
+    Returns:
+        message, payment_address, amount_sats, asset_ticker, otp_sent_to,
+        otp_code (only when server has EMAIL_BASED_OTP off — dev/test),
+        next_step.
+    """
+    manager = get_jan3_accounts_manager()
+    return manager.request_login(
+        email=email,
+        wallet_name=wallet_name,
+        password=password,
+        language=language,
+    )
+
+
+def jan3_login_complete(
+    email: str,
+    otp_code: str,
+    fingerprint: str | None = None,
+) -> dict[str, Any]:
+    """
+    Step 2 of the JAN3 login. Exchanges the OTP for JWT tokens and persists
+    the session to ``~/.aqua/jan3_accounts/{email}.json`` (0o600).
+
+    Args:
+        email: JAN3 account email (must match the one used in jan3_login_start).
+        otp_code: The 6-digit OTP from the verification email.
+        fingerprint: Optional device fingerprint string.
+
+    Returns:
+        email, captcha_exempt (always true after a paid login), message,
+        access_token_preview. Full tokens are NEVER echoed (and the
+        refresh token isn't previewed at all — it's the long-lived
+        secret and shouldn't appear in transcripts).
+    """
+    manager = get_jan3_accounts_manager()
+    return manager.complete_login(
+        email=email, otp_code=otp_code, fingerprint=fingerprint
+    )
+
+
+def jan3_session_info(email: str) -> dict[str, Any]:
+    """
+    Return non-sensitive information about a persisted JAN3 session.
+
+    Does NOT echo full tokens — only metadata and preview strings.
+    """
+    manager = get_jan3_accounts_manager()
+    session = manager.load_session(email)
+    if not session:
+        return {"email": email, "has_session": False}
+    from .jan3_accounts import _token_preview
+
+    return {
+        "email": session.email,
+        "has_session": True,
+        "base_url": session.base_url,
+        "created_at": session.created_at,
+        "refreshed_at": session.refreshed_at,
+        "captcha_exempt": session.captcha_exempt,
+        "access_token_preview": _token_preview(session.access_token),
+    }
+
+
+def jan3_list_sessions() -> dict[str, Any]:
+    """List all persisted JAN3 sessions (metadata only — no tokens)."""
+    manager = get_jan3_accounts_manager()
+    sessions = manager.list_sessions()
+    return {
+        "sessions": [
+            {
+                "email": s.email,
+                "base_url": s.base_url,
+                "created_at": s.created_at,
+                "refreshed_at": s.refreshed_at,
+                "captcha_exempt": s.captcha_exempt,
+            }
+            for s in sessions
+        ]
+    }
+
+
+def jan3_logout(email: str) -> dict[str, Any]:
+    """Delete a persisted JAN3 session. Idempotent."""
+    manager = get_jan3_accounts_manager()
+    deleted = manager.delete_session(email)
+    return {"email": email, "deleted": deleted}
+
+
 # Tool registry for MCP
 TOOLS = {
     "lw_generate_mnemonic": lw_generate_mnemonic,
@@ -2173,5 +2305,10 @@ TOOLS = {
     "wapupay_transaction": wapupay_transaction,
     "wapupay_spending_limit": wapupay_spending_limit,
     "wapupay_provision_account": wapupay_provision_account,
+    "jan3_login_start": jan3_login_start,
+    "jan3_login_complete": jan3_login_complete,
+    "jan3_session_info": jan3_session_info,
+    "jan3_list_sessions": jan3_list_sessions,
+    "jan3_logout": jan3_logout,
     "qr_decode": qr_decode,
 }

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -2239,6 +2239,43 @@ def jan3_logout(email: str) -> dict[str, Any]:
     return {"email": email, "deleted": deleted}
 
 
+def jan3_purchase_ln_username(
+    email: str,
+    ln_username: str,
+    wallet_name: str = "default",
+    password: str | None = None,
+    asset: str = "L-BTC",
+) -> dict[str, Any]:
+    """
+    Purchase / update the LN username for a JAN3 account.
+
+    Requires an existing session (run jan3_login_start + jan3_login_complete
+    first). Creates a payment-request order, crafts and signs a Liquid tx
+    paying the request, and submits it. The server applies the username
+    update atomically with the broadcast.
+
+    Args:
+        email: JAN3 account email (must already have a saved session).
+        ln_username: New Lightning username. 4–64 chars, lowercase letters
+            and digits, with at most one dot.
+        wallet_name: Liquid wallet to pay from.
+        password: Decrypts the wallet mnemonic if encrypted at rest.
+        asset: "L-BTC" or "USDt". Default "L-BTC".
+
+    Returns:
+        payment_id, status, txid (computed locally from the raw tx),
+        ln_username, amount_sats, asset_ticker, address, message.
+    """
+    manager = get_jan3_accounts_manager()
+    return manager.purchase_ln_username(
+        email=email,
+        ln_username=ln_username,
+        wallet_name=wallet_name,
+        password=password,
+        asset=asset,
+    )
+
+
 # Tool registry for MCP
 TOOLS = {
     "lw_generate_mnemonic": lw_generate_mnemonic,
@@ -2310,5 +2347,6 @@ TOOLS = {
     "jan3_session_info": jan3_session_info,
     "jan3_list_sessions": jan3_list_sessions,
     "jan3_logout": jan3_logout,
+    "jan3_purchase_ln_username": jan3_purchase_ln_username,
     "qr_decode": qr_decode,
 }

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -147,7 +147,12 @@ def get_jan3_manager() -> "JAN3AccountManager":
     if _jan3_manager is None:
         from .ankara import JAN3AccountManager
 
-        _jan3_manager = JAN3AccountManager(storage=get_manager().storage)
+        # Pass ``get_manager`` (not a resolved instance) so the WalletManager
+        # is only constructed if/when the opportunistic LN-pool top-up fires.
+        _jan3_manager = JAN3AccountManager(
+            storage=get_manager().storage,
+            wallet_manager_factory=get_manager,
+        )
     return _jan3_manager
 
 
@@ -1317,6 +1322,118 @@ def aqua_session() -> dict[str, Any]:
     return get_jan3_manager().session_status()
 
 
+def aqua_get_user() -> dict[str, Any]:
+    """Get the AQUA account profile (email, LN username, fingerprint, feature flags).
+
+    Use this to answer "what's my Lightning Address?" (`<ln_username>@aquabtc.com`)
+    and to read state the other LN-address tools depend on: `ln_address_toggled`,
+    `new_addresses_needed`, and the server-side wallet `fingerprint`.
+
+    Requires a prior `aqua_login` + `aqua_verify`. Auto-refreshes the access
+    token on 401.
+    """
+    return get_jan3_manager().get_user()
+
+
+def aqua_ln_address_toggle(enabled: bool) -> dict[str, Any]:
+    """Enable or disable the LN-address feature on the AQUA account.
+
+    When disabled, the server stops uploading invoices that route to this user.
+    Toggling back on does NOT automatically refill the unused-address pool —
+    follow up with `aqua_register_ln_addresses` if `aqua_get_user` reports
+    `new_addresses_needed > 0`.
+    """
+    return get_jan3_manager().ln_address_toggle(enabled)
+
+
+def aqua_ln_username_check_available(ln_username: str) -> dict[str, Any]:
+    """Check whether an LN username is free before paying to purchase it.
+
+    Returns `{is_available, reason}` so the agent can validate a desired
+    username cheaply before invoking `jan3_purchase_ln_username` (which costs
+    L-BTC).
+
+    Privacy note: the OpenAPI schema marks this endpoint anonymous, but the
+    live AQUA deployment requires a JWT. If a local session exists we forward
+    it, so the lookup is account-linked. Callers that need an unattributed
+    check should `aqua_logout` first.
+    """
+    return get_jan3_manager().ln_username_available(ln_username)
+
+
+def aqua_register_ln_addresses(
+    wallet_name: str = "default",
+    count: int | None = None,
+    override_fingerprint: bool = False,
+    password: str | None = None,
+) -> dict[str, Any]:
+    """Upload a batch of unused Liquid receive addresses for LN-address delivery.
+
+    The AQUA backend hands these out one-by-one as the user's
+    `<ln_username>@aquabtc.com` receives invoices. Without a healthy pool,
+    inbound LN payments CANNOT be delivered — call this whenever
+    `aqua_get_user` reports `new_addresses_needed > 0`.
+
+    Refuses with a clear error if `ln_username` is unset, `ln_address_toggled`
+    is false, or the server's stored `fingerprint` doesn't match this wallet
+    (unless `override_fingerprint=true`, which intentionally re-binds the
+    account and disables delivery for the previously-bound wallet).
+
+    Args:
+        wallet_name: Liquid wallet whose addresses get uploaded. Default: "default".
+        count: how many addresses to register. If omitted, uses the server's
+            `new_addresses_needed`, falling back to 5. Capped at
+            `MAX_ADDRESSES_PER_REGISTRATION` (15 per the OpenAPI schema).
+        override_fingerprint: re-bind the account to this wallet's fingerprint
+            (also flips `ln_address_toggled` to true server-side). Use only for
+            intentional rebind flows.
+        password: decrypts the wallet's mnemonic if it's encrypted at rest.
+
+    Returns:
+        `{requested_count, pool_size, fingerprint, addresses}`. `requested_count`
+        is how many addresses we sent; `pool_size` is the server's authoritative
+        active-unused-pool size after this call (the server dedupes against its
+        own state, so `pool_size` is the trustworthy "did this work?" signal).
+        `addresses` is the full active/unused pool the server now knows about.
+    """
+    return get_jan3_manager().register_ln_addresses(
+        wallet_manager=get_manager(),
+        wallet_name=wallet_name,
+        count=count,
+        override_fingerprint=override_fingerprint,
+        password=password,
+    )
+
+
+def aqua_ensure_ln_pool(
+    wallet_name: str = "default",
+    password: str | None = None,
+) -> dict[str, Any]:
+    """Idempotent LN-address pool refill — top up if the server says it's needed.
+
+    Reads `aqua_get_user` and only POSTs new addresses if
+    `new_addresses_needed > 0`. Skips silently when conditions don't allow
+    auto-refill (no LN username, LN address toggle off, server bound to a
+    different wallet fingerprint) and returns a `reason` field explaining the
+    no-op. Safe to call at any time — this is what runs automatically after a
+    JWT refresh.
+
+    Args:
+        wallet_name: Liquid wallet to source addresses from. Default: "default".
+        password: decrypts the wallet's mnemonic if encrypted at rest.
+
+    Returns:
+        `{refilled: bool, ...}`. On refill: `requested_count`, `pool_size`,
+        `fingerprint`. On no-op: `reason` is one of `no_ln_username`,
+        `ln_address_disabled`, `pool_full`, `fingerprint_mismatch`.
+    """
+    return get_jan3_manager().ensure_ln_pool(
+        wallet_manager=get_manager(),
+        wallet_name=wallet_name,
+        password=password,
+    )
+
+
 # ---------------------------------------------------------------------------
 # WapuPay (Argentine direct-fiat payments)
 # ---------------------------------------------------------------------------
@@ -2332,6 +2449,11 @@ TOOLS = {
     "aqua_verify": aqua_verify,
     "aqua_logout": aqua_logout,
     "aqua_session": aqua_session,
+    "aqua_get_user": aqua_get_user,
+    "aqua_ln_address_toggle": aqua_ln_address_toggle,
+    "aqua_ln_username_check_available": aqua_ln_username_check_available,
+    "aqua_register_ln_addresses": aqua_register_ln_addresses,
+    "aqua_ensure_ln_pool": aqua_ensure_ln_pool,
     "wapupay_exchange_rates": wapupay_exchange_rates,
     "wapupay_quote": wapupay_quote,
     "wapupay_create_order": wapupay_create_order,

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -265,13 +265,100 @@ class WalletManager:
         wallet_name: str,
         index: Optional[int] = None,
     ) -> Address:
-        """Get receive address."""
+        """Get a receive address.
+
+        With no ``index``, hands out the next previously-unhanded-out address
+        and bumps the wallet's persisted ``next_address_index`` counter so two
+        flows never share an address. lwk's own "next-unused" tip only advances
+        after the chain observes usage, which is too slow for off-chain
+        handouts (LN-address registration, Boltz claim addresses, …) — so we
+        max it against our own counter.
+
+        With an explicit ``index``, returns that exact address without
+        advancing the counter. Callers asserting a specific index are assumed
+        to know what they're doing.
+
+        Note: the no-arg path is NOT idempotent — each call writes to disk and
+        consumes an index. Callers that need to peek without committing should
+        pass an explicit ``index``.
+        """
         wollet = self._get_wollet(wallet_name)
+        if index is None:
+            wallet_record = self.storage.load_wallet(wallet_name)
+            if wallet_record is None:
+                raise ValueError(f"Wallet {wallet_name!r} not found")
+            lwk_tip = wollet.address(None).index()
+            effective = max(lwk_tip, wallet_record.next_address_index)
+            addr = wollet.address(effective)
+            wallet_record.next_address_index = effective + 1
+            self.storage.save_wallet(wallet_record)
+            return Address(address=str(addr.address()), index=addr.index())
         addr = wollet.address(index)
-        return Address(
-            address=str(addr.address()),
-            index=addr.index(),
-        )
+        return Address(address=str(addr.address()), index=addr.index())
+
+    def reserve_addresses(
+        self,
+        wallet_name: str,
+        count: int,
+    ) -> list[Address]:
+        """Hand out ``count`` fresh receive addresses in one shot.
+
+        Same semantics as calling ``get_address(name)`` ``count`` times — each
+        address is distinct and the persisted counter is advanced past all of
+        them — but batched into a single load + save of the wallet record. Use
+        when minting many addresses at once (e.g. for LN-address registration).
+        """
+        if count <= 0:
+            raise ValueError("count must be positive")
+        wollet = self._get_wollet(wallet_name)
+        wallet_record = self.storage.load_wallet(wallet_name)
+        if wallet_record is None:
+            raise ValueError(f"Wallet {wallet_name!r} not found")
+        lwk_tip = wollet.address(None).index()
+        start = max(lwk_tip, wallet_record.next_address_index)
+        addresses: list[Address] = []
+        for offset in range(count):
+            addr = wollet.address(start + offset)
+            addresses.append(Address(address=str(addr.address()), index=addr.index()))
+        wallet_record.next_address_index = start + count
+        self.storage.save_wallet(wallet_record)
+        return addresses
+
+    def fingerprint(
+        self,
+        wallet_name: str,
+        password: Optional[str] = None,
+    ) -> str:
+        """Return the BIP32 master fingerprint (8 hex chars) for ``wallet_name``.
+
+        Format matches the AQUA Ankara backend's ``fingerprint`` field on
+        ``UserResponse`` / ``UserLiquidAddressesUpsert``: ``HASH160(master xpub)[:4]``
+        in hex. For hot wallets this comes straight from the LWK signer; for
+        watch-only wallets we parse the embedded ``[fp/derivation]`` block from
+        the stored descriptor.
+        """
+        if wallet_name in self._signers:
+            return self._signers[wallet_name].fingerprint()
+
+        # ``load_wallet`` decrypts the mnemonic (if needed) and caches the
+        # resulting lwk.Signer in ``self._signers`` as a side effect — so for
+        # hot wallets the next check succeeds and we get the canonical
+        # BIP32-master fingerprint straight from the signer.
+        wallet = self.load_wallet(wallet_name, password=password)
+        if wallet_name in self._signers:
+            return self._signers[wallet_name].fingerprint()
+
+        # Watch-only: best-effort parse of the [fp/derivation]xpub block.
+        from .bitcoin import _extract_xpub_metadata
+
+        meta = _extract_xpub_metadata(wallet.descriptor)
+        fp = meta.get("fingerprint")
+        if not fp:
+            raise ValueError(
+                f"Cannot determine fingerprint for watch-only wallet {wallet_name!r}: "
+                "descriptor has no [fingerprint/derivation] block."
+            )
+        return fp
 
     def get_transactions(
         self,

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -431,3 +431,62 @@ class WalletManager:
 
         txid = client.broadcast(tx)
         return str(txid)
+
+    def craft_raw_tx(
+        self,
+        wallet_name: str,
+        address: str,
+        amount: int,
+        asset_id: Optional[str] = None,
+        password: Optional[str] = None,
+    ) -> str:
+        """Build, sign, finalize a Liquid tx. Returns hex; does NOT broadcast.
+
+        Used when a third party (JAN3 Ankara backend, etc.) wants to broadcast
+        on our behalf. Branches on whether the destination address is
+        confidential (blinded) or explicit (unblinded), since LWK's tx builder
+        exposes different methods for each.
+        """
+        wallet = self.storage.load_wallet(wallet_name)
+        if not wallet:
+            raise ValueError(f"Wallet '{wallet_name}' not found")
+
+        if wallet.watch_only:
+            raise ValueError("Cannot sign with watch-only wallet")
+
+        if amount <= 0:
+            raise ValueError("Amount must be positive")
+
+        if wallet_name not in self._signers:
+            if not wallet.encrypted_mnemonic:
+                raise ValueError("No mnemonic available for signing")
+            needs_password = self.storage.requires_user_password(wallet.encrypted_mnemonic)
+            if needs_password and not password:
+                raise ValueError("Password required to decrypt mnemonic")
+            self.load_wallet(wallet_name, password)
+
+        signer = self._signers[wallet_name]
+        wollet = self._get_wollet(wallet_name)
+        net = self._get_network(wallet.network)
+        policy_asset_id = self._get_policy_asset(wallet.network)
+
+        self.sync_wallet(wallet_name)
+
+        builder = net.tx_builder()
+        lwk_address = lwk.Address(address)
+        effective_asset_id = asset_id or policy_asset_id
+
+        if lwk_address.is_blinded():
+            if effective_asset_id == policy_asset_id:
+                builder.add_lbtc_recipient(lwk_address, amount)
+            else:
+                builder.add_recipient(lwk_address, amount, effective_asset_id)
+        else:
+            builder.add_explicit_recipient(lwk_address, amount, effective_asset_id)
+
+        pset = builder.finish(wollet)
+        # Populate wallet-aware details (e.g. input/output values) so callers
+        # can introspect the PSET before handing the hex off.
+        pset = wollet.add_details(pset)
+        signed_pset = signer.sign(pset)
+        return str(signed_pset.finalize())

--- a/tests/test_ankara.py
+++ b/tests/test_ankara.py
@@ -18,6 +18,7 @@ from aqua.ankara import (
     JAN3AccountManager,
     JAN3AuthClient,
     JAN3Session,
+    _AuthExpired,
 )
 from aqua.storage import Storage
 from aqua.wallet import WalletManager
@@ -343,6 +344,23 @@ class FakeAuthClient:
     def provision_wapupay_account(self, access_token):
         return self._yield("provision_wapupay_account", access_token)
 
+    def refresh_access(self, refresh_token):
+        return self._yield("refresh_access", refresh_token)
+
+    def get_user(self, access_token):
+        return self._yield("get_user", access_token)
+
+    def ln_address_toggle(self, access_token, enabled):
+        return self._yield("ln_address_toggle", access_token, enabled)
+
+    def ln_username_available(self, username, access_token=None):
+        return self._yield("ln_username_available", username, access_token)
+
+    def register_addresses(self, access_token, fingerprint, addresses, override_fingerprint=False):
+        return self._yield(
+            "register_addresses", access_token, fingerprint, list(addresses), override_fingerprint
+        )
+
 
 def make_jan3(storage, fake):
     m = JAN3AccountManager(storage=storage)
@@ -521,5 +539,601 @@ def test_provision_client_unreachable():
         with pytest.raises(ValueError) as ei:
             client.provision_wapupay_account("jwt")
     assert "unreachable" in str(ei.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# JAN3AuthClient: account/profile HTTP targets
+# ---------------------------------------------------------------------------
+
+
+def test_client_get_user_targets_auth_user():
+    client = JAN3AuthClient()
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["req"] = req
+        return _mock_resp({"email": "u@e.com", "ln_username": "alice"})
+
+    with patch("aqua.ankara.urllib.request.urlopen", side_effect=fake_urlopen):
+        out = client.get_user("jwt.access")
+    assert out["ln_username"] == "alice"
+    assert captured["req"].full_url == f"{AUTH_BASE_URL}/user/"
+    assert captured["req"].get_method() == "GET"
+    assert captured["req"].get_header("Authorization") == "Bearer jwt.access"
+
+
+def test_client_ln_address_toggle_posts_enabled_flag():
+    client = JAN3AuthClient()
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data)
+        return _mock_resp({"enabled": False})
+
+    with patch("aqua.ankara.urllib.request.urlopen", side_effect=fake_urlopen):
+        client.ln_address_toggle("jwt", enabled=False)
+    assert captured["url"] == f"{AUTH_BASE_URL}/user/ln-address-toggle/"
+    assert captured["body"] == {"enabled": False}
+
+
+def test_client_ln_username_available_is_anonymous_and_url_encodes():
+    client = JAN3AuthClient()
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["req"] = req
+        return _mock_resp({"is_available": True, "reason": None})
+
+    with patch("aqua.ankara.urllib.request.urlopen", side_effect=fake_urlopen):
+        client.ln_username_available("alice.smith")
+    assert captured["req"].full_url == f"{AUTH_BASE_URL}/user/ln-username/alice.smith/is-available"
+    # Anonymous endpoint: no Authorization header.
+    assert captured["req"].get_header("Authorization") is None
+
+
+def test_client_register_addresses_query_string_for_override():
+    client = JAN3AuthClient()
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data)
+        return _mock_resp({"addresses": ["lq1qfoo"]})
+
+    with patch("aqua.ankara.urllib.request.urlopen", side_effect=fake_urlopen):
+        client.register_addresses(
+            "jwt", "deadbeef", ["lq1qfoo", "lq1qbar"], override_fingerprint=True
+        )
+    assert captured["url"] == f"{AUTH_BASE_URL}/user/addresses/?override_fingerprint=true"
+    assert captured["body"] == {"fingerprint": "deadbeef", "addresses": ["lq1qfoo", "lq1qbar"]}
+
+
+def test_client_refresh_access_returns_new_access():
+    client = JAN3AuthClient()
+    with patch(
+        "aqua.ankara.urllib.request.urlopen",
+        side_effect=lambda req, timeout=None: _mock_resp({"access": "ACC2"}),
+    ):
+        assert client.refresh_access("REF") == "ACC2"
+
+
+def test_client_refresh_access_raises_when_response_missing_access():
+    client = JAN3AuthClient()
+    with patch(
+        "aqua.ankara.urllib.request.urlopen",
+        side_effect=lambda req, timeout=None: _mock_resp({}),
+    ):
+        with pytest.raises(ValueError):
+            client.refresh_access("REF")
+
+
+def test_client_401_with_token_raises_auth_expired():
+    from aqua.ankara import _AuthExpired
+    client = JAN3AuthClient()
+    with patch(
+        "aqua.ankara.urllib.request.urlopen",
+        side_effect=_http_error(401, '{"detail": "expired"}'),
+    ):
+        with pytest.raises(_AuthExpired):
+            client.get_user("expired.jwt")
+
+
+def test_client_401_without_token_falls_through_to_value_error():
+    # Anonymous endpoints don't trigger auto-refresh: a 401 there is a real error.
+    client = JAN3AuthClient()
+    with patch(
+        "aqua.ankara.urllib.request.urlopen",
+        side_effect=_http_error(401, '{"detail": "denied"}'),
+    ):
+        with pytest.raises(ValueError):
+            client.ln_username_available("alice")
+
+
+# ---------------------------------------------------------------------------
+# JAN3AccountManager: profile + LN-address surface (with auto-refresh)
+# ---------------------------------------------------------------------------
+
+
+def test_manager_get_user_returns_profile(jan3_storage):
+    profile = {"email": "u@e.com", "ln_username": "alice", "new_addresses_needed": 0}
+    fake = FakeAuthClient({"get_user": profile})
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    assert m.get_user() == profile
+    # Called with the persisted access token.
+    assert fake.calls[0] == ("get_user", ("acc.tok",))
+
+
+def test_manager_get_user_refreshes_on_401_and_retries(jan3_storage):
+    from aqua.ankara import _AuthExpired
+
+    profile = {"ln_username": "alice"}
+    # First get_user call: 401. Refresh returns "ACC2". Retry succeeds.
+    responses = {
+        "get_user": [_AuthExpired(), profile],
+        "refresh_access": "ACC2",
+    }
+    fake = FakeAuthClient()
+
+    def get_user(access):
+        fake.calls.append(("get_user", (access,)))
+        val = responses["get_user"].pop(0)
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+    def refresh_access(refresh):
+        fake.calls.append(("refresh_access", (refresh,)))
+        return responses["refresh_access"]
+
+    fake.get_user = get_user
+    fake.refresh_access = refresh_access
+
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage, access="OLD", refresh="REF")
+    out = m.get_user()
+    assert out == profile
+    # Sequence: 401 → refresh → retry with new token.
+    assert [c[0] for c in fake.calls] == ["get_user", "refresh_access", "get_user"]
+    assert fake.calls[0][1] == ("OLD",)
+    assert fake.calls[2][1] == ("ACC2",)
+    # Persisted session was updated.
+    assert jan3_storage.load_jan3_session().access == "ACC2"
+
+
+def test_manager_get_user_refresh_failure_points_to_relogin(jan3_storage):
+    from aqua.ankara import _AuthExpired
+
+    fake = FakeAuthClient({
+        "get_user": _AuthExpired(),
+        "refresh_access": ValueError("refresh dead"),
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    with pytest.raises(ValueError) as ei:
+        m.get_user()
+    assert "aqua_login" in str(ei.value)
+
+
+def test_manager_ln_username_available_anonymous_when_no_session(jan3_storage):
+    fake = FakeAuthClient({"ln_username_available": {"is_available": True, "reason": None}})
+    m = make_jan3(jan3_storage, fake)
+    out = m.ln_username_available("  alice  ")
+    assert out["is_available"] is True
+    # No session → no access token forwarded.
+    assert fake.calls == [("ln_username_available", ("alice", None))]
+
+
+def test_manager_ln_username_available_uses_token_when_session_exists(jan3_storage):
+    fake = FakeAuthClient({"ln_username_available": {"is_available": False, "reason": "taken"}})
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage, access="ACC1")
+    m.ln_username_available("alice")
+    # Session present → token forwarded so the live (auth-gated) deployment accepts the call.
+    assert fake.calls == [("ln_username_available", ("alice", "ACC1"))]
+
+
+def test_manager_ln_username_available_rejects_blank(jan3_storage):
+    m = make_jan3(jan3_storage, FakeAuthClient())
+    with pytest.raises(ValueError):
+        m.ln_username_available("   ")
+
+
+def test_manager_ln_address_toggle_uses_session_token(jan3_storage):
+    fake = FakeAuthClient({"ln_address_toggle": {"enabled": True}})
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage, access="ACC1")
+    m.ln_address_toggle(True)
+    assert fake.calls == [("ln_address_toggle", ("ACC1", True))]
+
+
+# ---------------------------------------------------------------------------
+# JAN3AccountManager.register_ln_addresses — orchestration
+# ---------------------------------------------------------------------------
+
+
+def _wm_stub(fingerprint="deadbeef", addrs=None):
+    """Wallet manager stub for register_ln_addresses tests.
+
+    Counter persistence now lives inside ``WalletManager.reserve_addresses``
+    (covered by tests/test_tools.py); from the orchestration's point of view,
+    ``reserve_addresses(name, count)`` just returns N fresh ``Address``-like
+    objects in one call.
+    """
+    wm = MagicMock()
+    wm.fingerprint.return_value = fingerprint
+    addrs = addrs or [f"lq1q{i:04d}" for i in range(20)]
+    items = [MagicMock(address=a, index=i) for i, a in enumerate(addrs)]
+    wm.reserve_addresses.side_effect = lambda _name, count: items[:count]
+    return wm
+
+
+def test_register_ln_addresses_happy_path_uses_server_count(jan3_storage):
+    user = {
+        "ln_username": "alice",
+        "ln_address_toggled": True,
+        "fingerprint": "deadbeef",
+        "new_addresses_needed": 3,
+    }
+    fake = FakeAuthClient({
+        "get_user": user,
+        "register_addresses": {"addresses": ["lq1q0000", "lq1q0001", "lq1q0002"]},
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    wm = _wm_stub()
+    out = m.register_ln_addresses(wallet_manager=wm, wallet_name="default")
+    assert out["requested_count"] == 3
+    assert out["pool_size"] == 3
+    assert out["fingerprint"] == "deadbeef"
+    assert out["addresses"] == ["lq1q0000", "lq1q0001", "lq1q0002"]
+    # Three no-arg mints — no tip probe, no manual indexing.
+    wm.reserve_addresses.assert_called_once_with("default", 3)
+    # POST shape matched.
+    register_call = next(c for c in fake.calls if c[0] == "register_addresses")
+    _, (access, fp, addrs, override) = register_call
+    assert access == "acc.tok"
+    assert fp == "deadbeef"
+    assert len(addrs) == 3
+    assert override is False
+
+
+def test_register_ln_addresses_defaults_to_five_when_server_says_zero(jan3_storage):
+    user = {
+        "ln_username": "alice",
+        "ln_address_toggled": True,
+        "fingerprint": "deadbeef",
+        "new_addresses_needed": 0,
+    }
+    fake = FakeAuthClient({
+        "get_user": user,
+        "register_addresses": {"addresses": []},
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    wm = _wm_stub()
+    m.register_ln_addresses(wallet_manager=wm, wallet_name="default")
+    wm.reserve_addresses.assert_called_once_with("default", 5)
+
+
+def test_register_ln_addresses_respects_explicit_count(jan3_storage):
+    user = {
+        "ln_username": "alice",
+        "ln_address_toggled": True,
+        "fingerprint": "deadbeef",
+        "new_addresses_needed": 0,
+    }
+    fake = FakeAuthClient({
+        "get_user": user,
+        "register_addresses": {"addresses": []},
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    wm = _wm_stub()
+    m.register_ln_addresses(wallet_manager=wm, wallet_name="default", count=2)
+    wm.reserve_addresses.assert_called_once_with("default", 2)
+
+
+def test_register_ln_addresses_caps_at_max(jan3_storage):
+    from aqua.ankara import MAX_ADDRESSES_PER_REGISTRATION
+
+    fake = FakeAuthClient({
+        "get_user": {"ln_username": "a", "ln_address_toggled": True, "fingerprint": "dead", "new_addresses_needed": 0},
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    with pytest.raises(ValueError) as ei:
+        m.register_ln_addresses(
+            wallet_manager=_wm_stub("dead"),
+            wallet_name="default",
+            count=MAX_ADDRESSES_PER_REGISTRATION + 1,
+        )
+    assert str(MAX_ADDRESSES_PER_REGISTRATION) in str(ei.value)
+
+
+def test_register_ln_addresses_refuses_without_username(jan3_storage):
+    fake = FakeAuthClient({"get_user": {"ln_username": None, "ln_address_toggled": True}})
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    with pytest.raises(ValueError) as ei:
+        m.register_ln_addresses(wallet_manager=_wm_stub(), wallet_name="default")
+    assert "purchase_ln_username" in str(ei.value)
+
+
+def test_register_ln_addresses_refuses_when_toggled_off(jan3_storage):
+    fake = FakeAuthClient({
+        "get_user": {"ln_username": "alice", "ln_address_toggled": False, "fingerprint": "dead"},
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    with pytest.raises(ValueError) as ei:
+        m.register_ln_addresses(wallet_manager=_wm_stub("dead"), wallet_name="default")
+    assert "ln_address_toggle" in str(ei.value)
+
+
+def test_register_ln_addresses_refuses_on_fingerprint_mismatch(jan3_storage):
+    fake = FakeAuthClient({
+        "get_user": {
+            "ln_username": "alice",
+            "ln_address_toggled": True,
+            "fingerprint": "11111111",
+            "new_addresses_needed": 5,
+        },
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    with pytest.raises(ValueError) as ei:
+        m.register_ln_addresses(wallet_manager=_wm_stub("22222222"), wallet_name="default")
+    msg = str(ei.value)
+    assert "fingerprint mismatch" in msg.lower()
+    assert "11111111" in msg and "22222222" in msg
+    # No POST attempted.
+    assert not any(c[0] == "register_addresses" for c in fake.calls)
+
+
+def test_register_ln_addresses_override_skips_fingerprint_and_toggle_checks(jan3_storage):
+    fake = FakeAuthClient({
+        "get_user": {
+            "ln_username": "alice",
+            "ln_address_toggled": False,  # off — would normally refuse
+            "fingerprint": "11111111",     # mismatched — would normally refuse
+            "new_addresses_needed": 0,
+        },
+        "register_addresses": {"addresses": []},
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    m.register_ln_addresses(
+        wallet_manager=_wm_stub("22222222"),
+        wallet_name="default",
+        override_fingerprint=True,
+    )
+    call = next(c for c in fake.calls if c[0] == "register_addresses")
+    _, (_, fp, _, override) = call
+    assert fp == "22222222"
+    assert override is True
+
+
+# ---------------------------------------------------------------------------
+# JAN3AccountManager.ensure_ln_pool — idempotent top-up
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_ln_pool_no_username_skips(jan3_storage):
+    fake = FakeAuthClient({"get_user": {"ln_username": None, "ln_address_toggled": True}})
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    out = m.ensure_ln_pool(wallet_manager=_wm_stub(), wallet_name="default")
+    assert out == {"refilled": False, "reason": "no_ln_username", "fingerprint": None}
+    assert not any(c[0] == "register_addresses" for c in fake.calls)
+
+
+def test_ensure_ln_pool_disabled_skips(jan3_storage):
+    fake = FakeAuthClient({
+        "get_user": {"ln_username": "alice", "ln_address_toggled": False, "fingerprint": "dead"},
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    out = m.ensure_ln_pool(wallet_manager=_wm_stub("dead"), wallet_name="default")
+    assert out["refilled"] is False and out["reason"] == "ln_address_disabled"
+
+
+def test_ensure_ln_pool_full_skips(jan3_storage):
+    fake = FakeAuthClient({
+        "get_user": {
+            "ln_username": "alice",
+            "ln_address_toggled": True,
+            "fingerprint": "dead",
+            "new_addresses_needed": 0,
+        },
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    out = m.ensure_ln_pool(wallet_manager=_wm_stub("dead"), wallet_name="default")
+    assert out == {
+        "refilled": False,
+        "reason": "pool_full",
+        "fingerprint": "dead",
+        "new_addresses_needed": 0,
+    }
+
+
+def test_ensure_ln_pool_fingerprint_mismatch_skips(jan3_storage):
+    fake = FakeAuthClient({
+        "get_user": {
+            "ln_username": "alice",
+            "ln_address_toggled": True,
+            "fingerprint": "11111111",
+            "new_addresses_needed": 3,
+        },
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    out = m.ensure_ln_pool(wallet_manager=_wm_stub("22222222"), wallet_name="default")
+    assert out == {
+        "refilled": False,
+        "reason": "fingerprint_mismatch",
+        "server_fingerprint": "11111111",
+        "local_fingerprint": "22222222",
+    }
+    assert not any(c[0] == "register_addresses" for c in fake.calls)
+
+
+def test_ensure_ln_pool_happy_path_refills(jan3_storage):
+    fake = FakeAuthClient({
+        "get_user": {
+            "ln_username": "alice",
+            "ln_address_toggled": True,
+            "fingerprint": "deadbeef",
+            "new_addresses_needed": 4,
+        },
+        "register_addresses": {"addresses": ["lq1qa", "lq1qb", "lq1qc", "lq1qd"]},
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    out = m.ensure_ln_pool(wallet_manager=_wm_stub(), wallet_name="default")
+    assert out["refilled"] is True
+    assert out["requested_count"] == 4
+    assert out["pool_size"] == 4
+    assert out["fingerprint"] == "deadbeef"
+
+
+def test_ensure_ln_pool_caps_at_max(jan3_storage):
+    from aqua.ankara import MAX_ADDRESSES_PER_REGISTRATION
+
+    fake = FakeAuthClient({
+        "get_user": {
+            "ln_username": "alice",
+            "ln_address_toggled": True,
+            "fingerprint": "deadbeef",
+            "new_addresses_needed": 50,
+        },
+        "register_addresses": {"addresses": []},
+    })
+    m = make_jan3(jan3_storage, fake)
+    logged_in(jan3_storage)
+    wm = _wm_stub()
+    m.ensure_ln_pool(wallet_manager=wm, wallet_name="default")
+    # Capped — never sends more than the server allows per call.
+    wm.reserve_addresses.assert_called_once_with("default", MAX_ADDRESSES_PER_REGISTRATION)
+
+
+# ---------------------------------------------------------------------------
+# _authed_call — opportunistic LN-pool top-up after refresh
+# ---------------------------------------------------------------------------
+
+
+def test_authed_call_tops_up_after_refresh(jan3_storage):
+    """Successful 401 → refresh → retry triggers an opportunistic top-up."""
+    profile = {
+        "ln_username": "alice",
+        "ln_address_toggled": True,
+        "fingerprint": "deadbeef",
+        "new_addresses_needed": 2,
+    }
+    # First get_user (the caller's): 401. Retry: profile. Top-up's single
+    # fetch with the new token: profile. ensure_ln_pool + register_ln_addresses
+    # reuse that profile, so no more get_user calls.
+    get_user_responses = [_AuthExpired(), profile, profile]
+    fake = FakeAuthClient()
+
+    def get_user(access):
+        fake.calls.append(("get_user", (access,)))
+        val = get_user_responses.pop(0)
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+    def refresh_access(refresh):
+        fake.calls.append(("refresh_access", (refresh,)))
+        return "ACC2"
+
+    def register_addresses(access, fp, addrs, override_fingerprint=False):
+        fake.calls.append(("register_addresses", (access, fp, list(addrs), override_fingerprint)))
+        return {"addresses": ["lq1qa", "lq1qb"]}
+
+    fake.get_user = get_user
+    fake.refresh_access = refresh_access
+    fake.register_addresses = register_addresses
+
+    wm = _wm_stub("deadbeef")
+    m = JAN3AccountManager(storage=jan3_storage, wallet_manager_factory=lambda: wm)
+    m._client = fake
+    logged_in(jan3_storage, access="OLD", refresh="REF")
+
+    # First call is what the user invoked; refresh + retry succeeds; THEN the
+    # top-up fires before returning to the caller.
+    out = m.get_user()
+    assert out == profile
+
+    # Expected call sequence: caller's get_user (401), refresh, retry get_user,
+    # top-up's single get_user, then the POST. The profile is threaded through
+    # ensure_ln_pool → register_ln_addresses so the top-up only costs one
+    # extra round trip total.
+    methods = [c[0] for c in fake.calls]
+    assert methods == [
+        "get_user",
+        "refresh_access",
+        "get_user",
+        "get_user",          # _opportunistic_top_up's single fetch
+        "register_addresses",
+    ]
+    # Top-up uses the NEW access token, not the stale one.
+    assert fake.calls[-1][1][0] == "ACC2"
+
+
+def test_authed_call_swallows_top_up_errors(jan3_storage):
+    """A failing top-up never breaks the caller's actual operation."""
+    profile = {
+        "ln_username": "alice",
+        "ln_address_toggled": True,
+        "fingerprint": "deadbeef",
+        "new_addresses_needed": 2,
+    }
+    get_user_responses = [_AuthExpired(), profile, ValueError("top-up boom")]
+    fake = FakeAuthClient()
+
+    def get_user(access):
+        fake.calls.append(("get_user", (access,)))
+        val = get_user_responses.pop(0)
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+    fake.get_user = get_user
+    fake.refresh_access = lambda r: "ACC2"
+
+    wm = _wm_stub("deadbeef")
+    m = JAN3AccountManager(storage=jan3_storage, wallet_manager_factory=lambda: wm)
+    m._client = fake
+    logged_in(jan3_storage, access="OLD", refresh="REF")
+
+    # The original call still succeeds.
+    assert m.get_user() == profile
+
+
+def test_authed_call_no_factory_no_top_up(jan3_storage):
+    """Managers constructed without a wallet_manager_factory skip the top-up."""
+    profile = {"ln_username": "alice", "ln_address_toggled": True, "new_addresses_needed": 2}
+    get_user_responses = [_AuthExpired(), profile]
+    fake = FakeAuthClient()
+
+    def get_user(access):
+        fake.calls.append(("get_user", (access,)))
+        val = get_user_responses.pop(0)
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+    fake.get_user = get_user
+    fake.refresh_access = lambda r: "ACC2"
+
+    m = JAN3AccountManager(storage=jan3_storage)  # no factory
+    m._client = fake
+    logged_in(jan3_storage, access="OLD", refresh="REF")
+    m.get_user()
+    # Only the caller's two get_user calls + the refresh — no top-up get_user.
+    assert [c[0] for c in fake.calls] == ["get_user", "get_user"]
 
 

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -1,0 +1,466 @@
+"""Tests for JAN3 Accounts paid captchaless login.
+
+Patches ``Jan3AccountsClient`` methods on the class so the manager-level
+tests never touch the network; the wallet manager is faked too since
+``craft_raw_tx`` is exercised in test_tools.py.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import stat
+import tempfile
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aqua.jan3_accounts import (
+    AQUA_ANKARA_API_URL,
+    ASSET_TICKER_LBTC,
+    Jan3AccountsClient,
+    Jan3AccountsManager,
+    Jan3Session,
+    Jan3UnauthorizedError,
+    _email_to_filename,
+    _token_preview,
+    _validate_email,
+)
+from aqua.storage import Storage
+
+# Real L-BTC mainnet policy asset id (any 64-hex placeholder is fine here).
+LBTC_ASSET_ID = "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d"
+VAULT_ADDR = (
+    "lq1qqvxk052kf3qtkxmrakx50a9gc3smqad2ync54hzntjt980kfej9kkfe"
+    "0247rp5h4yzmdftsahhw64uy8pzfe7cpg4fgykm7cv"
+)
+
+
+@pytest.fixture
+def storage():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Storage(Path(tmpdir))
+
+
+def _fake_wallet_manager(raw_tx: str = "0200deadbeef") -> MagicMock:
+    """Wallet manager stub for tests.
+
+    ``craft_raw_tx`` returns the canned hex; ``_get_policy_asset`` returns
+    the L-BTC policy id.
+    """
+    wm = MagicMock()
+    wm.craft_raw_tx.return_value = raw_tx
+    wm._get_policy_asset.return_value = LBTC_ASSET_ID
+    wallet = MagicMock()
+    wallet.network = "mainnet"
+    wm.storage.load_wallet.return_value = wallet
+    return wm
+
+
+def _manager(storage, raw_tx: str = "0200deadbeef") -> Jan3AccountsManager:
+    return Jan3AccountsManager(
+        storage=storage,
+        wallet_manager=_fake_wallet_manager(raw_tx),
+        base_url=AQUA_ANKARA_API_URL,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPureHelpers:
+    def test_validate_email_lowercases(self):
+        assert _validate_email("ME@Example.com") == "me@example.com"
+
+    @pytest.mark.parametrize("bad", ["", "not-an-email", "a@b", "a@.com", "@b.com"])
+    def test_validate_email_rejects(self, bad):
+        with pytest.raises(ValueError, match="Invalid email"):
+            _validate_email(bad)
+
+    def test_token_preview_short_is_fully_redacted(self):
+        # A 4-char preview of a 4-char token reveals the whole secret.
+        # Below the threshold we fully redact instead.
+        assert _token_preview("abc") == "…"
+        assert _token_preview("abcdefghijk") == "…"  # 11 chars, still redacted
+
+    def test_token_preview_long(self):
+        token = "abcd" + "x" * 20 + "wxyz"
+        assert _token_preview(token).startswith("abcd…")
+        assert _token_preview(token).endswith("…wxyz")
+
+    def test_token_preview_empty(self):
+        assert _token_preview("") == ""
+
+    def test_email_to_filename_safe(self):
+        assert _email_to_filename("me@example.com") == "me@example.com"
+
+    def test_email_to_filename_escapes_unsafe(self):
+        # `/` would let an attacker write outside jan3_accounts_dir; it must
+        # be percent-encoded. (`..` *within* a name is fine — pathlib treats
+        # the result as a single file component, not a directory traversal.)
+        encoded = _email_to_filename("a..b/c@d.com")
+        assert "/" not in encoded
+        assert "\\" not in encoded
+
+
+# ---------------------------------------------------------------------------
+# Jan3Session round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSessionRoundtrip:
+    def test_to_from_dict(self):
+        s = Jan3Session(
+            email="me@example.com",
+            base_url="https://test.aquabtc.com",
+            access_token="A" * 40,
+            refresh_token="R" * 40,
+            created_at="2026-06-16T00:00:00+00:00",
+            captcha_exempt=True,
+        )
+        s2 = Jan3Session.from_dict(s.to_dict())
+        assert s2 == s
+
+    def test_from_dict_backfills_optional_fields(self):
+        """Legacy files without refreshed_at / captcha_exempt should load."""
+        s = Jan3Session.from_dict({
+            "email": "x@y.com",
+            "base_url": "https://test.aquabtc.com",
+            "access_token": "a",
+            "refresh_token": "r",
+            "created_at": "now",
+        })
+        assert s.refreshed_at is None
+        assert s.captcha_exempt is False
+
+
+# ---------------------------------------------------------------------------
+# Jan3AccountsClient HTTP layer
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(data, status=200):
+    resp = MagicMock()
+    if isinstance(data, (dict, list)):
+        resp.read.return_value = json.dumps(data).encode()
+    elif data is None:
+        resp.read.return_value = b""
+    else:
+        resp.read.return_value = data
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+class TestHttpClient:
+    @patch("urllib.request.urlopen")
+    def test_get_vault_payment_address(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"address": VAULT_ADDR})
+        client = Jan3AccountsClient(base_url="https://test.aquabtc.com")
+        assert client.get_vault_payment_address() == VAULT_ADDR
+        # The path is the documented one.
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url.endswith("/api/v1/liquid-wallet/payment/receive-address/")
+
+    @patch("urllib.request.urlopen")
+    def test_get_vault_payment_address_empty_raises(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"address": ""})
+        client = Jan3AccountsClient(base_url="https://test.aquabtc.com")
+        with pytest.raises(RuntimeError, match="no address"):
+            client.get_vault_payment_address()
+
+    @patch("urllib.request.urlopen")
+    def test_get_product_price_selects_matching_row(self, mock_urlopen):
+        rows = [
+            {
+                "product_type": "OTHER",
+                "lbtc_sats_price": 1,
+                "usdt_base_units_price": 1,
+                "usdt_display_price": "1",
+            },
+            {
+                "product_type": "CAPTCHALESS_LOGIN",
+                "lbtc_sats_price": 100,
+                "usdt_base_units_price": 200,
+                "usdt_display_price": "0.10",
+            },
+        ]
+        mock_urlopen.return_value = _mock_response(rows)
+        client = Jan3AccountsClient(base_url="https://test.aquabtc.com")
+        row = client.get_product_price("CAPTCHALESS_LOGIN")
+        assert row["lbtc_sats_price"] == 100
+
+    @patch("urllib.request.urlopen")
+    def test_get_product_price_missing_row_raises(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response([])
+        client = Jan3AccountsClient(base_url="https://test.aquabtc.com")
+        with pytest.raises(RuntimeError, match="no entry for"):
+            client.get_product_price("LN_USERNAME_UPDATE")
+
+    @patch("urllib.request.urlopen")
+    def test_login_v2_body_carries_login_challenge(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"message": "ok"})
+        client = Jan3AccountsClient(base_url="https://test.aquabtc.com")
+        result = client.login_v2(
+            email="me@example.com",
+            language="en",
+            raw_tx="DEADBEEF",
+            payment_address=VAULT_ADDR,
+        )
+        assert result == {"message": "ok"}
+        # Verify request body shape.
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data.decode())
+        assert body["email"] == "me@example.com"
+        assert body["language"] == "en"
+        assert body["login_challenge"] == {
+            "raw_tx": "DEADBEEF",
+            "payment_address": VAULT_ADDR,
+        }
+        assert req.full_url.endswith("/api/v2/auth/login/")
+
+    @patch("urllib.request.urlopen")
+    def test_login_v2_without_challenge_omits_field(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"message": "ok"})
+        client = Jan3AccountsClient(base_url="https://test.aquabtc.com")
+        client.login_v2(email="me@example.com")
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data.decode())
+        assert "login_challenge" not in body
+
+    @patch("urllib.request.urlopen")
+    def test_401_raises_unauthorized(self, mock_urlopen):
+        err = urllib.error.HTTPError(
+            url="https://test.aquabtc.com/api/v1/auth/verify/",
+            code=401,
+            msg="Unauthorized",
+            hdrs=None,
+            fp=io.BytesIO(json.dumps({"message": "bad otp"}).encode()),
+        )
+        mock_urlopen.side_effect = err
+        client = Jan3AccountsClient(base_url="https://test.aquabtc.com")
+        with pytest.raises(Jan3UnauthorizedError):
+            client.verify_otp("me@example.com", "000000")
+
+    @patch("urllib.request.urlopen")
+    def test_other_http_error_raises_runtime(self, mock_urlopen):
+        err = urllib.error.HTTPError(
+            url="x", code=400, msg="Bad",
+            hdrs=None,
+            fp=io.BytesIO(json.dumps({"message": "CAPTCHA_REQUIRED"}).encode()),
+        )
+        mock_urlopen.side_effect = err
+        client = Jan3AccountsClient(base_url="https://test.aquabtc.com")
+        with pytest.raises(RuntimeError, match="CAPTCHA_REQUIRED"):
+            client.login_v2(email="me@example.com")
+
+
+# ---------------------------------------------------------------------------
+# Login flow
+# ---------------------------------------------------------------------------
+
+
+class TestRequestLogin:
+    def test_happy_path(self, storage):
+        mgr = _manager(storage, raw_tx="hex-tx")
+        with (
+            patch.object(Jan3AccountsClient, "get_vault_payment_address", return_value=VAULT_ADDR),
+            patch.object(
+                Jan3AccountsClient,
+                "get_product_price",
+                return_value={"lbtc_sats_price": 100},
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "login_v2",
+                return_value={"message": "OTP sent"},
+            ) as mock_login,
+        ):
+            result = mgr.request_login(
+                email="ME@Example.com",
+                wallet_name="default",
+                password=None,
+                language="en",
+            )
+
+        assert result["email"] == "me@example.com"
+        assert result["payment_address"] == VAULT_ADDR
+        assert result["amount_sats"] == 100
+        assert result["asset_ticker"] == ASSET_TICKER_LBTC
+        mgr.wallet_manager.craft_raw_tx.assert_called_once_with(
+            wallet_name="default",
+            address=VAULT_ADDR,
+            amount=100,
+            asset_id=LBTC_ASSET_ID,
+            password=None,
+        )
+        mock_login.assert_called_once_with(
+            email="me@example.com",
+            language="en",
+            raw_tx="hex-tx",
+            payment_address=VAULT_ADDR,
+        )
+        # No session is persisted yet — complete_login does that.
+        assert mgr.load_session("me@example.com") is None
+
+    def test_blocked_when_disabled(self, storage):
+        """A 403 CAPTCHALESS_LOGIN_DISABLED from the server surfaces as RuntimeError."""
+        mgr = _manager(storage)
+        with (
+            patch.object(Jan3AccountsClient, "get_vault_payment_address", return_value=VAULT_ADDR),
+            patch.object(
+                Jan3AccountsClient,
+                "get_product_price",
+                return_value={"lbtc_sats_price": 100},
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "login_v2",
+                side_effect=RuntimeError(
+                    "AQUA API error (403 POST /api/v2/auth/login/): CAPTCHALESS_LOGIN_DISABLED"
+                ),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="CAPTCHALESS_LOGIN_DISABLED"):
+                mgr.request_login(email="me@example.com")
+
+    def test_rejects_invalid_email(self, storage):
+        mgr = _manager(storage)
+        with pytest.raises(ValueError, match="Invalid email"):
+            mgr.request_login(email="not-an-email")
+
+    def test_rejects_non_positive_price(self, storage):
+        """If the server seeded the price at zero, we refuse to craft a zero-amount tx."""
+        mgr = _manager(storage)
+        with (
+            patch.object(Jan3AccountsClient, "get_vault_payment_address", return_value=VAULT_ADDR),
+            patch.object(
+                Jan3AccountsClient,
+                "get_product_price",
+                return_value={"lbtc_sats_price": 0},
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="non-positive"):
+                mgr.request_login(email="me@example.com")
+
+
+class TestCompleteLogin:
+    def test_persists_session(self, storage):
+        mgr = _manager(storage)
+        with patch.object(
+            Jan3AccountsClient,
+            "verify_otp",
+            return_value={"access": "A" * 40, "refresh": "R" * 40},
+        ):
+            result = mgr.complete_login(email="me@example.com", otp_code="123456")
+
+        assert result["captcha_exempt"] is True
+        assert result["access_token_preview"].startswith("AAAA")
+        # The refresh token is the long-lived secret — its preview must
+        # never appear in tool output (would land in MCP transcripts).
+        assert "refresh_token_preview" not in result
+
+        loaded = mgr.load_session("me@example.com")
+        assert loaded is not None
+        assert loaded.access_token == "A" * 40
+        assert loaded.refresh_token == "R" * 40
+        assert loaded.captcha_exempt is True
+
+        # File permissions: stash secrets at 0o600 on POSIX. (Skip on Windows
+        # where chmod is largely a no-op — the atomic-write helper attempts
+        # it best-effort.)
+        if os.name == "posix":
+            path = mgr._session_path("me@example.com")
+            mode = stat.S_IMODE(path.stat().st_mode)
+            assert mode == 0o600
+
+    def test_propagates_invalid_otp(self, storage):
+        mgr = _manager(storage)
+        with patch.object(
+            Jan3AccountsClient,
+            "verify_otp",
+            side_effect=Jan3UnauthorizedError("bad OTP"),
+        ):
+            with pytest.raises(Jan3UnauthorizedError):
+                mgr.complete_login(email="me@example.com", otp_code="000000")
+        assert mgr.load_session("me@example.com") is None
+
+    def test_rejects_blank_otp(self, storage):
+        mgr = _manager(storage)
+        with pytest.raises(ValueError, match="otp_code is required"):
+            mgr.complete_login(email="me@example.com", otp_code="   ")
+
+    def test_rejects_missing_tokens(self, storage):
+        mgr = _manager(storage)
+        with patch.object(
+            Jan3AccountsClient,
+            "verify_otp",
+            return_value={"access": "only-access"},
+        ):
+            with pytest.raises(RuntimeError, match="both access and refresh"):
+                mgr.complete_login(email="me@example.com", otp_code="123456")
+
+
+def _seed_session(mgr: Jan3AccountsManager, email: str) -> Jan3Session:
+    session = Jan3Session(
+        email=email,
+        base_url=mgr.base_url,
+        access_token="initial-access",
+        refresh_token="refresh-token-xyz",
+        created_at="2026-06-16T00:00:00+00:00",
+        captcha_exempt=True,
+    )
+    mgr.save_session(session)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Session management
+# ---------------------------------------------------------------------------
+
+
+class TestSessionManagement:
+    def test_logout_deletes_file(self, storage):
+        mgr = _manager(storage)
+        _seed_session(mgr, "me@example.com")
+        assert mgr.load_session("me@example.com") is not None
+
+        assert mgr.delete_session("me@example.com") is True
+        assert mgr.load_session("me@example.com") is None
+
+    def test_logout_idempotent(self, storage):
+        mgr = _manager(storage)
+        assert mgr.delete_session("ghost@example.com") is False
+
+    def test_list_sessions(self, storage):
+        mgr = _manager(storage)
+        _seed_session(mgr, "a@example.com")
+        _seed_session(mgr, "b@example.com")
+        emails = {s.email for s in mgr.list_sessions()}
+        assert emails == {"a@example.com", "b@example.com"}
+
+    def test_session_file_is_under_jan3_accounts_dir(self, storage):
+        mgr = _manager(storage)
+        path = mgr._session_path("me@example.com")
+        assert path.parent == storage.jan3_accounts_dir
+
+    def test_load_session_tolerates_corrupted_file(self, storage):
+        """A corrupted on-disk session shouldn't break every JAN3 tool —
+        treat it as missing so the caller can prompt a re-login."""
+        mgr = _manager(storage)
+        path = mgr._session_path("me@example.com")
+        path.write_text("{not valid json")
+        assert mgr.load_session("me@example.com") is None
+
+    def test_load_session_tolerates_missing_required_fields(self, storage):
+        """A file that's valid JSON but missing required dataclass fields
+        (e.g., refresh_token) should also be treated as missing."""
+        mgr = _manager(storage)
+        path = mgr._session_path("me@example.com")
+        path.write_text('{"email": "me@example.com"}')
+        assert mgr.load_session("me@example.com") is None

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -1,4 +1,4 @@
-"""Tests for JAN3 Accounts paid captchaless login.
+"""Tests for JAN3 Accounts integration (login + purchases).
 
 Patches ``Jan3AccountsClient`` methods on the class so the manager-level
 tests never touch the network; the wallet manager is faked too since
@@ -28,7 +28,9 @@ from aqua.jan3_accounts import (
     _email_to_filename,
     _token_preview,
     _validate_email,
+    _validate_ln_username,
 )
+from aqua.lnurl import resolve_lightning_address
 from aqua.storage import Storage
 
 # Real L-BTC mainnet policy asset id (any 64-hex placeholder is fine here).
@@ -81,6 +83,29 @@ class TestPureHelpers:
     def test_validate_email_rejects(self, bad):
         with pytest.raises(ValueError, match="Invalid email"):
             _validate_email(bad)
+
+    def test_validate_ln_username_lowercases(self):
+        assert _validate_ln_username("AliceBob") == "alicebob"
+
+    @pytest.mark.parametrize("ok", ["abcd", "ab.cd", "alice.bob", "u" * 64])
+    def test_validate_ln_username_accepts(self, ok):
+        assert _validate_ln_username(ok) == ok.lower()
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "abc",  # too short (<4)
+            "u" * 65,  # too long
+            "Has Space",
+            "a..b",  # two dots
+            "a-b",  # hyphen not allowed
+            "..",
+        ],
+    )
+    def test_validate_ln_username_rejects(self, bad):
+        with pytest.raises(ValueError, match="Invalid ln_username"):
+            _validate_ln_username(bad)
 
     def test_token_preview_short_is_fully_redacted(self):
         # A 4-char preview of a 4-char token reveals the whole secret.
@@ -259,6 +284,21 @@ class TestHttpClient:
         with pytest.raises(RuntimeError, match="CAPTCHA_REQUIRED"):
             client.login_v2(email="me@example.com")
 
+    @patch("urllib.request.urlopen")
+    def test_authed_request_injects_bearer(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"payment_id": "p1"})
+        client = Jan3AccountsClient(
+            base_url="https://test.aquabtc.com", access_token="tok-xyz"
+        )
+        client.create_ln_username_payment_request(asset="L-BTC", ln_username="alice")
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer tok-xyz"
+
+    def test_authed_request_without_token_raises(self):
+        client = Jan3AccountsClient(base_url="https://test.aquabtc.com")
+        with pytest.raises(ValueError, match="requires an access_token"):
+            client.create_ln_username_payment_request("L-BTC", "alice")
+
 
 # ---------------------------------------------------------------------------
 # Login flow
@@ -406,6 +446,11 @@ class TestCompleteLogin:
                 mgr.complete_login(email="me@example.com", otp_code="123456")
 
 
+# ---------------------------------------------------------------------------
+# Purchase flow
+# ---------------------------------------------------------------------------
+
+
 def _seed_session(mgr: Jan3AccountsManager, email: str) -> Jan3Session:
     session = Jan3Session(
         email=email,
@@ -417,6 +462,370 @@ def _seed_session(mgr: Jan3AccountsManager, email: str) -> Jan3Session:
     )
     mgr.save_session(session)
     return session
+
+
+class TestPurchaseLnUsername:
+    PR_RESPONSE = {
+        "payment_id": "11111111-1111-1111-1111-111111111111",
+        "status": "PENDING",
+        "product_type": "LN_USERNAME_UPDATE",
+        "asset_ticker": "L-BTC",
+        "amount": "0.00001000",
+        "amount_base_units": 1000,
+        "address": VAULT_ADDR,
+        "expires_at": "2026-06-16T01:00:00+00:00",
+        "product_details": {"ln_username": "alicebob"},
+    }
+    SUBMIT_RESPONSE = {**PR_RESPONSE, "status": "ACCEPTED"}
+
+    def _raw_hex(self):
+        # A real signed Liquid tx is far too large to inline; use a known-good
+        # short hex that lwk.Transaction will accept. The purchase flow only
+        # calls lwk.Transaction(...).txid() — mock that instead.
+        return "DEADBEEF" * 16
+
+    def test_happy_path(self, storage):
+        mgr = _manager(storage, raw_tx=self._raw_hex())
+        _seed_session(mgr, "me@example.com")
+
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "computed-txid"
+
+        with (
+            patch.object(
+                Jan3AccountsClient,
+                "create_ln_username_payment_request",
+                return_value=self.PR_RESPONSE,
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "submit_raw_tx",
+                return_value=self.SUBMIT_RESPONSE,
+            ) as mock_submit,
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            result = mgr.purchase_ln_username(
+                email="me@example.com",
+                ln_username="alicebob",
+                wallet_name="default",
+            )
+
+        assert result["payment_id"] == self.PR_RESPONSE["payment_id"]
+        assert result["status"] == "ACCEPTED"
+        assert result["txid"] == "computed-txid"
+        assert result["ln_username"] == "alicebob"
+        assert result["amount_sats"] == 1000
+        mock_submit.assert_called_once()
+        kwargs = mock_submit.call_args.kwargs
+        assert kwargs["payment_id"] == self.PR_RESPONSE["payment_id"]
+        assert kwargs["raw_tx"] == self._raw_hex()
+        # Wallet was asked to craft a tx for the exact amount/address.
+        mgr.wallet_manager.craft_raw_tx.assert_called_once_with(
+            wallet_name="default",
+            address=VAULT_ADDR,
+            amount=1000,
+            asset_id=LBTC_ASSET_ID,
+            password=None,
+        )
+
+    def test_requires_session(self, storage):
+        mgr = _manager(storage)
+        with pytest.raises(ValueError, match="No JAN3 session"):
+            mgr.purchase_ln_username(email="ghost@example.com", ln_username="alicebob")
+
+    def test_rejects_invalid_username_before_network(self, storage):
+        mgr = _manager(storage)
+        _seed_session(mgr, "me@example.com")
+        with patch.object(Jan3AccountsClient, "create_ln_username_payment_request") as mock_create:
+            with pytest.raises(ValueError, match="Invalid ln_username"):
+                mgr.purchase_ln_username(email="me@example.com", ln_username="bad..username")
+        mock_create.assert_not_called()
+
+    def test_refreshes_access_token_on_401(self, storage):
+        """First call gets 401 → refresh → second call succeeds."""
+        mgr = _manager(storage, raw_tx=self._raw_hex())
+        _seed_session(mgr, "me@example.com")
+
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "txid-after-refresh"
+
+        # Sequence: create_ln_username_payment_request succeeds on first try
+        # (no 401), then submit_raw_tx returns 401 once, then succeeds after
+        # refresh. (The 401 retry wraps each call independently.)
+        submit_responses = [
+            Jan3UnauthorizedError("expired"),
+            self.SUBMIT_RESPONSE,
+        ]
+
+        def submit_side_effect(*a, **k):
+            resp = submit_responses.pop(0)
+            if isinstance(resp, Exception):
+                raise resp
+            return resp
+
+        with (
+            patch.object(
+                Jan3AccountsClient,
+                "create_ln_username_payment_request",
+                return_value=self.PR_RESPONSE,
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "submit_raw_tx",
+                side_effect=submit_side_effect,
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "refresh_access_token",
+                return_value="new-access-token",
+            ) as mock_refresh,
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            result = mgr.purchase_ln_username(
+                email="me@example.com", ln_username="alicebob"
+            )
+
+        assert result["status"] == "ACCEPTED"
+        mock_refresh.assert_called_once_with("refresh-token-xyz")
+        # New token persisted on disk.
+        reloaded = mgr.load_session("me@example.com")
+        assert reloaded.access_token == "new-access-token"
+        assert reloaded.refreshed_at is not None
+
+    def test_refreshes_access_token_when_first_authed_call_401s(self, storage):
+        """The refresh-retry wrapper must kick in for the *first* authed
+        call too, not just submit. Earlier coverage only exercised the
+        second call — this fills the gap."""
+        mgr = _manager(storage, raw_tx=self._raw_hex())
+        _seed_session(mgr, "me@example.com")
+
+        create_responses = [
+            Jan3UnauthorizedError("expired"),
+            self.PR_RESPONSE,
+        ]
+
+        def create_side_effect(*a, **k):
+            resp = create_responses.pop(0)
+            if isinstance(resp, Exception):
+                raise resp
+            return resp
+
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "txid"
+
+        with (
+            patch.object(
+                Jan3AccountsClient,
+                "create_ln_username_payment_request",
+                side_effect=create_side_effect,
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "submit_raw_tx",
+                return_value=self.SUBMIT_RESPONSE,
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "refresh_access_token",
+                return_value="new-access-token",
+            ) as mock_refresh,
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            result = mgr.purchase_ln_username(
+                email="me@example.com", ln_username="alicebob"
+            )
+
+        assert result["status"] == "ACCEPTED"
+        mock_refresh.assert_called_once_with("refresh-token-xyz")
+        reloaded = mgr.load_session("me@example.com")
+        assert reloaded.access_token == "new-access-token"
+
+    def test_post_refresh_401_wipes_session(self, storage):
+        """Submit 401 → refresh OK → submit 401 again → session deleted.
+
+        Server-side revocation (account banned, key rotated, etc.) gives
+        us a successful refresh but the next authed call still 401s. The
+        local session is poisoned — wipe it so the user is forced to
+        re-login rather than retrying forever."""
+        mgr = _manager(storage, raw_tx=self._raw_hex())
+        _seed_session(mgr, "me@example.com")
+
+        with (
+            patch.object(
+                Jan3AccountsClient,
+                "create_ln_username_payment_request",
+                return_value=self.PR_RESPONSE,
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "submit_raw_tx",
+                side_effect=Jan3UnauthorizedError("server says no"),
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "refresh_access_token",
+                return_value="new-access-token",
+            ),
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=MagicMock()),
+        ):
+            with pytest.raises(Jan3UnauthorizedError):
+                mgr.purchase_ln_username(
+                    email="me@example.com", ln_username="alicebob"
+                )
+
+        assert mgr.load_session("me@example.com") is None
+
+    def test_double_401_wipes_session(self, storage):
+        """Submit 401 → refresh 401 → session deleted, error raised."""
+        mgr = _manager(storage, raw_tx=self._raw_hex())
+        _seed_session(mgr, "me@example.com")
+
+        with (
+            patch.object(
+                Jan3AccountsClient,
+                "create_ln_username_payment_request",
+                return_value=self.PR_RESPONSE,
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "submit_raw_tx",
+                side_effect=Jan3UnauthorizedError("expired"),
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "refresh_access_token",
+                side_effect=Jan3UnauthorizedError("refresh also expired"),
+            ),
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=MagicMock()),
+        ):
+            with pytest.raises(Jan3UnauthorizedError):
+                mgr.purchase_ln_username(email="me@example.com", ln_username="alicebob")
+
+        assert mgr.load_session("me@example.com") is None
+
+
+# ---------------------------------------------------------------------------
+# Refresh-token flow (issue #39): expired access token → refresh → retry
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshFlow:
+    """End-to-end verification of the access-token refresh contract.
+
+    Documents that the implementation:
+      1. Persists BOTH access_token and refresh_token after login.
+      2. Detects access-token expiry (HTTP 401) on any authed call.
+      3. Calls /api/v1/auth/refresh/ with the STORED refresh_token
+         (and no Authorization header — the bearer has just expired).
+      4. Persists the new access_token while preserving refresh_token.
+      5. Retries the original authed call with the new bearer.
+    """
+
+    @patch("urllib.request.urlopen")
+    def test_refresh_endpoint_wire_shape(self, mock_urlopen):
+        """The refresh call hits /api/v1/auth/refresh/ with ``{"refresh": …}``
+        and no Authorization header (the access token has just expired,
+        so presenting it would be useless or worse)."""
+        mock_urlopen.return_value = _mock_response({"access": "new-tok"})
+        client = Jan3AccountsClient(
+            base_url="https://test.aquabtc.com",
+            access_token="expired-tok",
+        )
+
+        assert client.refresh_access_token("the-refresh-token") == "new-tok"
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_method() == "POST"
+        assert req.full_url.endswith("/api/v1/auth/refresh/")
+        assert req.get_header("Authorization") is None
+        assert json.loads(req.data.decode()) == {"refresh": "the-refresh-token"}
+
+    @patch("urllib.request.urlopen")
+    def test_refresh_endpoint_missing_access_field_raises(self, mock_urlopen):
+        """A 200 OK with no ``access`` field is a server bug — surface it
+        as a clear RuntimeError rather than silently storing ``None``."""
+        mock_urlopen.return_value = _mock_response({})
+        client = Jan3AccountsClient(base_url="https://test.aquabtc.com")
+        with pytest.raises(RuntimeError, match="no access token"):
+            client.refresh_access_token("the-refresh-token")
+
+    def test_full_round_trip_on_access_token_expiry(self, storage):
+        """Login → persist BOTH tokens → 401 on authed call → refresh using
+        the stored refresh_token → persist new access_token (refresh_token
+        unchanged) → retry call uses the new bearer."""
+        mgr = _manager(storage, raw_tx="hex-tx")
+
+        # (1) Login persists access + refresh together on disk.
+        with patch.object(
+            Jan3AccountsClient,
+            "verify_otp",
+            return_value={
+                "access": "old-access",
+                "refresh": "the-refresh-token",
+            },
+        ):
+            mgr.complete_login(email="me@example.com", otp_code="123456")
+
+        before = mgr.load_session("me@example.com")
+        assert before.access_token == "old-access"
+        assert before.refresh_token == "the-refresh-token"
+        assert before.refreshed_at is None
+
+        # Capture the access_token each submit_raw_tx call sees so we can
+        # prove the retry used the NEW token (not the stale one).
+        tokens_seen: list[str] = []
+        submit_calls = {"n": 0}
+
+        def submit_side_effect(client_self, *args, **kwargs):
+            tokens_seen.append(client_self.access_token)
+            submit_calls["n"] += 1
+            if submit_calls["n"] == 1:
+                raise Jan3UnauthorizedError("token expired")
+            return TestPurchaseLnUsername.SUBMIT_RESPONSE
+
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "tx-after-refresh"
+
+        with (
+            patch.object(
+                Jan3AccountsClient,
+                "create_ln_username_payment_request",
+                return_value=TestPurchaseLnUsername.PR_RESPONSE,
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "submit_raw_tx",
+                autospec=True,
+                side_effect=submit_side_effect,
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "refresh_access_token",
+                return_value="new-access",
+            ) as mock_refresh,
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            result = mgr.purchase_ln_username(
+                email="me@example.com", ln_username="alicebob"
+            )
+
+        # (2/3) Refresh used the STORED refresh_token — not invented, not blank.
+        mock_refresh.assert_called_once_with("the-refresh-token")
+
+        # (5) First submit got the old token (and 401'd); the retry got the
+        # new token (and succeeded). Proves the retry rebuilt its client.
+        assert tokens_seen == ["old-access", "new-access"]
+        assert result["status"] == "ACCEPTED"
+
+        # (4) On-disk session after the refresh:
+        #   • access_token replaced with the new value
+        #   • refresh_token PRESERVED — the server's /auth/refresh/ contract
+        #     returns only {access}; we must not clobber refresh locally
+        #   • refreshed_at populated
+        after = mgr.load_session("me@example.com")
+        assert after.access_token == "new-access"
+        assert after.refresh_token == "the-refresh-token"
+        assert after.refreshed_at is not None
 
 
 # ---------------------------------------------------------------------------
@@ -464,3 +873,172 @@ class TestSessionManagement:
         path = mgr._session_path("me@example.com")
         path.write_text('{"email": "me@example.com"}')
         assert mgr.load_session("me@example.com") is None
+
+
+# ---------------------------------------------------------------------------
+# Purchase + LNURL resolution linkage
+# ---------------------------------------------------------------------------
+
+
+def _lnurl_response(data: dict, final_url: str | None = None) -> MagicMock:
+    """urlopen response mock for LNURL-leg patches.
+
+    Distinct from ``_mock_response`` above because ``aqua.lnurl._http_get_json``
+    calls ``resp.geturl()`` to enforce the post-redirect https guard.
+    """
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(data).encode()
+    resp.geturl.return_value = final_url or "https://example.com/x"
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def _payreq(
+    *,
+    callback: str = "https://test.aqua.net/lnurlp/cb",
+    min_msat: int = 1_000,
+    max_msat: int = 100_000_000_000,
+    metadata: str = '[["text/plain","pay alice"]]',
+) -> dict:
+    return {
+        "tag": "payRequest",
+        "callback": callback,
+        "minSendable": min_msat,
+        "maxSendable": max_msat,
+        "metadata": metadata,
+    }
+
+
+class TestPurchaseThenResolve:
+    """End-to-end (mocked) linkage: buy a JAN3 LN username and resolve the
+    resulting ``<username>@<jan3-domain>`` Lightning Address via aqua.lnurl.
+
+    Proves our code wires the two halves together — that the bare
+    ``ln_username`` returned by ``purchase_ln_username`` composes cleanly
+    into a ``.well-known/lnurlp/`` lookup that yields a payable BOLT11.
+    The real-backend version of this check lives in
+    ``tests/smoke/test_jan3_lightning.py``.
+    """
+
+    LN_USERNAME = "alicebob"
+    LN_DOMAIN = "test.aqua.net"
+    AMOUNT_SATS = 100
+    INVOICE = "lnbc1u1ptest_jan3_invoice"
+
+    PR_RESPONSE = {
+        "payment_id": "11111111-1111-1111-1111-111111111111",
+        "status": "PENDING",
+        "product_type": "LN_USERNAME_UPDATE",
+        "asset_ticker": "L-BTC",
+        "amount_base_units": 1000,
+        "address": VAULT_ADDR,
+        "expires_at": "2026-06-16T01:00:00+00:00",
+    }
+    SUBMIT_RESPONSE = {**PR_RESPONSE, "status": "ACCEPTED"}
+
+    def _purchase(self, mgr: Jan3AccountsManager) -> dict:
+        """Drive ``purchase_ln_username`` with all HTTP + signing mocked."""
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "computed-txid"
+        with (
+            patch.object(
+                Jan3AccountsClient,
+                "create_ln_username_payment_request",
+                return_value=self.PR_RESPONSE,
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "submit_raw_tx",
+                return_value=self.SUBMIT_RESPONSE,
+            ),
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            return mgr.purchase_ln_username(
+                email="me@example.com",
+                ln_username=self.LN_USERNAME,
+                wallet_name="default",
+            )
+
+    def test_purchase_then_resolve_returns_invoice(self, storage):
+        """Happy path: buy username → resolve <user>@<domain> → BOLT11."""
+        mgr = _manager(storage, raw_tx="DEADBEEF" * 16)
+        _seed_session(mgr, "me@example.com")
+
+        purchase = self._purchase(mgr)
+        assert purchase["ln_username"] == self.LN_USERNAME
+        address = f"{purchase['ln_username']}@{self.LN_DOMAIN}"
+
+        with (
+            patch("aqua.lnurl.urllib.request.urlopen") as mock_urlopen,
+            patch(
+                "aqua.lnurl.decode_bolt11_amount_sats",
+                return_value=self.AMOUNT_SATS,
+            ),
+        ):
+            mock_urlopen.side_effect = [
+                _lnurl_response(
+                    _payreq(),
+                    final_url=(
+                        f"https://{self.LN_DOMAIN}/.well-known/lnurlp/"
+                        f"{self.LN_USERNAME}"
+                    ),
+                ),
+                _lnurl_response({"pr": self.INVOICE}),
+            ]
+            invoice = resolve_lightning_address(address, self.AMOUNT_SATS)
+
+        assert invoice == self.INVOICE
+        first_req = mock_urlopen.call_args_list[0].args[0]
+        assert first_req.full_url == (
+            f"https://{self.LN_DOMAIN}/.well-known/lnurlp/{self.LN_USERNAME}"
+        )
+        second_req = mock_urlopen.call_args_list[1].args[0]
+        assert f"amount={self.AMOUNT_SATS * 1000}" in second_req.full_url
+
+    def test_resolve_amount_outside_bounds_raises(self, storage):
+        """Purchase succeeds, but payRequest declares bounds that exclude
+        the requested amount — surface as ValueError from aqua.lnurl."""
+        mgr = _manager(storage, raw_tx="DEADBEEF" * 16)
+        _seed_session(mgr, "me@example.com")
+
+        purchase = self._purchase(mgr)
+        address = f"{purchase['ln_username']}@{self.LN_DOMAIN}"
+
+        with patch("aqua.lnurl.urllib.request.urlopen") as mock_urlopen:
+            # min 1000 sats, max 10000 sats; we'll request 100 sats.
+            mock_urlopen.return_value = _lnurl_response(
+                _payreq(min_msat=1_000_000, max_msat=10_000_000),
+                final_url=(
+                    f"https://{self.LN_DOMAIN}/.well-known/lnurlp/"
+                    f"{self.LN_USERNAME}"
+                ),
+            )
+            with pytest.raises(ValueError, match="outside Lightning Address bounds"):
+                resolve_lightning_address(address, self.AMOUNT_SATS)
+
+    def test_resolve_amount_mismatched_invoice_raises(self, storage):
+        """Purchase succeeds, callback returns a BOLT11 encoding a different
+        amount than we asked for — surface as ValueError from aqua.lnurl."""
+        mgr = _manager(storage, raw_tx="DEADBEEF" * 16)
+        _seed_session(mgr, "me@example.com")
+
+        purchase = self._purchase(mgr)
+        address = f"{purchase['ln_username']}@{self.LN_DOMAIN}"
+
+        with (
+            patch("aqua.lnurl.urllib.request.urlopen") as mock_urlopen,
+            patch("aqua.lnurl.decode_bolt11_amount_sats", return_value=50),
+        ):
+            mock_urlopen.side_effect = [
+                _lnurl_response(
+                    _payreq(),
+                    final_url=(
+                        f"https://{self.LN_DOMAIN}/.well-known/lnurlp/"
+                        f"{self.LN_USERNAME}"
+                    ),
+                ),
+                _lnurl_response({"pr": self.INVOICE}),
+            ]
+            with pytest.raises(ValueError, match="does not match"):
+                resolve_lightning_address(address, self.AMOUNT_SATS)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1225,6 +1225,7 @@ class TestToolRegistry:
             "jan3_session_info",
             "jan3_list_sessions",
             "jan3_logout",
+            "jan3_purchase_ln_username",
         }
         assert set(TOOLS.keys()) == expected
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -49,11 +49,13 @@ def isolated_manager():
         tools_module._btc_manager = None  # so get_btc_manager() uses same storage
         tools_module._lightning_manager = None
         tools_module._pix_manager = None
+        tools_module._jan3_manager = None
         yield manager
         tools_module._manager = None
         tools_module._btc_manager = None
         tools_module._lightning_manager = None
         tools_module._pix_manager = None
+        tools_module._jan3_manager = None
 
 
 # ---------------------------------------------------------------------------
@@ -924,6 +926,172 @@ class TestSweep:
 
 
 # ---------------------------------------------------------------------------
+# craft_raw_tx (build-without-broadcast)  # Significance: 5 (Essential)
+# ---------------------------------------------------------------------------
+
+
+class TestCraftRawTx:
+    """`craft_raw_tx` returns a hex tx and never broadcasts."""
+
+    DEST_BLINDED = (
+        "lq1qqvxk052kf3qtkxmrakx50a9gc3smqad2ync54hzntjt980kfej9kkfe"
+        "0247rp5h4yzmdftsahhw64uy8pzfe7cpg4fgykm7cv"
+    )
+
+    def _setup(self, manager, wallet_name):
+        builder = MagicMock()
+        pset = MagicMock()
+        detailed_pset = MagicMock()
+        signed = MagicMock()
+        finalized = MagicMock()
+        finalized.__str__ = lambda self: "0200000001deadbeef00"
+        wollet = MagicMock()
+        net = MagicMock()
+
+        net.tx_builder.return_value = builder
+        builder.finish.return_value = pset
+        wollet.add_details.return_value = detailed_pset
+        manager._signers[wallet_name].sign = MagicMock(return_value=signed)
+        signed.finalize.return_value = finalized
+        manager._wollets[wallet_name] = wollet
+        return builder, wollet, net, finalized
+
+    def test_lbtc_blinded_uses_add_lbtc_recipient(self, isolated_manager):
+        """Confidential dest + L-BTC → add_lbtc_recipient, NOT add_recipient."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="craft_lbtc")
+        builder, wollet, net, _ = self._setup(isolated_manager, "craft_lbtc")
+
+        with (
+            patch.object(isolated_manager, "sync_wallet"),
+            patch.object(isolated_manager, "_get_network", return_value=net),
+        ):
+            raw = isolated_manager.craft_raw_tx(
+                wallet_name="craft_lbtc",
+                address=self.DEST_BLINDED,
+                amount=100,
+            )
+
+        assert raw == "0200000001deadbeef00"
+        builder.add_lbtc_recipient.assert_called_once()
+        builder.add_recipient.assert_not_called()
+        builder.add_explicit_recipient.assert_not_called()
+        # The PSET is passed through wollet.add_details before signing.
+        wollet.add_details.assert_called_once()
+
+    def test_blinded_non_lbtc_uses_add_recipient(self, isolated_manager):
+        """Confidential dest + non-policy asset → add_recipient(amount, asset)."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="craft_asset")
+        builder, wollet, net, _ = self._setup(isolated_manager, "craft_asset")
+        other_asset = "abcdef" * 10 + "abcd"  # arbitrary 64-hex-char id
+
+        with (
+            patch.object(isolated_manager, "sync_wallet"),
+            patch.object(isolated_manager, "_get_network", return_value=net),
+        ):
+            isolated_manager.craft_raw_tx(
+                wallet_name="craft_asset",
+                address=self.DEST_BLINDED,
+                amount=42,
+                asset_id=other_asset,
+            )
+
+        builder.add_recipient.assert_called_once()
+        args = builder.add_recipient.call_args[0]
+        assert args[1] == 42
+        assert args[2] == other_asset
+        builder.add_lbtc_recipient.assert_not_called()
+        builder.add_explicit_recipient.assert_not_called()
+
+    def test_unblinded_uses_add_explicit_recipient(self, isolated_manager):
+        """Unblinded (explicit) dest → add_explicit_recipient with asset id resolved."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="craft_expl")
+        builder, wollet, net, _ = self._setup(isolated_manager, "craft_expl")
+
+        fake_addr = MagicMock()
+        fake_addr.is_blinded.return_value = False
+        canned_policy = "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d"
+
+        with (
+            patch.object(isolated_manager, "sync_wallet"),
+            patch.object(isolated_manager, "_get_network", return_value=net),
+            patch.object(isolated_manager, "_get_policy_asset", return_value=canned_policy),
+            patch("aqua.wallet.lwk.Address", return_value=fake_addr),
+        ):
+            isolated_manager.craft_raw_tx(
+                wallet_name="craft_expl",
+                address="anything-unblinded",
+                amount=7,
+            )
+
+        builder.add_explicit_recipient.assert_called_once()
+        args = builder.add_explicit_recipient.call_args[0]
+        assert args[0] is fake_addr
+        assert args[1] == 7
+        # The L-BTC policy asset id was resolved automatically for unblinded.
+        assert args[2] == canned_policy
+        builder.add_lbtc_recipient.assert_not_called()
+        builder.add_recipient.assert_not_called()
+
+    def test_does_not_broadcast(self, isolated_manager):
+        """`craft_raw_tx` must not call client.broadcast."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="craft_nobroadcast")
+        _, _, net, _ = self._setup(isolated_manager, "craft_nobroadcast")
+        mock_client = MagicMock()
+
+        with (
+            patch.object(isolated_manager, "sync_wallet"),
+            patch.object(isolated_manager, "_get_network", return_value=net),
+            patch.object(isolated_manager, "_get_client", return_value=mock_client),
+        ):
+            isolated_manager.craft_raw_tx(
+                wallet_name="craft_nobroadcast",
+                address=self.DEST_BLINDED,
+                amount=100,
+            )
+
+        mock_client.broadcast.assert_not_called()
+
+    def test_watch_only_rejects(self, isolated_manager):
+        net = lwk.Network.mainnet()
+        signer = lwk.Signer(lwk.Mnemonic(TEST_MNEMONIC), net)
+        desc = str(signer.wpkh_slip77_descriptor())
+        lw_import_descriptor(descriptor=desc, wallet_name="wo_craft")
+
+        with pytest.raises(ValueError, match="watch-only"):
+            isolated_manager.craft_raw_tx(
+                wallet_name="wo_craft",
+                address=self.DEST_BLINDED,
+                amount=100,
+            )
+
+    def test_zero_amount_rejects(self, isolated_manager):
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="craft_zero")
+        with pytest.raises(ValueError, match="Amount must be positive"):
+            isolated_manager.craft_raw_tx(
+                wallet_name="craft_zero",
+                address=self.DEST_BLINDED,
+                amount=0,
+            )
+
+    def test_negative_amount_rejects(self, isolated_manager):
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="craft_neg")
+        with pytest.raises(ValueError, match="Amount must be positive"):
+            isolated_manager.craft_raw_tx(
+                wallet_name="craft_neg",
+                address=self.DEST_BLINDED,
+                amount=-1,
+            )
+
+    def test_missing_wallet_raises(self, isolated_manager):
+        with pytest.raises(ValueError, match="not found"):
+            isolated_manager.craft_raw_tx(
+                wallet_name="ghost_craft",
+                address=self.DEST_BLINDED,
+                amount=1,
+            )
+
+
+# ---------------------------------------------------------------------------
 # WalletManager internal logic  # Significance: 4 (Important)
 # ---------------------------------------------------------------------------
 
@@ -1052,6 +1220,11 @@ class TestToolRegistry:
             "wapupay_transaction",
             "wapupay_spending_limit",
             "wapupay_provision_account",
+            "jan3_login_start",
+            "jan3_login_complete",
+            "jan3_session_info",
+            "jan3_list_sessions",
+            "jan3_logout",
         }
         assert set(TOOLS.keys()) == expected
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -276,6 +276,120 @@ class TestAddress:
         with pytest.raises(ValueError, match="not found"):
             lw_address(wallet_name="nope")
 
+    def test_no_arg_advances_counter_so_indices_are_distinct(self, isolated_manager):
+        """Consecutive no-arg ``get_address`` calls hand back distinct indices.
+
+        Regression for the LN-address-vs-direct-receive collision: lwk's
+        "next-unused" tip only advances after on-chain observation, so before
+        the counter rework every call returned the same index until something
+        settled on chain.
+        """
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="advance_test")
+        first = isolated_manager.get_address("advance_test")
+        second = isolated_manager.get_address("advance_test")
+        third = isolated_manager.get_address("advance_test")
+        assert {first.index, second.index, third.index} == {first.index, first.index + 1, first.index + 2}
+        assert len({first.address, second.address, third.address}) == 3
+
+    def test_counter_persists_across_wallet_manager_instances(self, isolated_manager):
+        """Reopening the wallet picks up where the counter left off."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="persist_test")
+        a = isolated_manager.get_address("persist_test")
+        b = isolated_manager.get_address("persist_test")
+        # Simulate a fresh process by instantiating a new manager on the same storage.
+        fresh = WalletManager(storage=isolated_manager.storage)
+        c = fresh.get_address("persist_test")
+        assert c.index == b.index + 1
+        assert c.address not in {a.address, b.address}
+
+    def test_explicit_index_does_not_advance_counter(self, isolated_manager):
+        """Asking for index=N is a query, not a handout — counter stays put."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="explicit_test")
+        before = isolated_manager.storage.load_wallet("explicit_test").next_address_index
+        isolated_manager.get_address("explicit_test", index=42)
+        isolated_manager.get_address("explicit_test", index=43)
+        after = isolated_manager.storage.load_wallet("explicit_test").next_address_index
+        assert before == after
+
+    def test_counter_promoted_when_lwk_tip_is_higher(self, isolated_manager):
+        """If lwk has observed on-chain activity past our counter, jump to its tip."""
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="tip_test")
+        record = isolated_manager.storage.load_wallet("tip_test")
+        # Stash an artificially-stale counter; nothing else has touched this wallet so
+        # lwk's tip is whatever lwk says (typically 0 for a fresh wallet) — but the
+        # contract we care about is: handed-out index is ``>= persisted counter``,
+        # and the counter advances past it.
+        record.next_address_index = 100
+        isolated_manager.storage.save_wallet(record)
+        out = isolated_manager.get_address("tip_test")
+        assert out.index >= 100
+        after = isolated_manager.storage.load_wallet("tip_test").next_address_index
+        assert after == out.index + 1
+
+    def test_legacy_ln_addr_next_index_key_is_migrated(self, isolated_manager):
+        """Wallets persisted before the rename keep their burned-index history."""
+        from aqua.storage import WalletData
+
+        raw = {
+            "name": "legacy",
+            "network": "mainnet",
+            "descriptor": "ct(slip77(deadbeef),elwpkh([deadbeef/84'/1776'/0']xpub.../<0;1>/*))#0",
+            "btc_descriptor": None,
+            "btc_change_descriptor": None,
+            "encrypted_mnemonic": None,
+            "watch_only": True,
+            "created_at": "2026-06-26T00:00:00+00:00",
+            "ln_addr_next_index": 7,
+        }
+        wallet = WalletData.from_dict(raw)
+        assert wallet.next_address_index == 7
+        assert not hasattr(wallet, "ln_addr_next_index")
+
+    def test_aqua_register_ln_addresses_does_not_collide_with_lw_address(self, isolated_manager):
+        """Cross-flow collision regression: after LN registration burns indices,
+        ``lw_address`` MUST return an index strictly past those — the bug that
+        triggered the receive-address rework."""
+        import aqua.tools as tools_module
+        from aqua.ankara import JAN3AccountManager, JAN3Session
+
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="default")
+
+        # Fake AQUA client so register_ln_addresses doesn't touch the network.
+        fake_client = MagicMock()
+        fake_client.get_user.return_value = {
+            "ln_username": "alice",
+            "ln_address_toggled": True,
+            "fingerprint": isolated_manager.fingerprint("default"),
+            "new_addresses_needed": 3,
+        }
+        fake_client.register_addresses.return_value = {"addresses": []}
+
+        mgr = JAN3AccountManager(storage=isolated_manager.storage)
+        mgr._client = fake_client
+        isolated_manager.storage.save_jan3_session(
+            JAN3Session(email="u@e.com", access="ACC", refresh="REF", created_at="t0")
+        )
+        tools_module._jan3_manager = mgr
+
+        from aqua.tools import aqua_register_ln_addresses
+
+        registered = aqua_register_ln_addresses(wallet_name="default", count=3)
+        assert registered["requested_count"] == 3
+        # The addresses actually sent to the server (via fake_client).
+        sent_addresses = fake_client.register_addresses.call_args[0][2]
+        sent_indices = {
+            isolated_manager.get_address("default", index=i).index: addr
+            for i, addr in enumerate(sent_addresses)
+        }
+        # `lw_address` AFTER registration must return an index past the last
+        # one we burned. Pre-rework this returned the same lwk tip as the first
+        # registered address.
+        next_receive = lw_address(wallet_name="default")
+        burned_max = isolated_manager.storage.load_wallet("default").next_address_index - 1
+        assert next_receive["index"] > burned_max - 3  # past all 3 burned
+        # And every sent address differs from the new receive address.
+        assert next_receive["address"] not in sent_addresses
+
 
 # ---------------------------------------------------------------------------
 # Deposit-address QR codes (issue #69)  # Significance: 4
@@ -1210,6 +1324,11 @@ class TestToolRegistry:
             "aqua_verify",
             "aqua_logout",
             "aqua_session",
+            "aqua_get_user",
+            "aqua_ln_address_toggle",
+            "aqua_ln_username_check_available",
+            "aqua_register_ln_addresses",
+            "aqua_ensure_ln_pool",
             "wapupay_exchange_rates",
             "wapupay_quote",
             "wapupay_create_order",


### PR DESCRIPTION
I made a mistake and thought this was part of the other ticket so I opened this PR.

## Summary
Two commits on top of #101:
1. **`jan3_purchase_ln_username` MCP tool + CLI** — lifted from #101's original commit (which bundled it with the captchaless login). Validator (`_validate_ln_username`, `LN_USERNAME_REGEX`), payment-request client method (`create_ln_username_payment_request`), purchase manager method (`Jan3AccountsManager.purchase_ln_username`), refresh-on-401 retry plumbing, and accompanying tests.
2. **AQUA-account LN-address pool management** — extends `src/aqua/ankara.py` with the LN-pool wiring and adds the matching MCP tools (`aqua_register_ln_addresses`, `aqua_ensure_ln_pool`, `aqua_ln_address_toggle`, `aqua_ln_username_check_available`, `aqua_get_user`), CLI surface, storage records, and tests (`tests/test_ankara.py`, `tests/test_tools.py`).

## Stacked PR
This branch is stacked on `39-jan3-accounts-ln` (PR #101).
- Review **#101 first** (captchaless login), then this PR.
- After #101 merges to `develop`, this PR's base will be re-targeted to `develop`.

Closes #108.

## Test plan
- [ ] `uv run python -m pytest tests/test_jan3_accounts.py tests/test_ankara.py tests/test_tools.py`
- [ ] `uv run python -m pytest tests/` (full suite)
- [ ] Smoke: purchase an LN username + register an LN-address pool against staging Ankara via the new MCP tools.
