### PR TITLE
#108 Feature: Implement Lightning Address

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,27 @@ which now builds a `Jan3AccountsManager`) and delegates provisioning to it.
    calls (those need the API key, not a login); `jan3_logout` forgets a
     session but does **not** delete the provisioned API key.
 
+- **Lightning Address (LN-address delivery)** — also on `Jan3AccountsManager`
+  (per-email JWT, either login flow). A user's Lightning Address is
+  `ln_username@<domain>`; the backend returns the full address in the
+  `ln_username` field — surface it verbatim, never append a domain. Four tools:
+  - `jan3_purchase_ln_username <email> <ln_username>` — buys/updates the username
+    on-chain: creates an `LN_USERNAME_UPDATE` payment request and funds it with a
+    signed L-BTC tx (`wallet_manager.craft_raw_tx` → `submit_raw_tx`). Check first
+    with `jan3_ln_username_check_available`.
+  - `jan3_ln_address_toggle <email> --enable/--disable` — opts the account in/out
+    of LN-address delivery. **On enable it immediately populates the pool** of
+    unused Liquid receive addresses (best-effort, reported under
+    `ln_address_pool`); received BTC lands on those stored addresses.
+  - `jan3_get_user <email>` — account profile; when LN-address is active it
+    **auto-tops-up the pool** (best-effort, never fails the read).
+  - `register_ln_addresses` / `ensure_ln_pool` are **internal manager methods,
+    NOT MCP tools** — the pool self-heals via toggle-on + `jan3_get_user`. They
+    rely on `WalletManager.reserve_addresses` (batched minting) and
+    `WalletManager.fingerprint` (account↔wallet binding); the no-arg
+    `get_address` advances a persisted `WalletData.next_address_index` counter so
+    off-chain handouts never reuse an index.
+
 ## WapuPay (Argentine direct-fiat)
 
 `wapupay.py` lets a user pay an Argentine bank account in **ARS**, funded with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,15 +155,15 @@ which now builds a `Jan3AccountsManager`) and delegates provisioning to it.
   - `jan3_purchase_ln_username <email> <ln_username>` — buys/updates the username
     on-chain: creates an `LN_USERNAME_UPDATE` payment request and funds it with a
     signed L-BTC tx (`wallet_manager.craft_raw_tx` → `submit_raw_tx`). Check first
-    with `jan3_ln_username_check_available`.
-  - `jan3_ln_address_toggle <email> --enable/--disable` — opts the account in/out
+    with `jan3_ln_check_username`.
+  - `jan3_enable_lightning_address <email> --enable/--disable` — opts the account in/out
     of LN-address delivery. **On enable it immediately populates the pool** of
     unused Liquid receive addresses (best-effort, reported under
     `ln_address_pool`); received BTC lands on those stored addresses.
-  - `jan3_get_user <email>` — account profile; when LN-address is active it
+  - `jan3_user_info <email>` — account profile; when LN-address is active it
     **auto-tops-up the pool** (best-effort, never fails the read).
   - `register_ln_addresses` / `ensure_ln_pool` are **internal manager methods,
-    NOT MCP tools** — the pool self-heals via toggle-on + `jan3_get_user`. They
+    NOT MCP tools** — the pool self-heals via toggle-on + `jan3_user_info`. They
     rely on `WalletManager.reserve_addresses` (batched minting) and
     `WalletManager.fingerprint` (account↔wallet binding); the no-arg
     `get_address` advances a persisted `WalletData.next_address_index` counter so

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,14 @@ which now builds a `Jan3AccountsManager`) and delegates provisioning to it.
     `WalletManager.fingerprint` (account↔wallet binding); the no-arg
     `get_address` advances a persisted `WalletData.next_address_index` counter so
     off-chain handouts never reuse an index.
+  - `next_address_index` caveats: the counter lives **only in the local wallet
+    JSON**. A seed reimport (or deleted `~/.aqua`) resets it to 0 while the
+    server still delivers to the previously registered pool; the first
+    successful pool registration repairs it (`ensure_counter_covers` matches
+    the server's unused pool against derivations and bumps the counter), but
+    until then no-arg `get_address` can re-hand pool indices. **Downgrade
+    break**: releases ≤ v0.4.2 construct `WalletData` strictly and crash on
+    wallet files containing this key — call it out in release notes.
 
 ## WapuPay (Argentine direct-fiat)
 

--- a/src/aqua/cli/jan3.py
+++ b/src/aqua/cli/jan3.py
@@ -148,26 +148,14 @@ def logout(ctx, email):
 @jan3.command("user-info")
 @click.option("--email", required=True, help="JAN3 account email.")
 @click.option("--wallet-name", default="default", show_default=True)
-@click.option(
-    "--password-stdin", "password_stdin", is_flag=True, default=False, help=_PASSWORD_HELP
-)
 @click.pass_obj
-def user_info(ctx, email, wallet_name, password_stdin):
+def user_info(ctx, email, wallet_name):
     """Show the AQUA account profile + Lightning Address status.
 
     When LN-address is active this also tops up the Liquid address pool
     (best-effort, reported under `ln_address_pool`).
     """
-    password = resolve_secret(
-        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
-    )
-    run_tool(
-        ctx,
-        lambda: handle_password_retry(
-            jan3_user_info,
-            {"email": email, "wallet_name": wallet_name, "password": password},
-        ),
-    )
+    run_tool(ctx, lambda: jan3_user_info(email=email, wallet_name=wallet_name))
 
 
 @jan3.command("enable-lightning-address")
@@ -177,29 +165,17 @@ def user_info(ctx, email, wallet_name, password_stdin):
     help="Enable or disable the Lightning Address.",
 )
 @click.option("--wallet-name", default="default", show_default=True)
-@click.option(
-    "--password-stdin", "password_stdin", is_flag=True, default=False, help=_PASSWORD_HELP
-)
 @click.pass_obj
-def enable_lightning_address(ctx, email, enabled, wallet_name, password_stdin):
+def enable_lightning_address(ctx, email, enabled, wallet_name):
     """Enable/disable the Lightning Address.
 
     Enabling populates a batch of Liquid receive addresses so AQUA can deliver
     inbound Lightning payments to those addresses.
     """
-    password = resolve_secret(
-        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
-    )
     run_tool(
         ctx,
-        lambda: handle_password_retry(
-            jan3_enable_lightning_address,
-            {
-                "email": email,
-                "enabled": enabled,
-                "wallet_name": wallet_name,
-                "password": password,
-            },
+        lambda: jan3_enable_lightning_address(
+            email=email, enabled=enabled, wallet_name=wallet_name
         ),
     )
 

--- a/src/aqua/cli/jan3.py
+++ b/src/aqua/cli/jan3.py
@@ -25,6 +25,7 @@ from ..tools import (
     jan3_login_start,
     jan3_logout,
     jan3_purchase_ln_username,
+    jan3_rebind_wallet,
     jan3_session_info,
     jan3_user_info,
     jan3_verify,
@@ -199,6 +200,50 @@ def enable_lightning_address(ctx, email, enabled, wallet_name, password_stdin):
                 "wallet_name": wallet_name,
                 "password": password,
             },
+        ),
+    )
+
+
+@jan3.command("rebind-wallet")
+@click.option("--email", required=True, help="Your JAN3 account email (account/session).")
+@click.option(
+    "--wallet-name", default="default", show_default=True,
+    help="Local Liquid wallet to bind Lightning-Address delivery to.",
+)
+@click.option(
+    "--yes", "assume_yes", is_flag=True, default=False,
+    help="Skip the confirmation prompt (overwrites existing binding).",
+)
+@click.pass_obj
+def rebind_wallet(ctx, email, wallet_name, assume_yes):
+    """Re-bind your Lightning Address to a different wallet (DESTRUCTIVE).
+
+    Moves inbound Lightning delivery to --wallet-name; the previously-bound
+    wallet stops receiving. Previews the change first (showing your Lightning
+    Address and the current→new fingerprint), then asks for confirmation unless
+    --yes is given. If the account is already bound to this wallet it is a no-op.
+    No wallet password is needed — re-binding never signs.
+    """
+    try:
+        preview = jan3_rebind_wallet(
+            email=email, wallet_name=wallet_name, confirm=False
+        )
+    except Exception as e:
+        raise click.UsageError(f"Could not read account/wallet state: {e}") from e
+
+    # No-op (already bound to this wallet): nothing to confirm — show the result.
+    if not preview.get("requires_confirmation"):
+        run_tool(ctx, lambda: preview)
+        return
+
+    if not assume_yes:
+        click.echo(preview.get("warning", ""), err=True)
+        click.confirm("Continue?", abort=True, err=True)
+
+    run_tool(
+        ctx,
+        lambda: jan3_rebind_wallet(
+            email=email, wallet_name=wallet_name, confirm=True
         ),
     )
 

--- a/src/aqua/cli/jan3.py
+++ b/src/aqua/cli/jan3.py
@@ -242,13 +242,45 @@ def ln_check_username(ctx, email, ln_username):
     help="Desired username (local part, before the @domain).",
 )
 @click.option("--wallet-name", default="default", show_default=True)
-@click.option("--asset", default="L-BTC", show_default=True, help="Funding asset ticker.")
+@click.option(
+    "--asset", default="L-BTC", show_default=True,
+    type=click.Choice(["L-BTC", "USDt"], case_sensitive=False),
+    help="Funding asset — L-BTC or USDt.",
+)
+@click.option(
+    "--yes", "assume_yes", is_flag=True, default=False,
+    help="Skip the price confirmation prompt.",
+)
 @click.option(
     "--password-stdin", "password_stdin", is_flag=True, default=False, help=_PASSWORD_HELP
 )
 @click.pass_obj
-def purchase_ln_username(ctx, email, ln_username, wallet_name, asset, password_stdin):
-    """Buy / update the Lightning username with an on-chain L-BTC payment."""
+def purchase_ln_username(ctx, email, ln_username, wallet_name, asset, assume_yes, password_stdin):
+    """Buy / update the Lightning username with an on-chain payment (L-BTC or USDt).
+
+    Quotes the price first and asks for confirmation unless --yes is given.
+    """
+    # 1) Non-spending price quote (no signing, no password).
+    try:
+        quote = jan3_purchase_ln_username(
+            email=email,
+            ln_username=ln_username,
+            wallet_name=wallet_name,
+            asset=asset,
+            confirm=False,
+        )
+    except Exception as e:
+        raise click.UsageError(f"Could not fetch the price quote: {e}") from e
+
+    if not assume_yes:
+        click.echo(
+            f"Lightning Address {ln_username!r} costs "
+            f"{quote.get('display_amount')} (quote expires {quote.get('expires_at')}).",
+            err=True,
+        )
+        click.confirm("Proceed with the payment?", abort=True, err=True)
+
+    # 2) Confirmed — resolve the password and fund the purchase.
     password = resolve_secret(
         "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
     )
@@ -262,6 +294,7 @@ def purchase_ln_username(ctx, email, ln_username, wallet_name, asset, password_s
                 "wallet_name": wallet_name,
                 "asset": asset,
                 "password": password,
+                "confirm": True,
             },
         ),
     )

--- a/src/aqua/cli/jan3.py
+++ b/src/aqua/cli/jan3.py
@@ -258,27 +258,31 @@ def ln_check_username(ctx, email, ln_username):
 def purchase_ln_username(ctx, email, ln_username, wallet_name, asset, assume_yes, password_stdin):
     """Buy / update the Lightning username with an on-chain payment (L-BTC or USDt).
 
-    Quotes the price first and asks for confirmation unless --yes is given.
+    Quotes the price and asks for confirmation; the payment then funds that
+    exact quoted order (aborting if it expired). --yes skips the quote and
+    accepts the current price.
     """
-    # 1) Non-spending price quote (no signing, no password).
-    try:
-        quote = jan3_purchase_ln_username(
-            email=email,
-            ln_username=ln_username,
-            wallet_name=wallet_name,
-            asset=asset,
-            confirm=False,
-        )
-    except Exception as e:
-        raise click.UsageError(f"Could not fetch the price quote: {e}") from e
-
+    expected_amount_base_units = None
     if not assume_yes:
+        # 1) Non-spending price quote — the server locks the price on this order.
+        try:
+            quote = jan3_purchase_ln_username(
+                email=email,
+                ln_username=ln_username,
+                wallet_name=wallet_name,
+                asset=asset,
+                confirm=False,
+            )
+        except Exception as e:
+            raise click.UsageError(f"Could not fetch the price quote: {e}") from e
+
         click.echo(
             f"Lightning Address {ln_username!r} costs "
             f"{quote.get('display_amount')} (quote expires {quote.get('expires_at')}).",
             err=True,
         )
         click.confirm("Proceed with the payment?", abort=True, err=True)
+        expected_amount_base_units = quote.get("amount_base_units")
 
     # 2) Confirmed — resolve the password and fund the purchase.
     password = resolve_secret(
@@ -295,6 +299,7 @@ def purchase_ln_username(ctx, email, ln_username, wallet_name, asset, assume_yes
                 "asset": asset,
                 "password": password,
                 "confirm": True,
+                "expected_amount_base_units": expected_amount_base_units,
             },
         ),
     )

--- a/src/aqua/cli/jan3.py
+++ b/src/aqua/cli/jan3.py
@@ -17,16 +17,16 @@ import logging
 import click
 
 from ..tools import (
-    jan3_get_user,
+    jan3_enable_lightning_address,
     jan3_list_sessions,
-    jan3_ln_address_toggle,
-    jan3_ln_username_check_available,
+    jan3_ln_check_username,
     jan3_login,
     jan3_login_complete,
     jan3_login_start,
     jan3_logout,
     jan3_purchase_ln_username,
     jan3_session_info,
+    jan3_user_info,
     jan3_verify,
 )
 from .output import run_tool
@@ -144,14 +144,14 @@ def logout(ctx, email):
     run_tool(ctx, lambda: jan3_logout(email))
 
 
-@jan3.command("get-user")
+@jan3.command("user-info")
 @click.option("--email", required=True, help="JAN3 account email.")
 @click.option("--wallet-name", default="default", show_default=True)
 @click.option(
     "--password-stdin", "password_stdin", is_flag=True, default=False, help=_PASSWORD_HELP
 )
 @click.pass_obj
-def get_user(ctx, email, wallet_name, password_stdin):
+def user_info(ctx, email, wallet_name, password_stdin):
     """Show the AQUA account profile + Lightning Address status.
 
     When LN-address is active this also tops up the Liquid address pool
@@ -163,13 +163,13 @@ def get_user(ctx, email, wallet_name, password_stdin):
     run_tool(
         ctx,
         lambda: handle_password_retry(
-            jan3_get_user,
+            jan3_user_info,
             {"email": email, "wallet_name": wallet_name, "password": password},
         ),
     )
 
 
-@jan3.command("ln-address-toggle")
+@jan3.command("enable-lightning-address")
 @click.option("--email", required=True)
 @click.option(
     "--enable/--disable", "enabled", required=True,
@@ -180,7 +180,7 @@ def get_user(ctx, email, wallet_name, password_stdin):
     "--password-stdin", "password_stdin", is_flag=True, default=False, help=_PASSWORD_HELP
 )
 @click.pass_obj
-def ln_address_toggle(ctx, email, enabled, wallet_name, password_stdin):
+def enable_lightning_address(ctx, email, enabled, wallet_name, password_stdin):
     """Enable/disable the Lightning Address.
 
     Enabling populates a batch of Liquid receive addresses so AQUA can deliver
@@ -192,7 +192,7 @@ def ln_address_toggle(ctx, email, enabled, wallet_name, password_stdin):
     run_tool(
         ctx,
         lambda: handle_password_retry(
-            jan3_ln_address_toggle,
+            jan3_enable_lightning_address,
             {
                 "email": email,
                 "enabled": enabled,
@@ -203,17 +203,17 @@ def ln_address_toggle(ctx, email, enabled, wallet_name, password_stdin):
     )
 
 
-@jan3.command("ln-username-check")
+@jan3.command("ln-check-username")
 @click.option("--email", required=True)
 @click.option(
     "--ln-username", required=True,
     help="Desired username (local part, before the @domain).",
 )
 @click.pass_obj
-def ln_username_check(ctx, email, ln_username):
+def ln_check_username(ctx, email, ln_username):
     """Check whether a Lightning username is available before purchasing."""
     run_tool(
-        ctx, lambda: jan3_ln_username_check_available(email=email, ln_username=ln_username)
+        ctx, lambda: jan3_ln_check_username(email=email, ln_username=ln_username)
     )
 
 

--- a/src/aqua/cli/jan3.py
+++ b/src/aqua/cli/jan3.py
@@ -17,11 +17,15 @@ import logging
 import click
 
 from ..tools import (
+    jan3_get_user,
     jan3_list_sessions,
+    jan3_ln_address_toggle,
+    jan3_ln_username_check_available,
     jan3_login,
     jan3_login_complete,
     jan3_login_start,
     jan3_logout,
+    jan3_purchase_ln_username,
     jan3_session_info,
     jan3_verify,
 )
@@ -138,3 +142,108 @@ def list_sessions(ctx):
 def logout(ctx, email):
     """Delete a persisted JAN3 session."""
     run_tool(ctx, lambda: jan3_logout(email))
+
+
+@jan3.command("get-user")
+@click.option("--email", required=True, help="JAN3 account email.")
+@click.option("--wallet-name", default="default", show_default=True)
+@click.option(
+    "--password-stdin", "password_stdin", is_flag=True, default=False, help=_PASSWORD_HELP
+)
+@click.pass_obj
+def get_user(ctx, email, wallet_name, password_stdin):
+    """Show the AQUA account profile + Lightning Address status.
+
+    When LN-address is active this also tops up the Liquid address pool
+    (best-effort, reported under `ln_address_pool`).
+    """
+    password = resolve_secret(
+        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
+    )
+    run_tool(
+        ctx,
+        lambda: handle_password_retry(
+            jan3_get_user,
+            {"email": email, "wallet_name": wallet_name, "password": password},
+        ),
+    )
+
+
+@jan3.command("ln-address-toggle")
+@click.option("--email", required=True)
+@click.option(
+    "--enable/--disable", "enabled", required=True,
+    help="Enable or disable the Lightning Address.",
+)
+@click.option("--wallet-name", default="default", show_default=True)
+@click.option(
+    "--password-stdin", "password_stdin", is_flag=True, default=False, help=_PASSWORD_HELP
+)
+@click.pass_obj
+def ln_address_toggle(ctx, email, enabled, wallet_name, password_stdin):
+    """Enable/disable the Lightning Address.
+
+    Enabling populates a batch of Liquid receive addresses so AQUA can deliver
+    inbound Lightning payments to those addresses.
+    """
+    password = resolve_secret(
+        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
+    )
+    run_tool(
+        ctx,
+        lambda: handle_password_retry(
+            jan3_ln_address_toggle,
+            {
+                "email": email,
+                "enabled": enabled,
+                "wallet_name": wallet_name,
+                "password": password,
+            },
+        ),
+    )
+
+
+@jan3.command("ln-username-check")
+@click.option("--email", required=True)
+@click.option(
+    "--ln-username", required=True,
+    help="Desired username (local part, before the @domain).",
+)
+@click.pass_obj
+def ln_username_check(ctx, email, ln_username):
+    """Check whether a Lightning username is available before purchasing."""
+    run_tool(
+        ctx, lambda: jan3_ln_username_check_available(email=email, ln_username=ln_username)
+    )
+
+
+@jan3.command("purchase-ln-username")
+@click.option("--email", required=True)
+@click.option(
+    "--ln-username", required=True,
+    help="Desired username (local part, before the @domain).",
+)
+@click.option("--wallet-name", default="default", show_default=True)
+@click.option("--asset", default="L-BTC", show_default=True, help="Funding asset ticker.")
+@click.option(
+    "--password-stdin", "password_stdin", is_flag=True, default=False, help=_PASSWORD_HELP
+)
+@click.pass_obj
+def purchase_ln_username(ctx, email, ln_username, wallet_name, asset, password_stdin):
+    """Buy / update the Lightning username with an on-chain L-BTC payment."""
+    password = resolve_secret(
+        "Password", password_stdin, env_var="AQUA_PASSWORD", required=False
+    )
+    run_tool(
+        ctx,
+        lambda: handle_password_retry(
+            jan3_purchase_ln_username,
+            {
+                "email": email,
+                "ln_username": ln_username,
+                "wallet_name": wallet_name,
+                "asset": asset,
+                "password": password,
+            },
+        ),
+    )

--- a/src/aqua/cli/jan3.py
+++ b/src/aqua/cli/jan3.py
@@ -216,13 +216,10 @@ def enable_lightning_address(ctx, email, enabled, wallet_name, password_stdin):
 )
 @click.pass_obj
 def rebind_wallet(ctx, email, wallet_name, assume_yes):
-    """Re-bind your Lightning Address to a different wallet (DESTRUCTIVE).
+    """Re-bind Lightning Address delivery to --wallet-name (DESTRUCTIVE).
 
-    Moves inbound Lightning delivery to --wallet-name; the previously-bound
-    wallet stops receiving. Previews the change first (showing your Lightning
-    Address and the current→new fingerprint), then asks for confirmation unless
-    --yes is given. If the account is already bound to this wallet it is a no-op.
-    No wallet password is needed — re-binding never signs.
+    Previews the change first; asks for confirmation unless --yes is given.
+    Already-bound to this wallet is a no-op.
     """
     try:
         preview = jan3_rebind_wallet(

--- a/src/aqua/features.py
+++ b/src/aqua/features.py
@@ -130,7 +130,7 @@ CLI_COMMAND_TO_MCP_TOOL: dict[tuple[str, str], str] = {
     # qr group (cli/qr.py)
     ("qr", "decode"): "qr_decode",
 
-    # jan3 group (cli/jan3.py) — JAN3 account login + sessions
+    # jan3 group (cli/jan3.py) — JAN3 account login + sessions + Lightning Address
     ("jan3", "login"): "jan3_login",
     ("jan3", "verify"): "jan3_verify",
     ("jan3", "login-start"): "jan3_login_start",
@@ -138,6 +138,10 @@ CLI_COMMAND_TO_MCP_TOOL: dict[tuple[str, str], str] = {
     ("jan3", "session-info"): "jan3_session_info",
     ("jan3", "list-sessions"): "jan3_list_sessions",
     ("jan3", "logout"): "jan3_logout",
+    ("jan3", "get-user"): "jan3_get_user",
+    ("jan3", "ln-address-toggle"): "jan3_ln_address_toggle",
+    ("jan3", "ln-username-check"): "jan3_ln_username_check_available",
+    ("jan3", "purchase-ln-username"): "jan3_purchase_ln_username",
 }
 
 

--- a/src/aqua/features.py
+++ b/src/aqua/features.py
@@ -138,9 +138,9 @@ CLI_COMMAND_TO_MCP_TOOL: dict[tuple[str, str], str] = {
     ("jan3", "session-info"): "jan3_session_info",
     ("jan3", "list-sessions"): "jan3_list_sessions",
     ("jan3", "logout"): "jan3_logout",
-    ("jan3", "get-user"): "jan3_get_user",
-    ("jan3", "ln-address-toggle"): "jan3_ln_address_toggle",
-    ("jan3", "ln-username-check"): "jan3_ln_username_check_available",
+    ("jan3", "user-info"): "jan3_user_info",
+    ("jan3", "enable-lightning-address"): "jan3_enable_lightning_address",
+    ("jan3", "ln-check-username"): "jan3_ln_check_username",
     ("jan3", "purchase-ln-username"): "jan3_purchase_ln_username",
 }
 

--- a/src/aqua/features.py
+++ b/src/aqua/features.py
@@ -140,6 +140,7 @@ CLI_COMMAND_TO_MCP_TOOL: dict[tuple[str, str], str] = {
     ("jan3", "logout"): "jan3_logout",
     ("jan3", "user-info"): "jan3_user_info",
     ("jan3", "enable-lightning-address"): "jan3_enable_lightning_address",
+    ("jan3", "rebind-wallet"): "jan3_rebind_wallet",
     ("jan3", "ln-check-username"): "jan3_ln_check_username",
     ("jan3", "purchase-ln-username"): "jan3_purchase_ln_username",
 }

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -32,6 +32,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import asdict, dataclass, fields
 from datetime import UTC, datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Optional
 
@@ -78,6 +79,24 @@ _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 # Mirrors aqua-ankara's common.constants.LN_USERNAME_REGEX so we fail fast
 # before a network call: lowercase alphanumerics with at most one dot.
 LN_USERNAME_REGEX = re.compile(r"^[a-z0-9]+(\.[a-z0-9]+)?$")
+
+
+def _format_display_amount(amount_base_units: int, asset_ticker: str) -> str:
+    """Render a human-facing price string for the agent to surface verbatim.
+
+    ``amount_base_units`` is the technical integer the wallet actually funds — the
+    single source of truth — but for the user it must be shown per-asset:
+
+    * **L-BTC** — base units *are* satoshis → ``"2000 Sats"``.
+    * **USDt** (and other 8-decimal Liquid assets) → a 2-decimal fiat-style
+      amount (``base_units / 1e8``) → ``"1.50 USDT"``.
+    """
+    ticker = (asset_ticker or "").strip()
+    if ticker.upper() in ("L-BTC", "LBTC", "BTC"):
+        return f"{amount_base_units} Sats"
+    value = Decimal(amount_base_units) / Decimal(100_000_000)
+    unit = "USDT" if ticker.upper() == "USDT" else ticker
+    return f"{value:.2f} {unit}"
 
 
 def _now_iso() -> str:
@@ -788,7 +807,7 @@ class Jan3AccountsManager:
     def ln_username_available(self, email: str, username: str) -> dict:
         """Check whether an LN username is free to claim (authenticated).
 
-        Call before ``purchase_ln_username`` to avoid paying L-BTC on a username
+        Call before ``purchase_ln_username`` to avoid paying for a username
         that's already taken.
         """
         email = _validate_email(email)
@@ -1052,10 +1071,21 @@ class Jan3AccountsManager:
         wallet_name: str = "default",
         password: Optional[str] = None,
         asset: str = ASSET_TICKER_LBTC,
+        confirm: bool = False,
     ) -> dict:
-        """Buy / update the Lightning username for ``email`` (on-chain L-BTC payment).
+        """Buy / update the Lightning username for ``email`` (on-chain payment).
 
-        Creates a payment request, funds it with a signed L-BTC tx, and submits it.
+        Two-step to avoid spending without consent:
+
+        * ``confirm=False`` (default) — creates a payment request to fetch the
+          live price and returns a **quote** (``requires_confirmation=True``); it
+          does NOT sign or broadcast anything. Show the price to the user first.
+        * ``confirm=True`` — re-quotes and funds it: crafts a signed tx in
+          ``asset`` (``"L-BTC"`` or ``"USDt"``) to AQUA's address and submits it.
+
+        Each call creates a fresh payment request, so the confirmed price is
+        always current (the quote may have expired). Orphaned unfunded orders
+        expire server-side.
         """
         email = _validate_email(email)
         ln_username = _validate_ln_username(ln_username)
@@ -1068,19 +1098,43 @@ class Jan3AccountsManager:
         )
         payment_id = order.get("payment_id")
         address = order.get("address")
-        amount_sats = int(order.get("amount_base_units") or 0)
+        amount_base_units = int(order.get("amount_base_units") or 0)
         asset_ticker = order.get("asset_ticker") or asset
-        if not payment_id or not address or amount_sats <= 0:
+        amount = order.get("amount")
+        expires_at = order.get("expires_at")
+        if not payment_id or not address or amount_base_units <= 0:
             raise ValueError(
                 "AQUA payment-request response is missing fields "
                 f"(payment_id/address/amount): {order!r}"
             )
 
+        display_amount = _format_display_amount(amount_base_units, asset_ticker)
+
+        if not confirm:
+            # Dry-run quote: no signing, no broadcast. The caller must show
+            # ``display_amount`` to the user and re-call with confirm=True.
+            return {
+                "requires_confirmation": True,
+                "confirmed": False,
+                "ln_username": ln_username,
+                "asset_ticker": asset_ticker,
+                "amount_base_units": amount_base_units,
+                "amount": amount,
+                "display_amount": display_amount,
+                "expires_at": expires_at,
+                "address": address,
+                "message": (
+                    f"Purchasing the Lightning Address {ln_username!r} costs "
+                    f"{display_amount}. Show this to the user; on their approval "
+                    "re-call with confirm=true to pay."
+                ),
+            }
+
         asset_id = self._resolve_asset_id(wallet_name, asset_ticker)
         raw_tx = self.wallet_manager.craft_raw_tx(
             wallet_name=wallet_name,
             address=address,
-            amount=amount_sats,
+            amount=amount_base_units,
             asset_id=asset_id,
             password=password,
         )
@@ -1095,15 +1149,19 @@ class Jan3AccountsManager:
             ),
         )
         return {
+            "confirmed": True,
             "payment_id": payment_id,
             "status": result.get("status"),
             "txid": txid,
             "ln_username": ln_username,
-            "amount_sats": amount_sats,
             "asset_ticker": asset_ticker,
+            "amount_base_units": amount_base_units,
+            "amount": amount,
+            "display_amount": display_amount,
+            "expires_at": expires_at,
             "address": address,
             "message": (
-                f"Submitted raw_tx for {ln_username!r}. Server reports "
-                f"{result.get('status', 'UNKNOWN')}."
+                f"Submitted raw_tx for {ln_username!r} ({display_amount}). "
+                f"Server reports {result.get('status', 'UNKNOWN')}."
             ),
         }

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -591,17 +591,13 @@ class Jan3AccountsManager:
                 "You can now make authenticated calls."
             ),
             "access_token_preview": _token_preview(access),
-            # Cue the agent to offer the Lightning Address opt-in right after
-            # login — this is the intended post-login UX. Enabling it stores a
-            # batch of Liquid receive addresses so inbound Lightning payments are
-            # delivered there.
             "next_step": (
                 "Ask the user if they want to activate their Lightning Address. "
                 "If yes, call jan3_enable_lightning_address(email, enabled=true) — this "
                 "stores a batch of Liquid receive addresses so JAN3/AQUA can "
-                "deliver inbound Lightning payments to them. A Lightning username "
-                "(jan3_purchase_ln_username) is required first; run jan3_user_info "
-                "to check current status."
+                "deliver inbound Lightning payments to them. A Lightning Address is assigned "
+                "automatically to the account, run jan3_user_info to check it. The user can change "
+                "it's username (LN Address) through jan3_purchase_ln_username."
             ),
         }
 
@@ -752,14 +748,10 @@ class Jan3AccountsManager:
         wallet_name: str = "default",
         password: Optional[str] = None,
     ) -> dict:
-        """Fetch the AQUA account profile for ``email`` and keep the pool healthy.
+        """Fetch the AQUA account profile for ``email``.
 
-        The returned dict is the backend profile (``ln_username``,
-        ``ln_address_toggled``, ``fingerprint``, ``new_addresses_needed``, …).
-        When the LN-address feature is active we opportunistically top up the
-        unused-address pool — best-effort, never failing the profile read — and
-        attach the outcome under ``ln_address_pool``. This is why there is no
-        user-facing "ensure pool" tool: reading the account self-heals it.
+        Auto-tops-up the LN-address pool when active (result under
+        ``ln_address_pool``); never fails the profile read on pool errors.
         """
         email = _validate_email(email)
         profile = self._with_auth_retry(
@@ -780,11 +772,8 @@ class Jan3AccountsManager:
     ) -> dict:
         """Enable or disable the LN-address feature for ``email``.
 
-        Enabling means AQUA will deliver inbound Lightning payments to the user's
-        Lightning Address by handing out the Liquid receive addresses we register
-        here. So on enable we immediately populate the pool (best-effort) and
-        report the outcome under ``ln_address_pool`` — a ``no_ln_username`` skip
-        just means the user still has to run ``jan3_purchase_ln_username``.
+        On enable, populates the address pool immediately (best-effort, under
+        ``ln_address_pool``).
         """
         email = _validate_email(email)
         resp = self._with_auth_retry(
@@ -822,14 +811,10 @@ class Jan3AccountsManager:
         password: Optional[str] = None,
         profile: Optional[dict] = None,
     ) -> dict:
-        """Mint unused Liquid receive addresses and POST them to /auth/user/addresses/.
+        """Mint ``count`` unused Liquid receive addresses and POST to /auth/user/addresses/.
 
-        Internal — NOT exposed as an MCP tool. The pool is managed automatically
-        via :meth:`ensure_ln_pool` (called by :meth:`get_user` and on
-        :meth:`ln_address_toggle` enable). Without a healthy pool the AQUA
-        backend can't deliver inbound LN payments — it hands out one address per
-        invoice. Raises on hard errors (no username, disabled, fingerprint
-        mismatch); the auto path wraps those into skip dicts.
+        Internal — not an MCP tool. Raises on hard errors (no username, disabled,
+        fingerprint mismatch); callers on the auto path wrap these into skip dicts.
         """
         email = _validate_email(email)
         user = (
@@ -897,11 +882,8 @@ class Jan3AccountsManager:
     ) -> dict:
         """Idempotent LN-address pool top-up (internal — NOT an MCP tool).
 
-        Only POSTs new addresses when the server reports
-        ``new_addresses_needed > 0``. Returns a ``{refilled: False, reason: …}``
-        dict (never raises for policy reasons) when auto-refill doesn't apply:
-        no LN username, toggle off, pool already full, or the local wallet's
-        fingerprint doesn't match the account-bound one.
+        POSTs only when ``new_addresses_needed > 0``; returns a skip dict
+        (``{refilled: False, reason: …}``) for policy non-starters. Never raises.
         """
         email = _validate_email(email)
 
@@ -963,12 +945,10 @@ class Jan3AccountsManager:
         password: Optional[str],
         profile: Optional[dict] = None,
     ) -> dict:
-        """Best-effort wrapper around :meth:`ensure_ln_pool` for the auto paths.
+        """Best-effort wrapper around :meth:`ensure_ln_pool` (auto paths only).
 
-        Used by :meth:`get_user` and by :meth:`ln_address_toggle` on enable, so
-        the pool self-heals without a dedicated user-facing tool. Never raises: a
-        locked/encrypted wallet (no password), an offline backend, etc. are
-        reported as a skip dict rather than failing the caller.
+        Called by :meth:`get_user` and :meth:`ln_address_toggle` on enable.
+        Never raises — errors become a skip dict so the caller is never broken.
         """
         try:
             return self.ensure_ln_pool(
@@ -988,13 +968,9 @@ class Jan3AccountsManager:
         wallet_name: str = "default",
         confirm: bool = False,
     ) -> dict:
-        """Re-bind the account's Lightning Address to ``wallet_name`` (self-serve).
+        """Re-bind Lightning Address delivery to ``wallet_name`` via override_fingerprint.
 
-        This is the only path that passes ``override_fingerprint=true`` — it
-        re-binds the AQUA account to this wallet's fingerprint and re-enables LN
-        delivery. It is reachable in three states, only the last of which is
-        destructive:
-
+        Two-step handshake: ``confirm=False`` returns a non-mutating preview.
         * **first bind** — the account has no wallet bound yet (``fingerprint``
           empty on the profile). Binds ``wallet_name``; not destructive.
         * **already bound** — the account is already bound to this exact wallet
@@ -1003,12 +979,6 @@ class Jan3AccountsManager:
         * **re-bind** — the account is bound to a *different* wallet. Destructive:
           the previously-bound wallet stops receiving inbound Lightning. Requires
           explicit confirmation.
-
-        Two-step handshake: ``confirm=False`` returns a non-mutating preview
-        (``requires_confirmation``, ``warning``, ``current_fingerprint`` →
-        ``new_fingerprint``); ``confirm=True`` executes. The Lightning Address in
-        the preview is ``ln_username`` (a full ``user@domain``) — never the
-        account login ``email``.
         """
         email = _validate_email(email)
         profile = self._with_auth_retry(
@@ -1024,8 +994,7 @@ class Jan3AccountsManager:
         server_fp = profile.get("fingerprint")
         local_fp = self.wallet_manager.fingerprint(wallet_name)
 
-        # Already bound to this exact wallet: nothing to re-bind. Keep the pool
-        # healthy via the normal (non-override) path and report a no-op.
+        # Already bound: no-op, but keep the pool healthy via the non-override path.
         if server_fp and server_fp == local_fp:
             pool = self._auto_ensure_ln_pool(
                 email, wallet_name=wallet_name, password=None, profile=profile
@@ -1092,9 +1061,7 @@ class Jan3AccountsManager:
     ) -> dict:
         """Buy / update the Lightning username for ``email`` (on-chain L-BTC payment).
 
-        Creates an LN_USERNAME_UPDATE payment request, funds it with a signed
-        L-BTC tx to AQUA's address, and submits the raw tx. On a 401 the access
-        token is refreshed and the call retried once (via ``_with_auth_retry``).
+        Creates a payment request, funds it with a signed L-BTC tx, and submits it.
         """
         email = _validate_email(email)
         ln_username = _validate_ln_username(ln_username)

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -746,7 +746,6 @@ class Jan3AccountsManager:
         self,
         email: str,
         wallet_name: str = "default",
-        password: Optional[str] = None,
     ) -> dict:
         """Fetch the AQUA account profile for ``email``.
 
@@ -759,7 +758,7 @@ class Jan3AccountsManager:
         )
         result = dict(profile)
         result["ln_address_pool"] = self._auto_ensure_ln_pool(
-            email, wallet_name=wallet_name, password=password, profile=profile
+            email, wallet_name=wallet_name, profile=profile
         )
         return result
 
@@ -768,7 +767,6 @@ class Jan3AccountsManager:
         email: str,
         enabled: bool,
         wallet_name: str = "default",
-        password: Optional[str] = None,
     ) -> dict:
         """Enable or disable the LN-address feature for ``email``.
 
@@ -783,7 +781,7 @@ class Jan3AccountsManager:
         out: dict[str, Any] = {"email": email, "enabled": bool(enabled), "result": resp}
         if enabled:
             out["ln_address_pool"] = self._auto_ensure_ln_pool(
-                email, wallet_name=wallet_name, password=password, profile=None
+                email, wallet_name=wallet_name, profile=None
             )
         return out
 
@@ -808,7 +806,6 @@ class Jan3AccountsManager:
         wallet_name: str = "default",
         count: Optional[int] = None,
         override_fingerprint: bool = False,
-        password: Optional[str] = None,
         profile: Optional[dict] = None,
     ) -> dict:
         """Mint ``count`` unused Liquid receive addresses and POST to /auth/user/addresses/.
@@ -837,7 +834,7 @@ class Jan3AccountsManager:
             )
 
         server_fp = user.get("fingerprint")
-        local_fp = self.wallet_manager.fingerprint(wallet_name, password=password)
+        local_fp = self.wallet_manager.fingerprint(wallet_name)
         if server_fp and server_fp != local_fp and not override_fingerprint:
             raise ValueError(
                 f"Wallet fingerprint mismatch: account is bound to {server_fp!r}, "
@@ -877,7 +874,6 @@ class Jan3AccountsManager:
         self,
         email: str,
         wallet_name: str = "default",
-        password: Optional[str] = None,
         profile: Optional[dict] = None,
     ) -> dict:
         """Idempotent LN-address pool top-up (internal — NOT an MCP tool).
@@ -908,7 +904,7 @@ class Jan3AccountsManager:
             )
 
         server_fp = user.get("fingerprint")
-        local_fp = self.wallet_manager.fingerprint(wallet_name, password=password)
+        local_fp = self.wallet_manager.fingerprint(wallet_name)
         if server_fp and server_fp != local_fp:
             return _skip(
                 "fingerprint_mismatch",
@@ -928,7 +924,6 @@ class Jan3AccountsManager:
             email,
             wallet_name=wallet_name,
             count=min(needed, MAX_ADDRESSES_PER_REGISTRATION),
-            password=password,
             profile=user,
         )
         return {
@@ -942,7 +937,6 @@ class Jan3AccountsManager:
         self,
         email: str,
         wallet_name: str,
-        password: Optional[str],
         profile: Optional[dict] = None,
     ) -> dict:
         """Best-effort wrapper around :meth:`ensure_ln_pool` (auto paths only).
@@ -952,7 +946,7 @@ class Jan3AccountsManager:
         """
         try:
             return self.ensure_ln_pool(
-                email, wallet_name=wallet_name, password=password, profile=profile
+                email, wallet_name=wallet_name, profile=profile
             )
         except Exception as e:  # noqa: BLE001 — auto path must never break its caller
             logger.warning("Auto LN-address pool top-up skipped for %s: %s", email, e)
@@ -997,7 +991,7 @@ class Jan3AccountsManager:
         # Already bound: no-op, but keep the pool healthy via the non-override path.
         if server_fp and server_fp == local_fp:
             pool = self._auto_ensure_ln_pool(
-                email, wallet_name=wallet_name, password=None, profile=profile
+                email, wallet_name=wallet_name, profile=profile
             )
             return {
                 "email": email,

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -597,10 +597,10 @@ class Jan3AccountsManager:
             # delivered there.
             "next_step": (
                 "Ask the user if they want to activate their Lightning Address. "
-                "If yes, call jan3_ln_address_toggle(email, enabled=true) — this "
+                "If yes, call jan3_enable_lightning_address(email, enabled=true) — this "
                 "stores a batch of Liquid receive addresses so JAN3/AQUA can "
                 "deliver inbound Lightning payments to them. A Lightning username "
-                "(jan3_purchase_ln_username) is required first; run jan3_get_user "
+                "(jan3_purchase_ln_username) is required first; run jan3_user_info "
                 "to check current status."
             ),
         }
@@ -847,7 +847,7 @@ class Jan3AccountsManager:
         if not user.get("ln_address_toggled") and not override_fingerprint:
             raise ValueError(
                 "LN address is currently disabled — call "
-                "jan3_ln_address_toggle(enabled=true) first, or pass "
+                "jan3_enable_lightning_address(enabled=true) first, or pass "
                 "override_fingerprint=true to re-enable it as part of this call."
             )
 

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -932,6 +932,13 @@ class Jan3AccountsManager:
                 "fingerprint_mismatch",
                 server_fingerprint=server_fp,
                 local_fingerprint=local_fp,
+                message=(
+                    f"The pool was NOT topped up: this account delivers Lightning "
+                    f"payments to the wallet bound to fingerprint {server_fp!r}, "
+                    f"but wallet {wallet_name!r} is {local_fp!r}. Retry with the "
+                    "wallet that matches the bound fingerprint (self-serve "
+                    "re-binding to a different wallet is not yet available)."
+                ),
             )
 
         result = self.register_ln_addresses(

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -67,8 +67,7 @@ ASSET_TICKER_USDT = "USDt"
 LN_USERNAME_PAYMENT_REQUEST_PATH = "/api/v1/liquid-wallet/payment-request/ln-username/"
 SUBMIT_RAW_TX_PATH = "/api/v1/liquid-wallet/payment/submit-raw-tx/"
 
-# Server-side per-call cap on address registration, and the app's default pool
-# size to register when the server doesn't report how many are needed.
+# Server-side per-call cap on address registration; default pool size otherwise.
 MAX_ADDRESSES_PER_REGISTRATION = 15
 DEFAULT_LN_ADDRESS_POOL = 5
 
@@ -76,20 +75,14 @@ DEFAULT_LN_ADDRESS_POOL = 5
 # catches obvious mistakes before we make a network call.
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
-# Mirrors aqua-ankara's common.constants.LN_USERNAME_REGEX so we fail fast
-# before a network call: lowercase alphanumerics with at most one dot.
+# Mirrors aqua-ankara's LN_USERNAME_REGEX to fail fast before a network call.
 LN_USERNAME_REGEX = re.compile(r"^[a-z0-9]+(\.[a-z0-9]+)?$")
 
 
 def _format_display_amount(amount_base_units: int, asset_ticker: str) -> str:
     """Render a human-facing price string for the agent to surface verbatim.
 
-    ``amount_base_units`` is the technical integer the wallet actually funds — the
-    single source of truth — but for the user it must be shown per-asset:
-
-    * **L-BTC** — base units *are* satoshis → ``"2000 Sats"``.
-    * **USDt** (and other 8-decimal Liquid assets) → a 2-decimal fiat-style
-      amount (``base_units / 1e8``) → ``"1.50 USDT"``.
+    L-BTC is shown in Sats; other assets (e.g. USDt) as a 2-decimal fiat-style amount.
     """
     ticker = (asset_ticker or "").strip()
     if ticker.upper() in ("L-BTC", "LBTC", "BTC"):
@@ -101,6 +94,17 @@ def _format_display_amount(amount_base_units: int, asset_ticker: str) -> str:
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _order_expired(iso_ts: Optional[str]) -> bool:
+    """True when an order's ISO ``expires_at`` is in the past (unparseable → False)."""
+    if not iso_ts:
+        return False
+    try:
+        dt = datetime.fromisoformat(str(iso_ts).replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return dt <= datetime.now(UTC)
 
 
 def _token_preview(token: str) -> str:
@@ -160,6 +164,16 @@ class Jan3Session:
     created_at: str
     refreshed_at: Optional[str] = None
     captcha_exempt: bool = False
+    # Locked quote from purchase_ln_username(confirm=False):
+    # {"ln_username", "payment_id", "address", "amount_base_units",
+    #  "asset_ticker", "amount", "expires_at"}. confirm=True funds THIS order
+    # instead of re-quoting; cleared once funded.
+    pending_ln_purchase: Optional[dict] = None
+    # LN-address batch whose registration POST failed with unknown outcome:
+    # {"wallet_name", "fingerprint", "addresses"}. Retried verbatim on the next
+    # registration instead of burning fresh indices (the server dedups
+    # re-uploads), cleared once a POST succeeds.
+    pending_ln_registration: Optional[dict] = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -171,6 +185,8 @@ class Jan3Session:
         data = {k: v for k, v in data.items() if k in known}
         data.setdefault("refreshed_at", None)
         data.setdefault("captcha_exempt", False)
+        data.setdefault("pending_ln_purchase", None)
+        data.setdefault("pending_ln_registration", None)
         return cls(**data)
 
 
@@ -829,8 +845,8 @@ class Jan3AccountsManager:
     ) -> dict:
         """Mint ``count`` unused Liquid receive addresses and POST to /auth/user/addresses/.
 
-        Internal — not an MCP tool. Raises on hard errors (no username, disabled,
-        fingerprint mismatch); callers on the auto path wrap these into skip dicts.
+        Internal — not an MCP tool. A previously failed POST's batch is re-uploaded
+        verbatim (``count`` ignored) so retries never mint additional indices.
         """
         email = _validate_email(email)
         user = (
@@ -873,20 +889,62 @@ class Jan3AccountsManager:
                 "(server-side per-call limit)"
             )
 
-        addresses = [
-            a.address for a in self.wallet_manager.reserve_addresses(wallet_name, count)
-        ]
+        # Re-upload a batch left pending by a previous failed POST (the server dedups).
+        session = self.load_session(email)
+        pending = session.pending_ln_registration if session else None
+        if (
+            pending
+            and pending.get("addresses")
+            and pending.get("wallet_name") == wallet_name
+            and pending.get("fingerprint") == local_fp
+        ):
+            addresses = list(pending["addresses"])
+        else:
+            addresses = [
+                a.address
+                for a in self.wallet_manager.reserve_addresses(wallet_name, count)
+            ]
+            if session is not None:
+                # Persist before the POST so a failed/unknown outcome retries verbatim.
+                session.pending_ln_registration = {
+                    "wallet_name": wallet_name,
+                    "fingerprint": local_fp,
+                    "addresses": addresses,
+                }
+                self.save_session(session)
+
         resp = self._with_auth_retry(
             email,
             lambda access: self._authed_client(access).register_addresses(
                 local_fp, addresses, override_fingerprint=override_fingerprint
             ),
         )
+
+        # Clear the pending batch; re-load since the POST may have rewritten the session.
+        session = self.load_session(email)
+        if session is not None and session.pending_ln_registration is not None:
+            session.pending_ln_registration = None
+            self.save_session(session)
+
+        # Advance past pool addresses we didn't just upload (e.g. post-reimport).
+        pool = resp.get("addresses", []) or []
+        posted = set(addresses)
+        unknown = [a for a in pool if a not in posted]
+        if unknown:
+            try:
+                self.wallet_manager.ensure_counter_covers(wallet_name, unknown)
+            except Exception as e:  # best-effort repair; registration succeeded
+                logger.warning(
+                    "LN-pool counter reconciliation skipped for wallet %r: %s",
+                    wallet_name,
+                    e,
+                )
+
         return {
             "requested_count": len(addresses),
-            "pool_size": len(resp.get("addresses", [])),
+            "pool_size": len(pool),
             "fingerprint": local_fp,
-            "addresses": resp.get("addresses", []),
+            "addresses": pool,
         }
 
     def ensure_ln_pool(
@@ -923,7 +981,20 @@ class Jan3AccountsManager:
             )
 
         server_fp = user.get("fingerprint")
-        local_fp = self.wallet_manager.fingerprint(wallet_name)
+        try:
+            local_fp = self.wallet_manager.fingerprint(wallet_name)
+        except ValueError as e:
+            # Distinct from auto_topup_unavailable: this is permanent, not transient.
+            return _skip(
+                "wallet_fingerprint_unavailable",
+                message=(
+                    f"The pool was NOT topped up: wallet {wallet_name!r} cannot "
+                    f"produce a fingerprint ({e}). This is permanent for this "
+                    "wallet — re-import it from its mnemonic, or from a "
+                    "descriptor that includes the [fingerprint/derivation] "
+                    "key-origin block, then retry."
+                ),
+            )
         if server_fp and server_fp != local_fp:
             return _skip(
                 "fingerprint_mismatch",
@@ -1072,94 +1143,146 @@ class Jan3AccountsManager:
         password: Optional[str] = None,
         asset: str = ASSET_TICKER_LBTC,
         confirm: bool = False,
+        expected_amount_base_units: Optional[int] = None,
     ) -> dict:
         """Buy / update the Lightning username for ``email`` (on-chain payment).
 
-        Two-step to avoid spending without consent:
-
-        * ``confirm=False`` (default) — creates a payment request to fetch the
-          live price and returns a **quote** (``requires_confirmation=True``); it
-          does NOT sign or broadcast anything. Show the price to the user first.
-        * ``confirm=True`` — re-quotes and funds it: crafts a signed tx in
-          ``asset`` (``"L-BTC"`` or ``"USDt"``) to AQUA's address and submits it.
-
-        Each call creates a fresh payment request, so the confirmed price is
-        always current (the quote may have expired). Orphaned unfunded orders
-        expire server-side.
+        Two-step to avoid spending without consent: ``confirm=False`` (default)
+        locks in a price quote without signing/broadcasting; ``confirm=True`` funds
+        that exact quoted order (rejecting it if expired or altered). Without a
+        prior matching quote it creates and funds a fresh order in one go, bounded
+        by ``expected_amount_base_units``.
         """
         email = _validate_email(email)
         ln_username = _validate_ln_username(ln_username)
 
-        order = self._with_auth_retry(
-            email,
-            lambda access: self._authed_client(
-                access
-            ).create_ln_username_payment_request(asset, ln_username),
-        )
-        payment_id = order.get("payment_id")
-        address = order.get("address")
-        amount_base_units = int(order.get("amount_base_units") or 0)
-        asset_ticker = order.get("asset_ticker") or asset
-        amount = order.get("amount")
-        expires_at = order.get("expires_at")
-        if not payment_id or not address or amount_base_units <= 0:
-            raise ValueError(
-                "AQUA payment-request response is missing fields "
-                f"(payment_id/address/amount): {order!r}"
+        def _parse_order(order: dict) -> dict:
+            payment_id = order.get("payment_id")
+            address = order.get("address")
+            amount_base_units = int(order.get("amount_base_units") or 0)
+            if not payment_id or not address or amount_base_units <= 0:
+                raise ValueError(
+                    "AQUA payment-request response is missing fields "
+                    f"(payment_id/address/amount): {order!r}"
+                )
+            return {
+                "payment_id": payment_id,
+                "address": address,
+                "amount_base_units": amount_base_units,
+                "asset_ticker": order.get("asset_ticker") or asset,
+                "amount": order.get("amount"),
+                "expires_at": order.get("expires_at"),
+            }
+
+        def _create_order() -> dict:
+            # The backend expires any previous pending LN_USERNAME order for this user.
+            return _parse_order(
+                self._with_auth_retry(
+                    email,
+                    lambda access: self._authed_client(
+                        access
+                    ).create_ln_username_payment_request(asset, ln_username),
+                )
             )
 
-        display_amount = _format_display_amount(amount_base_units, asset_ticker)
-
         if not confirm:
-            # Dry-run quote: no signing, no broadcast. The caller must show
-            # ``display_amount`` to the user and re-call with confirm=True.
+            # Dry-run quote: no signing/broadcast; caller re-calls with confirm=True.
+            fields = _create_order()
+            display_amount = _format_display_amount(
+                fields["amount_base_units"], fields["asset_ticker"]
+            )
+            session = self.load_session(email)
+            if session is not None:
+                session.pending_ln_purchase = {"ln_username": ln_username, **fields}
+                self.save_session(session)
             return {
                 "requires_confirmation": True,
                 "confirmed": False,
                 "ln_username": ln_username,
-                "asset_ticker": asset_ticker,
-                "amount_base_units": amount_base_units,
-                "amount": amount,
+                **fields,
                 "display_amount": display_amount,
-                "expires_at": expires_at,
-                "address": address,
                 "message": (
                     f"Purchasing the Lightning Address {ln_username!r} costs "
-                    f"{display_amount}. Show this to the user; on their approval "
-                    "re-call with confirm=true to pay."
+                    f"{display_amount} (quote locked until "
+                    f"{fields['expires_at']}). Show this to the user; on their "
+                    "approval re-call with confirm=true to pay exactly this."
                 ),
             }
 
-        asset_id = self._resolve_asset_id(wallet_name, asset_ticker)
+        # confirm=True — prefer funding the order quoted in step 1.
+        session = self.load_session(email)
+        pending = session.pending_ln_purchase if session else None
+        fields = None
+        if (
+            pending
+            and pending.get("ln_username") == ln_username
+            and (pending.get("asset_ticker") or "").strip().upper()
+            == (asset or "").strip().upper()
+        ):
+            if _order_expired(pending.get("expires_at")):
+                raise ValueError(
+                    f"The approved quote expired at {pending['expires_at']!r}. "
+                    "Nothing was signed or spent — re-quote with confirm=false "
+                    "and show the new price to the user."
+                )
+            fields = {k: v for k, v in pending.items() if k != "ln_username"}
+
+        if fields is None:
+            # No matching quote (--yes / stateless path): create and fund in one go.
+            fields = _create_order()
+
+        if (
+            expected_amount_base_units is not None
+            and fields["amount_base_units"] > int(expected_amount_base_units)
+        ):
+            expected_display = _format_display_amount(
+                int(expected_amount_base_units), fields["asset_ticker"]
+            )
+            current_display = _format_display_amount(
+                fields["amount_base_units"], fields["asset_ticker"]
+            )
+            raise ValueError(
+                f"Price changed: the approved quote was {expected_display} but "
+                f"the current price is {current_display}. Nothing was signed "
+                "or spent. Show the new price to the user and, on their "
+                "approval, re-call with confirm=true and the updated "
+                f"expected_amount_base_units={fields['amount_base_units']}."
+            )
+
+        display_amount = _format_display_amount(
+            fields["amount_base_units"], fields["asset_ticker"]
+        )
+        asset_id = self._resolve_asset_id(wallet_name, fields["asset_ticker"])
         raw_tx = self.wallet_manager.craft_raw_tx(
             wallet_name=wallet_name,
-            address=address,
-            amount=amount_base_units,
+            address=fields["address"],
+            amount=fields["amount_base_units"],
             asset_id=asset_id,
             password=password,
         )
-        # The API response omits the txid; compute it locally from the finalized
-        # raw tx so the caller has something to track on a block explorer.
+        # The API response omits the txid; compute it locally from the finalized raw tx.
         txid = str(lwk.Transaction(raw_tx).txid())
 
         result = self._with_auth_retry(
             email,
             lambda access: self._authed_client(access).submit_raw_tx(
-                payment_id=payment_id, raw_tx=raw_tx
+                payment_id=fields["payment_id"], raw_tx=raw_tx
             ),
         )
+
+        # Funded — consume the quote; re-load since the submit may have rewritten the session.
+        session = self.load_session(email)
+        if session is not None and session.pending_ln_purchase is not None:
+            session.pending_ln_purchase = None
+            self.save_session(session)
+
         return {
             "confirmed": True,
-            "payment_id": payment_id,
             "status": result.get("status"),
             "txid": txid,
             "ln_username": ln_username,
-            "asset_ticker": asset_ticker,
-            "amount_base_units": amount_base_units,
-            "amount": amount,
+            **fields,
             "display_amount": display_amount,
-            "expires_at": expires_at,
-            "address": address,
             "message": (
                 f"Submitted raw_tx for {ln_username!r} ({display_amount}). "
                 f"Server reports {result.get('status', 'UNKNOWN')}."

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -35,6 +35,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Optional
 
+import lwk
+
 from .ankara import (
     ANKARA_API_URL,
     HTTP_TIMEOUT_SECONDS,
@@ -60,9 +62,22 @@ PRODUCT_TYPE_CAPTCHALESS_LOGIN = "CAPTCHALESS_LOGIN"
 ASSET_TICKER_LBTC = "L-BTC"
 ASSET_TICKER_USDT = "USDt"
 
+# LN-username / LN-address endpoints (same Ankara host).
+LN_USERNAME_PAYMENT_REQUEST_PATH = "/api/v1/liquid-wallet/payment-request/ln-username/"
+SUBMIT_RAW_TX_PATH = "/api/v1/liquid-wallet/payment/submit-raw-tx/"
+
+# Server-side per-call cap on address registration, and the app's default pool
+# size to register when the server doesn't report how many are needed.
+MAX_ADDRESSES_PER_REGISTRATION = 15
+DEFAULT_LN_ADDRESS_POOL = 5
+
 # Minimal email syntax check — the server validates properly; this just
 # catches obvious mistakes before we make a network call.
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+# Mirrors aqua-ankara's common.constants.LN_USERNAME_REGEX so we fail fast
+# before a network call: lowercase alphanumerics with at most one dot.
+LN_USERNAME_REGEX = re.compile(r"^[a-z0-9]+(\.[a-z0-9]+)?$")
 
 
 def _now_iso() -> str:
@@ -87,6 +102,16 @@ def _validate_email(email: str) -> str:
     if not email or not _EMAIL_RE.match(email):
         raise ValueError(f"Invalid email address: {email!r}")
     return email.lower()
+
+
+def _validate_ln_username(username: str) -> str:
+    username = (username or "").strip().lower()
+    if not (4 <= len(username) <= 64) or not LN_USERNAME_REGEX.match(username):
+        raise ValueError(
+            f"Invalid ln_username {username!r}: must be 4–64 chars, "
+            "lowercase letters and digits, with at most one dot."
+        )
+    return username
 
 
 def _email_to_filename(email: str) -> str:
@@ -300,6 +325,72 @@ class Jan3AccountsClient:
         client = Jan3AccountsClient(base_url=self.base_url, access_token=access_token)
         return client._api_request("POST", WAPUPAY_ACCOUNT_PATH, auth=True) or {}
 
+    # ─── LN-address / LN-username (authenticated) ──────────────────────
+
+    def get_user(self) -> dict:
+        """GET /api/v1/auth/user/ — the account profile (email, ln_username,
+        fingerprint, ln_address_toggled, new_addresses_needed, …)."""
+        return self._api_request("GET", f"{AUTH_BASE_PATH_V1}/user/", auth=True) or {}
+
+    def ln_address_toggle(self, enabled: bool) -> dict:
+        """POST /api/v1/auth/user/ln-address-toggle/ — opt in/out of LN-address delivery."""
+        return self._api_request(
+            "POST",
+            f"{AUTH_BASE_PATH_V1}/user/ln-address-toggle/",
+            body={"enabled": bool(enabled)},
+            auth=True,
+        ) or {}
+
+    def ln_username_available(self, username: str) -> dict:
+        """GET /api/v1/auth/user/ln-username/{u}/is-available — availability check.
+
+        The OpenAPI schema marks this anonymous, but the live deployment requires
+        a JWT — so we forward the bearer token whenever the client has one.
+        """
+        safe = urllib.parse.quote(username, safe="")
+        return self._api_request(
+            "GET",
+            f"{AUTH_BASE_PATH_V1}/user/ln-username/{safe}/is-available",
+            auth=bool(self.access_token),
+        ) or {}
+
+    def register_addresses(
+        self,
+        fingerprint: str,
+        addresses: list[str],
+        override_fingerprint: bool = False,
+    ) -> dict:
+        """POST /api/v1/auth/user/addresses/ — upload unused Liquid receive addresses.
+
+        ``override_fingerprint=true`` (query string) re-binds the account to this
+        wallet's fingerprint and flips ``ln_address_toggled`` back to true.
+        """
+        return self._api_request(
+            "POST",
+            f"{AUTH_BASE_PATH_V1}/user/addresses/",
+            body={"fingerprint": fingerprint, "addresses": list(addresses)},
+            query={"override_fingerprint": "true"} if override_fingerprint else None,
+            auth=True,
+        ) or {}
+
+    def create_ln_username_payment_request(self, asset: str, ln_username: str) -> dict:
+        """POST …/payment-request/ln-username/ — create an LN_USERNAME_UPDATE order."""
+        return self._api_request(
+            "POST",
+            LN_USERNAME_PAYMENT_REQUEST_PATH,
+            body={"asset": asset, "ln_username": ln_username},
+            auth=True,
+        ) or {}
+
+    def submit_raw_tx(self, payment_id: str, raw_tx: str) -> dict:
+        """POST …/payment/submit-raw-tx/ — submit the signed funding tx for an order."""
+        return self._api_request(
+            "POST",
+            SUBMIT_RAW_TX_PATH,
+            body={"payment_id": payment_id, "raw_tx": raw_tx},
+            auth=True,
+        ) or {}
+
 
 # ---------------------------------------------------------------------------
 # Manager (login orchestration + multi-account persistence)
@@ -500,6 +591,18 @@ class Jan3AccountsManager:
                 "You can now make authenticated calls."
             ),
             "access_token_preview": _token_preview(access),
+            # Cue the agent to offer the Lightning Address opt-in right after
+            # login — this is the intended post-login UX. Enabling it stores a
+            # batch of Liquid receive addresses so inbound Lightning payments are
+            # delivered there.
+            "next_step": (
+                "Ask the user if they want to activate their Lightning Address. "
+                "If yes, call jan3_ln_address_toggle(email, enabled=true) — this "
+                "stores a batch of Liquid receive addresses so JAN3/AQUA can "
+                "deliver inbound Lightning payments to them. A Lightning username "
+                "(jan3_purchase_ln_username) is required first; run jan3_get_user "
+                "to check current status."
+            ),
         }
 
     def logout(self, email: str) -> dict:
@@ -636,3 +739,302 @@ class Jan3AccountsManager:
                 "AQUA backend did not return a WapuPay API key (token missing)."
             )
         return str(token).strip()
+
+    # ─── LN address / LN username ──────────────────────────────────────
+
+    def _authed_client(self, access_token: str) -> Jan3AccountsClient:
+        """Build a stateless client bound to ``access_token`` for one authed call."""
+        return Jan3AccountsClient(base_url=self.base_url, access_token=access_token)
+
+    def get_user(
+        self,
+        email: str,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+    ) -> dict:
+        """Fetch the AQUA account profile for ``email`` and keep the pool healthy.
+
+        The returned dict is the backend profile (``ln_username``,
+        ``ln_address_toggled``, ``fingerprint``, ``new_addresses_needed``, …).
+        When the LN-address feature is active we opportunistically top up the
+        unused-address pool — best-effort, never failing the profile read — and
+        attach the outcome under ``ln_address_pool``. This is why there is no
+        user-facing "ensure pool" tool: reading the account self-heals it.
+        """
+        email = _validate_email(email)
+        profile = self._with_auth_retry(
+            email, lambda access: self._authed_client(access).get_user()
+        )
+        result = dict(profile)
+        result["ln_address_pool"] = self._auto_ensure_ln_pool(
+            email, wallet_name=wallet_name, password=password, profile=profile
+        )
+        return result
+
+    def ln_address_toggle(
+        self,
+        email: str,
+        enabled: bool,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+    ) -> dict:
+        """Enable or disable the LN-address feature for ``email``.
+
+        Enabling means AQUA will deliver inbound Lightning payments to the user's
+        Lightning Address by handing out the Liquid receive addresses we register
+        here. So on enable we immediately populate the pool (best-effort) and
+        report the outcome under ``ln_address_pool`` — a ``no_ln_username`` skip
+        just means the user still has to run ``jan3_purchase_ln_username``.
+        """
+        email = _validate_email(email)
+        resp = self._with_auth_retry(
+            email,
+            lambda access: self._authed_client(access).ln_address_toggle(bool(enabled)),
+        )
+        out: dict[str, Any] = {"email": email, "enabled": bool(enabled), "result": resp}
+        if enabled:
+            out["ln_address_pool"] = self._auto_ensure_ln_pool(
+                email, wallet_name=wallet_name, password=password, profile=None
+            )
+        return out
+
+    def ln_username_available(self, email: str, username: str) -> dict:
+        """Check whether an LN username is free to claim (authenticated).
+
+        Call before ``purchase_ln_username`` to avoid paying L-BTC on a username
+        that's already taken.
+        """
+        email = _validate_email(email)
+        username = (username or "").strip().lower()
+        if not username:
+            raise ValueError("ln_username is required")
+        return self._with_auth_retry(
+            email,
+            lambda access: self._authed_client(access).ln_username_available(username),
+        )
+
+    def register_ln_addresses(
+        self,
+        email: str,
+        wallet_name: str = "default",
+        count: Optional[int] = None,
+        override_fingerprint: bool = False,
+        password: Optional[str] = None,
+        profile: Optional[dict] = None,
+    ) -> dict:
+        """Mint unused Liquid receive addresses and POST them to /auth/user/addresses/.
+
+        Internal — NOT exposed as an MCP tool. The pool is managed automatically
+        via :meth:`ensure_ln_pool` (called by :meth:`get_user` and on
+        :meth:`ln_address_toggle` enable). Without a healthy pool the AQUA
+        backend can't deliver inbound LN payments — it hands out one address per
+        invoice. Raises on hard errors (no username, disabled, fingerprint
+        mismatch); the auto path wraps those into skip dicts.
+        """
+        email = _validate_email(email)
+        user = (
+            profile
+            if profile is not None
+            else self._with_auth_retry(
+                email, lambda access: self._authed_client(access).get_user()
+            )
+        )
+        if not user.get("ln_username"):
+            raise ValueError(
+                "This account has no LN username yet — run "
+                "jan3_purchase_ln_username first."
+            )
+        if not user.get("ln_address_toggled") and not override_fingerprint:
+            raise ValueError(
+                "LN address is currently disabled — call "
+                "jan3_ln_address_toggle(enabled=true) first, or pass "
+                "override_fingerprint=true to re-enable it as part of this call."
+            )
+
+        server_fp = user.get("fingerprint")
+        local_fp = self.wallet_manager.fingerprint(wallet_name, password=password)
+        if server_fp and server_fp != local_fp and not override_fingerprint:
+            raise ValueError(
+                f"Wallet fingerprint mismatch: account is bound to {server_fp!r}, "
+                f"this wallet is {local_fp!r}. Pass override_fingerprint=true to "
+                "re-bind (this also disables LN delivery for the previously-bound "
+                "wallet)."
+            )
+
+        if count is None:
+            needed = user.get("new_addresses_needed") or 0
+            count = needed if needed > 0 else DEFAULT_LN_ADDRESS_POOL
+        if count <= 0:
+            raise ValueError("count must be positive")
+        if count > MAX_ADDRESSES_PER_REGISTRATION:
+            raise ValueError(
+                f"count cannot exceed {MAX_ADDRESSES_PER_REGISTRATION} "
+                "(server-side per-call limit)"
+            )
+
+        addresses = [
+            a.address for a in self.wallet_manager.reserve_addresses(wallet_name, count)
+        ]
+        resp = self._with_auth_retry(
+            email,
+            lambda access: self._authed_client(access).register_addresses(
+                local_fp, addresses, override_fingerprint=override_fingerprint
+            ),
+        )
+        return {
+            "requested_count": len(addresses),
+            "pool_size": len(resp.get("addresses", [])),
+            "fingerprint": local_fp,
+            "addresses": resp.get("addresses", []),
+        }
+
+    def ensure_ln_pool(
+        self,
+        email: str,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+        profile: Optional[dict] = None,
+    ) -> dict:
+        """Idempotent LN-address pool top-up (internal — NOT an MCP tool).
+
+        Only POSTs new addresses when the server reports
+        ``new_addresses_needed > 0``. Returns a ``{refilled: False, reason: …}``
+        dict (never raises for policy reasons) when auto-refill doesn't apply:
+        no LN username, toggle off, pool already full, or the local wallet's
+        fingerprint doesn't match the account-bound one.
+        """
+        email = _validate_email(email)
+
+        def _skip(reason: str, **extra) -> dict:
+            return {"refilled": False, "reason": reason, **extra}
+
+        user = (
+            profile
+            if profile is not None
+            else self._with_auth_retry(
+                email, lambda access: self._authed_client(access).get_user()
+            )
+        )
+        if not user.get("ln_username"):
+            return _skip("no_ln_username", fingerprint=user.get("fingerprint"))
+        if not user.get("ln_address_toggled"):
+            return _skip("ln_address_disabled", fingerprint=user.get("fingerprint"))
+        needed = user.get("new_addresses_needed") or 0
+        if needed <= 0:
+            return _skip(
+                "pool_full", fingerprint=user.get("fingerprint"), new_addresses_needed=0
+            )
+
+        server_fp = user.get("fingerprint")
+        local_fp = self.wallet_manager.fingerprint(wallet_name, password=password)
+        if server_fp and server_fp != local_fp:
+            return _skip(
+                "fingerprint_mismatch",
+                server_fingerprint=server_fp,
+                local_fingerprint=local_fp,
+            )
+
+        result = self.register_ln_addresses(
+            email,
+            wallet_name=wallet_name,
+            count=min(needed, MAX_ADDRESSES_PER_REGISTRATION),
+            password=password,
+            profile=user,
+        )
+        return {
+            "refilled": True,
+            "requested_count": result["requested_count"],
+            "pool_size": result["pool_size"],
+            "fingerprint": result["fingerprint"],
+        }
+
+    def _auto_ensure_ln_pool(
+        self,
+        email: str,
+        wallet_name: str,
+        password: Optional[str],
+        profile: Optional[dict] = None,
+    ) -> dict:
+        """Best-effort wrapper around :meth:`ensure_ln_pool` for the auto paths.
+
+        Used by :meth:`get_user` and by :meth:`ln_address_toggle` on enable, so
+        the pool self-heals without a dedicated user-facing tool. Never raises: a
+        locked/encrypted wallet (no password), an offline backend, etc. are
+        reported as a skip dict rather than failing the caller.
+        """
+        try:
+            return self.ensure_ln_pool(
+                email, wallet_name=wallet_name, password=password, profile=profile
+            )
+        except Exception as e:  # noqa: BLE001 — auto path must never break its caller
+            logger.warning("Auto LN-address pool top-up skipped for %s: %s", email, e)
+            return {
+                "refilled": False,
+                "reason": "auto_topup_unavailable",
+                "detail": str(e),
+            }
+
+    def purchase_ln_username(
+        self,
+        email: str,
+        ln_username: str,
+        wallet_name: str = "default",
+        password: Optional[str] = None,
+        asset: str = ASSET_TICKER_LBTC,
+    ) -> dict:
+        """Buy / update the Lightning username for ``email`` (on-chain L-BTC payment).
+
+        Creates an LN_USERNAME_UPDATE payment request, funds it with a signed
+        L-BTC tx to AQUA's address, and submits the raw tx. On a 401 the access
+        token is refreshed and the call retried once (via ``_with_auth_retry``).
+        """
+        email = _validate_email(email)
+        ln_username = _validate_ln_username(ln_username)
+
+        order = self._with_auth_retry(
+            email,
+            lambda access: self._authed_client(
+                access
+            ).create_ln_username_payment_request(asset, ln_username),
+        )
+        payment_id = order.get("payment_id")
+        address = order.get("address")
+        amount_sats = int(order.get("amount_base_units") or 0)
+        asset_ticker = order.get("asset_ticker") or asset
+        if not payment_id or not address or amount_sats <= 0:
+            raise ValueError(
+                "AQUA payment-request response is missing fields "
+                f"(payment_id/address/amount): {order!r}"
+            )
+
+        asset_id = self._resolve_asset_id(wallet_name, asset_ticker)
+        raw_tx = self.wallet_manager.craft_raw_tx(
+            wallet_name=wallet_name,
+            address=address,
+            amount=amount_sats,
+            asset_id=asset_id,
+            password=password,
+        )
+        # The API response omits the txid; compute it locally from the finalized
+        # raw tx so the caller has something to track on a block explorer.
+        txid = str(lwk.Transaction(raw_tx).txid())
+
+        result = self._with_auth_retry(
+            email,
+            lambda access: self._authed_client(access).submit_raw_tx(
+                payment_id=payment_id, raw_tx=raw_tx
+            ),
+        )
+        return {
+            "payment_id": payment_id,
+            "status": result.get("status"),
+            "txid": txid,
+            "ln_username": ln_username,
+            "amount_sats": amount_sats,
+            "asset_ticker": asset_ticker,
+            "address": address,
+            "message": (
+                f"Submitted raw_tx for {ln_username!r}. Server reports "
+                f"{result.get('status', 'UNKNOWN')}."
+            ),
+        }

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -936,8 +936,9 @@ class Jan3AccountsManager:
                     f"The pool was NOT topped up: this account delivers Lightning "
                     f"payments to the wallet bound to fingerprint {server_fp!r}, "
                     f"but wallet {wallet_name!r} is {local_fp!r}. Retry with the "
-                    "wallet that matches the bound fingerprint (self-serve "
-                    "re-binding to a different wallet is not yet available)."
+                    "wallet that matches the bound fingerprint, or re-bind delivery "
+                    "to this wallet with jan3_rebind_wallet (this stops delivery to "
+                    "the previously-bound wallet)."
                 ),
             )
 
@@ -980,6 +981,106 @@ class Jan3AccountsManager:
                 "reason": "auto_topup_unavailable",
                 "detail": str(e),
             }
+
+    def rebind_wallet(
+        self,
+        email: str,
+        wallet_name: str = "default",
+        confirm: bool = False,
+    ) -> dict:
+        """Re-bind the account's Lightning Address to ``wallet_name`` (self-serve).
+
+        This is the only path that passes ``override_fingerprint=true`` — it
+        re-binds the AQUA account to this wallet's fingerprint and re-enables LN
+        delivery. It is reachable in three states, only the last of which is
+        destructive:
+
+        * **first bind** — the account has no wallet bound yet (``fingerprint``
+          empty on the profile). Binds ``wallet_name``; not destructive.
+        * **already bound** — the account is already bound to this exact wallet
+          (server fingerprint == this wallet's). A no-op; best-effort pool
+          top-up via the normal (non-override) path. No confirmation needed.
+        * **re-bind** — the account is bound to a *different* wallet. Destructive:
+          the previously-bound wallet stops receiving inbound Lightning. Requires
+          explicit confirmation.
+
+        Two-step handshake: ``confirm=False`` returns a non-mutating preview
+        (``requires_confirmation``, ``warning``, ``current_fingerprint`` →
+        ``new_fingerprint``); ``confirm=True`` executes. The Lightning Address in
+        the preview is ``ln_username`` (a full ``user@domain``) — never the
+        account login ``email``.
+        """
+        email = _validate_email(email)
+        profile = self._with_auth_retry(
+            email, lambda access: self._authed_client(access).get_user()
+        )
+        ln_username = profile.get("ln_username")
+        if not ln_username:
+            raise ValueError(
+                "This account has no LN username yet — run "
+                "jan3_purchase_ln_username first."
+            )
+
+        server_fp = profile.get("fingerprint")
+        local_fp = self.wallet_manager.fingerprint(wallet_name)
+
+        # Already bound to this exact wallet: nothing to re-bind. Keep the pool
+        # healthy via the normal (non-override) path and report a no-op.
+        if server_fp and server_fp == local_fp:
+            pool = self._auto_ensure_ln_pool(
+                email, wallet_name=wallet_name, password=None, profile=profile
+            )
+            return {
+                "email": email,
+                "ln_username": ln_username,
+                "wallet_name": wallet_name,
+                "fingerprint": local_fp,
+                "already_bound": True,
+                "requires_confirmation": False,
+                "rebound": False,
+                "ln_address_pool": pool,
+            }
+
+        state = "first_bind" if not server_fp else "rebind"
+        if state == "first_bind":
+            warning = (
+                f"This binds your Lightning Address {ln_username} to wallet "
+                f"{wallet_name!r} [{local_fp}]. No wallet was previously bound, "
+                "so nothing stops receiving."
+            )
+        else:
+            warning = (
+                f"Re-binding your Lightning Address {ln_username} to wallet "
+                f"{wallet_name!r} [{local_fp}] moves inbound Lightning delivery "
+                f"away from the currently-bound wallet [{server_fp}], which will "
+                "stop receiving. This is destructive."
+            )
+
+        info = {
+            "email": email,
+            "ln_username": ln_username,
+            "wallet_name": wallet_name,
+            "state": state,
+            "current_fingerprint": server_fp,
+            "new_fingerprint": local_fp,
+        }
+        if not confirm:
+            return {**info, "requires_confirmation": True, "rebound": False, "warning": warning}
+
+        result = self.register_ln_addresses(
+            email,
+            wallet_name=wallet_name,
+            override_fingerprint=True,
+            profile=profile,
+        )
+        return {
+            **info,
+            "rebound": True,
+            "requires_confirmation": False,
+            "requested_count": result["requested_count"],
+            "pool_size": result["pool_size"],
+            "fingerprint": result["fingerprint"],
+        }
 
     def purchase_ln_username(
         self,

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1328,7 +1328,7 @@ TOOL_SCHEMAS = {
             "Verify the OTP emailed by jan3_login and persist the JAN3 session "
             "for that email (multi-account, 0o600). Ask the user for the 6-digit "
             "code from their email. The result's next_step cues you to offer the "
-            "user the Lightning Address opt-in (jan3_ln_address_toggle)."
+            "user the Lightning Address opt-in (jan3_enable_lightning_address)."
         ),
         "inputSchema": {
             "type": "object",
@@ -1387,7 +1387,7 @@ TOOL_SCHEMAS = {
             "tokens and saves the session to ~/.aqua/jan3/{email}.json (0o600). "
             "Only token previews are echoed back — never the full tokens. The "
             "result's next_step cues you to offer the user the Lightning Address "
-            "opt-in (jan3_ln_address_toggle)."
+            "opt-in (jan3_enable_lightning_address)."
         ),
         "inputSchema": {
             "type": "object",
@@ -1436,7 +1436,7 @@ TOOL_SCHEMAS = {
             "required": ["email"],
         },
     },
-    "jan3_get_user": {
+    "jan3_user_info": {
         "description": (
             "Get the AQUA account profile (email, ln_username, fingerprint, "
             "feature flags). The ln_username field is the user's full Lightning "
@@ -1464,7 +1464,7 @@ TOOL_SCHEMAS = {
             "required": ["email"],
         },
     },
-    "jan3_ln_address_toggle": {
+    "jan3_enable_lightning_address": {
         "description": (
             "Enable or disable the user's Lightning Address. Ask the user first: "
             "enabling means JAN3/AQUA delivers inbound Lightning payments to their "
@@ -1495,7 +1495,7 @@ TOOL_SCHEMAS = {
             "required": ["email", "enabled"],
         },
     },
-    "jan3_ln_username_check_available": {
+    "jan3_ln_check_username": {
         "description": (
             "Check whether a Lightning username is free before buying it. Call "
             "before jan3_purchase_ln_username to avoid paying L-BTC on a username "
@@ -1518,7 +1518,7 @@ TOOL_SCHEMAS = {
             "Purchase / update the Lightning username for a JAN3 account with an "
             "on-chain L-BTC payment. Creates a payment request, funds it with a "
             "signed L-BTC tx to AQUA's address, and submits it. Check availability "
-            "first with jan3_ln_username_check_available. Requires an active JAN3 "
+            "first with jan3_ln_check_username. Requires an active JAN3 "
             "session for the email (either login flow)."
         ),
         "inputSchema": {

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1549,13 +1549,16 @@ TOOL_SCHEMAS = {
             "Purchase / update the Lightning username for a JAN3 account with an "
             "on-chain payment (fund in L-BTC or USDt). TWO-STEP, do NOT pass "
             "confirm=true first: (1) call with confirm=false (default) to get a "
-            "price quote WITHOUT spending — it returns display_amount (already "
-            "formatted for the user, e.g. '2000 Sats' for L-BTC or '1.50 USDT' "
-            "for USDt), amount_base_units (technical), amount, asset_ticker and "
-            "expires_at; SHOW display_amount to the user and get explicit consent; "
-            "(2) only then call with confirm=true to sign and submit. When telling "
-            "the user the price, use display_amount verbatim — never surface the "
-            "raw amount/amount_base_units. Check availability first with "
+            "price quote WITHOUT spending — the server locks the price on that "
+            "order; it returns display_amount (already formatted for the user, "
+            "e.g. '2000 Sats' for L-BTC or '1.50 USDT' for USDt), "
+            "amount_base_units (technical), amount, asset_ticker, payment_id "
+            "and expires_at; SHOW display_amount to the user and get explicit "
+            "consent; (2) only then call with confirm=true — it funds exactly "
+            "the quoted order (same payment_id and amount) and errors if the "
+            "quote expired (re-quote and re-confirm). When telling the user "
+            "the price, use display_amount verbatim — never surface the raw "
+            "amount/amount_base_units. Check availability first with "
             "jan3_ln_check_username. Requires an active JAN3 session (either flow)."
         ),
         "inputSchema": {
@@ -1587,8 +1590,14 @@ TOOL_SCHEMAS = {
                     "type": "boolean",
                     "default": False,
                     "description": "False (default) returns a non-spending price "
-                    "quote; True signs and submits the payment. Only set True "
-                    "after the user approves the quoted display_amount.",
+                    "quote; True funds the previously quoted order. Only set "
+                    "True after the user approves the quoted display_amount.",
+                },
+                "expected_amount_base_units": {
+                    "type": "integer",
+                    "description": "With confirm=true and no prior quote, the "
+                    "amount_base_units the user approved; the purchase aborts "
+                    "(nothing spent) if the current price exceeds it.",
                 },
             },
             "required": ["email", "ln_username"],

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1498,6 +1498,44 @@ TOOL_SCHEMAS = {
             "required": ["email", "enabled"],
         },
     },
+    "jan3_rebind_wallet": {
+        "description": (
+            "Re-bind the account's Lightning Address to a different local wallet "
+            "(the only path that passes override_fingerprint). DESTRUCTIVE: it "
+            "moves inbound Lightning delivery to wallet_name and stops delivery to "
+            "the previously-bound wallet. Use when the account is bound to a wallet "
+            "you no longer have (new seed, old JAN3 account) or to switch which "
+            "wallet receives funds. TWO-STEP HANDSHAKE — do NOT pass confirm=true "
+            "first: (1) call with confirm=false to get a non-mutating preview "
+            "(ln_username, current_fingerprint->new_fingerprint, warning), SHOW the "
+            "warning and get explicit user consent; (2) only then call with "
+            "confirm=true to execute. The ln_username shown is the Lightning Address "
+            "(a user@domain), it isn't the account login email, never substitute one for the other."
+            "already_bound=true means it was a no-op. Requires a prior JAN3 login."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "JAN3 account email (identifies the account/session).",
+                },
+                "wallet_name": {
+                    "type": "string",
+                    "default": "default",
+                    "description": "Local Liquid wallet to bind LN delivery to.",
+                },
+                "confirm": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "False previews without mutating; True executes "
+                    "the re-bind (override). Only set True after explicit user consent.",
+                },
+            },
+            "required": ["email"],
+        },
+    },
     "jan3_ln_check_username": {
         "description": (
             "Check whether a Lightning username is free before buying it. Call "

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1327,7 +1327,8 @@ TOOL_SCHEMAS = {
         "description": (
             "Verify the OTP emailed by jan3_login and persist the JAN3 session "
             "for that email (multi-account, 0o600). Ask the user for the 6-digit "
-            "code from their email."
+            "code from their email. The result's next_step cues you to offer the "
+            "user the Lightning Address opt-in (jan3_ln_address_toggle)."
         ),
         "inputSchema": {
             "type": "object",
@@ -1384,7 +1385,9 @@ TOOL_SCHEMAS = {
         "description": (
             "Step 2 of the paid captchaless login. Exchanges the OTP for JWT "
             "tokens and saves the session to ~/.aqua/jan3/{email}.json (0o600). "
-            "Only token previews are echoed back — never the full tokens."
+            "Only token previews are echoed back — never the full tokens. The "
+            "result's next_step cues you to offer the user the Lightning Address "
+            "opt-in (jan3_ln_address_toggle)."
         ),
         "inputSchema": {
             "type": "object",
@@ -1431,6 +1434,117 @@ TOOL_SCHEMAS = {
                 "email": {"type": "string", "format": "email"},
             },
             "required": ["email"],
+        },
+    },
+    "jan3_get_user": {
+        "description": (
+            "Get the AQUA account profile (email, ln_username, fingerprint, "
+            "feature flags). The ln_username field is the user's full Lightning "
+            "Address as returned by the backend — surface it verbatim, never "
+            "append a domain. Carries the LN-address state (ln_address_toggled, "
+            "new_addresses_needed, fingerprint). When LN-address is active this "
+            "auto-tops-up the unused-address pool (best-effort, under "
+            "ln_address_pool). Requires a prior JAN3 login for the email."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "email": {"type": "string", "format": "email"},
+                "wallet_name": {
+                    "type": "string",
+                    "default": "default",
+                    "description": "Liquid wallet whose addresses back the LN-address pool.",
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Decrypts the wallet mnemonic if encrypted at rest "
+                    "(needed for the automatic pool top-up on encrypted wallets).",
+                },
+            },
+            "required": ["email"],
+        },
+    },
+    "jan3_ln_address_toggle": {
+        "description": (
+            "Enable or disable the user's Lightning Address. Ask the user first: "
+            "enabling means JAN3/AQUA delivers inbound Lightning payments to their "
+            "Lightning Address by handing out a batch of Liquid receive addresses "
+            "this tool registers (received BTC lands on those stored Liquid "
+            "addresses). On enable, the pool is populated immediately (best-effort, "
+            "under ln_address_pool); a no_ln_username result means the user must "
+            "run jan3_purchase_ln_username first. Requires a prior JAN3 login."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "email": {"type": "string", "format": "email"},
+                "enabled": {
+                    "type": "boolean",
+                    "description": "True to opt in (and populate the pool), False to opt out.",
+                },
+                "wallet_name": {
+                    "type": "string",
+                    "default": "default",
+                    "description": "Liquid wallet whose addresses back the pool.",
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Decrypts the wallet mnemonic if encrypted at rest.",
+                },
+            },
+            "required": ["email", "enabled"],
+        },
+    },
+    "jan3_ln_username_check_available": {
+        "description": (
+            "Check whether a Lightning username is free before buying it. Call "
+            "before jan3_purchase_ln_username to avoid paying L-BTC on a username "
+            "that's already taken. Requires an active JAN3 session for the email."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "email": {"type": "string", "format": "email"},
+                "ln_username": {
+                    "type": "string",
+                    "description": "Desired username (the local part, before the @domain).",
+                },
+            },
+            "required": ["email", "ln_username"],
+        },
+    },
+    "jan3_purchase_ln_username": {
+        "description": (
+            "Purchase / update the Lightning username for a JAN3 account with an "
+            "on-chain L-BTC payment. Creates a payment request, funds it with a "
+            "signed L-BTC tx to AQUA's address, and submits it. Check availability "
+            "first with jan3_ln_username_check_available. Requires an active JAN3 "
+            "session for the email (either login flow)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "email": {"type": "string", "format": "email"},
+                "ln_username": {
+                    "type": "string",
+                    "description": "Desired username (the local part, before the @domain).",
+                },
+                "wallet_name": {
+                    "type": "string",
+                    "default": "default",
+                    "description": "Liquid wallet used to fund the purchase.",
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Decrypts the wallet mnemonic if encrypted at rest.",
+                },
+                "asset": {
+                    "type": "string",
+                    "default": "L-BTC",
+                    "description": "Funding asset ticker.",
+                },
+            },
+            "required": ["email", "ln_username"],
         },
     },
 }

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -132,7 +132,10 @@ TOOL_SCHEMAS = {
                 },
                 "index": {
                     "type": "integer",
-                    "description": "Specific address index (optional)",
+                    "description": (
+                        "If index is omitted, returns the next unused receive address (idempotent). "
+                        "Specifying an index gets the address at that index. "
+                    ),
                 },
             },
         },

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1458,11 +1458,6 @@ TOOL_SCHEMAS = {
                     "default": "default",
                     "description": "Liquid wallet whose addresses back the LN-address pool.",
                 },
-                "password": {
-                    "type": "string",
-                    "description": "Decrypts the wallet mnemonic if encrypted at rest "
-                    "(needed for the automatic pool top-up on encrypted wallets).",
-                },
             },
             "required": ["email"],
         },
@@ -1489,10 +1484,6 @@ TOOL_SCHEMAS = {
                     "type": "string",
                     "default": "default",
                     "description": "Liquid wallet whose addresses back the pool.",
-                },
-                "password": {
-                    "type": "string",
-                    "description": "Decrypts the wallet mnemonic if encrypted at rest.",
                 },
             },
             "required": ["email", "enabled"],

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1469,8 +1469,7 @@ TOOL_SCHEMAS = {
             "Lightning Address by handing out a batch of Liquid receive addresses "
             "this tool registers (received BTC lands on those stored Liquid "
             "addresses). On enable, the pool is populated immediately (best-effort, "
-            "under ln_address_pool); a no_ln_username result means the user must "
-            "run jan3_purchase_ln_username first. Requires a prior JAN3 login."
+            "under ln_address_pool). Requires a prior JAN3 login."
         ),
         "inputSchema": {
             "type": "object",
@@ -1530,7 +1529,7 @@ TOOL_SCHEMAS = {
     "jan3_ln_check_username": {
         "description": (
             "Check whether a Lightning username is free before buying it. Call "
-            "before jan3_purchase_ln_username to avoid paying L-BTC on a username "
+            "before jan3_purchase_ln_username to avoid paying for a username "
             "that's already taken. Requires an active JAN3 session for the email."
         ),
         "inputSchema": {
@@ -1548,10 +1547,16 @@ TOOL_SCHEMAS = {
     "jan3_purchase_ln_username": {
         "description": (
             "Purchase / update the Lightning username for a JAN3 account with an "
-            "on-chain L-BTC payment. Creates a payment request, funds it with a "
-            "signed L-BTC tx to AQUA's address, and submits it. Check availability "
-            "first with jan3_ln_check_username. Requires an active JAN3 "
-            "session for the email (either login flow)."
+            "on-chain payment (fund in L-BTC or USDt). TWO-STEP, do NOT pass "
+            "confirm=true first: (1) call with confirm=false (default) to get a "
+            "price quote WITHOUT spending — it returns display_amount (already "
+            "formatted for the user, e.g. '2000 Sats' for L-BTC or '1.50 USDT' "
+            "for USDt), amount_base_units (technical), amount, asset_ticker and "
+            "expires_at; SHOW display_amount to the user and get explicit consent; "
+            "(2) only then call with confirm=true to sign and submit. When telling "
+            "the user the price, use display_amount verbatim — never surface the "
+            "raw amount/amount_base_units. Check availability first with "
+            "jan3_ln_check_username. Requires an active JAN3 session (either flow)."
         ),
         "inputSchema": {
             "type": "object",
@@ -1568,12 +1573,22 @@ TOOL_SCHEMAS = {
                 },
                 "password": {
                     "type": "string",
-                    "description": "Decrypts the wallet mnemonic if encrypted at rest.",
+                    "description": "Decrypts the wallet mnemonic if encrypted at rest "
+                    "(only needed when confirm=true).",
                 },
                 "asset": {
                     "type": "string",
                     "default": "L-BTC",
-                    "description": "Funding asset ticker.",
+                    "enum": ["L-BTC", "USDt"],
+                    "description": "Funding asset — 'L-BTC' or 'USDt'. Ask the user "
+                    "which they prefer; the price is quoted in that asset.",
+                },
+                "confirm": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "False (default) returns a non-spending price "
+                    "quote; True signs and submits the payment. Only set True "
+                    "after the user approves the quoted display_amount.",
                 },
             },
             "required": ["email", "ln_username"],

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -7,6 +7,8 @@ import os
 import re
 import shutil
 import sys
+import time
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field, fields, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -15,6 +17,11 @@ from typing import Optional
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
 
 logger = logging.getLogger(__name__)
 
@@ -72,16 +79,12 @@ class WalletData:
         data = {**data}
         data.setdefault("btc_descriptor", None)
         data.setdefault("btc_change_descriptor", None)
-        # The address counter used to be named ``ln_addr_next_index`` when it
-        # only tracked LN-address registrations. Migrate the legacy key in-place
-        # so existing wallets keep their burned-index history; it's dropped on
-        # the next save.
+        # Migrate the legacy ``ln_addr_next_index`` key so wallets keep their history.
         legacy = data.pop("ln_addr_next_index", None)
         if "next_address_index" not in data and legacy is not None:
             data["next_address_index"] = legacy
         data.setdefault("next_address_index", 0)
-        # Forward compatibility: drop any other unknown keys written by future
-        # branches so this branch can still load the wallet file.
+        # Forward compatibility: drop unknown keys written by future branches.
         known = {f.name for f in fields(cls)}
         data = {k: v for k, v in data.items() if k in known}
         return cls(**data)
@@ -360,6 +363,47 @@ class Storage:
         """Get path to wallet file."""
         _validate_wallet_name(name)
         return self.wallets_dir / f"{name}.json"
+
+    @contextmanager
+    def wallet_lock(self, name: str, timeout_seconds: float = 30.0):
+        """Cross-process exclusive lock for read-modify-write of a wallet record.
+
+        ``save_wallet`` is a last-writer-wins overwrite, so counter-advancing
+        writers must load-and-save while holding this lock to avoid two
+        processes handing out the same index. Raises ``TimeoutError`` on timeout.
+        """
+        _validate_wallet_name(name)
+        lock_path = self.wallets_dir / f"{name}.lock"
+        # "a" creates the file if missing without ever truncating it.
+        fh = open(lock_path, "a")
+        try:
+            deadline = time.monotonic() + timeout_seconds
+            while True:
+                try:
+                    if sys.platform == "win32":
+                        fh.seek(0)
+                        msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
+                    else:
+                        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            f"Could not lock wallet {name!r} within "
+                            f"{timeout_seconds:.0f}s — another aqua process "
+                            "is holding it."
+                        ) from None
+                    time.sleep(0.05)
+            try:
+                yield
+            finally:
+                if sys.platform == "win32":
+                    fh.seek(0)
+                    msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        finally:
+            fh.close()
 
     def wallet_exists(self, name: str) -> bool:
         """Check if wallet exists."""

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -58,6 +58,15 @@ class WalletData:
     encrypted_mnemonic: Optional[str] = None  # Encrypted, if full wallet
     watch_only: bool = False
     created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    # Monotonically-increasing counter of receive addresses handed out via
+    # ``WalletManager.get_address(name, index=None)`` / ``reserve_addresses``.
+    # lwk's "next-unused" tip only advances after the chain observes usage,
+    # which doesn't help for off-chain handouts (LN-address registration,
+    # Boltz claim addresses, …). Every no-arg ``get_address`` bumps this so two
+    # flows never share an address. Single-writer assumption: the MCP server
+    # handles one tool call at a time, so the load→compute→save dance in
+    # ``reserve_addresses`` is safe without a lock.
+    next_address_index: int = 0
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -68,9 +77,16 @@ class WalletData:
         data = {**data}
         data.setdefault("btc_descriptor", None)
         data.setdefault("btc_change_descriptor", None)
-        # Forward compatibility: drop unknown keys written by other branches
-        # (e.g. next_address_index from an in-flight PR) so this branch can
-        # still load the wallet file.
+        # The address counter used to be named ``ln_addr_next_index`` when it
+        # only tracked LN-address registrations. Migrate the legacy key in-place
+        # so existing wallets keep their burned-index history; it's dropped on
+        # the next save.
+        legacy = data.pop("ln_addr_next_index", None)
+        if "next_address_index" not in data and legacy is not None:
+            data["next_address_index"] = legacy
+        data.setdefault("next_address_index", 0)
+        # Forward compatibility: drop any other unknown keys written by future
+        # branches so this branch can still load the wallet file.
         known = {f.name for f in fields(cls)}
         data = {k: v for k, v in data.items() if k in known}
         return cls(**data)

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -58,14 +58,9 @@ class WalletData:
     encrypted_mnemonic: Optional[str] = None  # Encrypted, if full wallet
     watch_only: bool = False
     created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
-    # Monotonically-increasing counter of receive addresses handed out via
-    # ``WalletManager.get_address(name, index=None)`` / ``reserve_addresses``.
-    # lwk's "next-unused" tip only advances after the chain observes usage,
-    # which doesn't help for off-chain handouts (LN-address registration,
-    # Boltz claim addresses, …). Every no-arg ``get_address`` bumps this so two
-    # flows never share an address. Single-writer assumption: the MCP server
-    # handles one tool call at a time, so the load→compute→save dance in
-    # ``reserve_addresses`` is safe without a lock.
+    # Monotonically-increasing counter of handed-out receive addresses. Advances
+    # ahead of lwk's "next-unused" tip for off-chain handouts (LN-address pool,
+    # Boltz claims) so two flows never share an index.
     next_address_index: int = 0
 
     def to_dict(self) -> dict:

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -331,7 +331,10 @@ def lw_address(
 
     Args:
         wallet_name: Name of the wallet. Default: "default"
-        index: Specific address index. Default: next unused
+        index: Specify to get a particular address. 
+            If omitted, returns next unused address (read-only). 
+            Does not advance counter; repeated calls return same address.
+       
 
     Returns:
         address: The Liquid address
@@ -339,7 +342,7 @@ def lw_address(
         qr_code_path: Path to a PNG QR of the address (or qr_error on failure)
     """
     manager = get_manager()
-    addr = manager.get_address(wallet_name, index)
+    addr = manager.peek_address(wallet_name, index)
     return _attach_deposit_qr(addr.to_dict(), "address")
 
 

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -2293,15 +2293,14 @@ def jan3_purchase_ln_username(
     password: str | None = None,
     asset: str = "L-BTC",
     confirm: bool = False,
+    expected_amount_base_units: int | None = None,
 ) -> dict[str, Any]:
     """Purchase / update the Lightning username for a JAN3 account (on-chain).
 
-    Two-step so the user approves the price before any spend:
-
-    * ``confirm=False`` (default) returns a quote — ``requires_confirmation``,
-      ``display_amount`` (e.g. ``"2000 Sats"`` or ``"1.50 USDT"``),
-      ``amount_base_units``, ``amount``, ``expires_at`` — WITHOUT signing.
-    * ``confirm=True`` funds and submits the on-chain payment in ``asset``.
+    Two-step so the user approves the price before any spend: ``confirm=False``
+    (default) locks in a quote without signing; ``confirm=True`` funds that exact
+    quoted order, erroring if it expired. Without a prior quote it creates and
+    funds a fresh order, bounded by ``expected_amount_base_units`` when given.
 
     Args:
         email: the JAN3 account email.
@@ -2310,12 +2309,11 @@ def jan3_purchase_ln_username(
         password: decrypts the wallet mnemonic if encrypted at rest (confirm only).
         asset: funding asset ticker — "L-BTC" or "USDt" (default L-BTC).
         confirm: False previews the price; True pays.
+        expected_amount_base_units: ceiling on confirm=True when there's no prior quote.
 
     Returns:
-        Quote (confirm=False): requires_confirmation, ln_username, asset_ticker,
-        amount_base_units, amount, display_amount, expires_at, address, message.
-        Receipt (confirm=True): payment_id, status, txid, plus the same amount
-        fields.
+        Quote (confirm=False): display_amount, amount_base_units, payment_id, expires_at.
+        Receipt (confirm=True): payment_id, status, txid.
     """
     return get_jan3_manager().purchase_ln_username(
         email,
@@ -2324,6 +2322,7 @@ def jan3_purchase_ln_username(
         password=password,
         asset=asset,
         confirm=confirm,
+        expected_amount_base_units=expected_amount_base_units,
     )
 
 

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -2124,7 +2124,7 @@ def jan3_verify(
     Returns:
         email, logged_in, captcha_exempt (False for this free flow), message,
         access_token_preview, and next_step — which cues you to offer the user
-        the Lightning Address opt-in (jan3_ln_address_toggle).
+        the Lightning Address opt-in (jan3_enable_lightning_address).
     """
     return get_jan3_manager().verify(
         email, otp_code, fingerprint=fingerprint, captcha_exempt=False
@@ -2180,7 +2180,7 @@ def jan3_login_complete(
     Returns:
         email, logged_in, captcha_exempt (True for this paid flow), message,
         access_token_preview, and next_step — which cues you to offer the user
-        the Lightning Address opt-in (jan3_ln_address_toggle). Full tokens are
+        the Lightning Address opt-in (jan3_enable_lightning_address). Full tokens are
         NEVER echoed.
     """
     return get_jan3_manager().verify(
@@ -2218,7 +2218,7 @@ def jan3_logout(email: str) -> dict[str, Any]:
     return get_jan3_manager().logout(email)
 
 
-def jan3_get_user(
+def jan3_user_info(
     email: str,
     wallet_name: str = "default",
     password: str | None = None,
@@ -2246,7 +2246,7 @@ def jan3_get_user(
     )
 
 
-def jan3_ln_address_toggle(
+def jan3_enable_lightning_address(
     email: str,
     enabled: bool,
     wallet_name: str = "default",
@@ -2272,7 +2272,7 @@ def jan3_ln_address_toggle(
     )
 
 
-def jan3_ln_username_check_available(email: str, ln_username: str) -> dict[str, Any]:
+def jan3_ln_check_username(email: str, ln_username: str) -> dict[str, Any]:
     """Check whether a Lightning username is free before buying it.
 
     Call before `jan3_purchase_ln_username` to avoid paying L-BTC on a username
@@ -2296,7 +2296,7 @@ def jan3_purchase_ln_username(
 
     Creates an LN_USERNAME_UPDATE payment request, funds it with a signed L-BTC
     tx to AQUA's address, and submits it. Check availability first with
-    `jan3_ln_username_check_available`. Requires an active JAN3 session for
+    `jan3_ln_check_username`. Requires an active JAN3 session for
     `email` (either login flow).
 
     Args:
@@ -2388,9 +2388,9 @@ TOOLS = {
     "jan3_session_info": jan3_session_info,
     "jan3_list_sessions": jan3_list_sessions,
     "jan3_logout": jan3_logout,
-    "jan3_get_user": jan3_get_user,
-    "jan3_ln_address_toggle": jan3_ln_address_toggle,
-    "jan3_ln_username_check_available": jan3_ln_username_check_available,
+    "jan3_user_info": jan3_user_info,
+    "jan3_enable_lightning_address": jan3_enable_lightning_address,
+    "jan3_ln_check_username": jan3_ln_check_username,
     "jan3_purchase_ln_username": jan3_purchase_ln_username,
     "qr_decode": qr_decode,
 }

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -2123,7 +2123,8 @@ def jan3_verify(
 
     Returns:
         email, logged_in, captcha_exempt (False for this free flow), message,
-        access_token_preview.
+        access_token_preview, and next_step — which cues you to offer the user
+        the Lightning Address opt-in (jan3_ln_address_toggle).
     """
     return get_jan3_manager().verify(
         email, otp_code, fingerprint=fingerprint, captcha_exempt=False
@@ -2178,7 +2179,9 @@ def jan3_login_complete(
 
     Returns:
         email, logged_in, captcha_exempt (True for this paid flow), message,
-        access_token_preview. Full tokens are NEVER echoed.
+        access_token_preview, and next_step — which cues you to offer the user
+        the Lightning Address opt-in (jan3_ln_address_toggle). Full tokens are
+        NEVER echoed.
     """
     return get_jan3_manager().verify(
         email, otp_code, fingerprint=fingerprint, captcha_exempt=True
@@ -2213,6 +2216,107 @@ def jan3_list_sessions() -> dict[str, Any]:
 def jan3_logout(email: str) -> dict[str, Any]:
     """Delete the persisted JAN3 session for `email`. Idempotent."""
     return get_jan3_manager().logout(email)
+
+
+def jan3_get_user(
+    email: str,
+    wallet_name: str = "default",
+    password: str | None = None,
+) -> dict[str, Any]:
+    """Get the AQUA account profile for `email` (Lightning Address status included).
+
+    The `ln_username` field is the user's full Lightning Address as returned by
+    the backend — surface it verbatim, never append a domain. Also carries the
+    state the LN-address feature depends on: `ln_address_toggled`,
+    `new_addresses_needed`, and the server-side wallet `fingerprint`.
+
+    When LN-address is active this call automatically tops up the pool of unused
+    Liquid receive addresses the backend needs to deliver inbound Lightning
+    payments (best-effort — reported under `ln_address_pool`, never fails the
+    read). Requires a prior `jan3_login`+`jan3_verify` (or the captchaless flow).
+
+    Args:
+        email: the JAN3 account email.
+        wallet_name: Liquid wallet whose addresses back the LN-address pool.
+        password: decrypts the wallet mnemonic if encrypted at rest (needed for
+            the automatic pool top-up on encrypted wallets).
+    """
+    return get_jan3_manager().get_user(
+        email, wallet_name=wallet_name, password=password
+    )
+
+
+def jan3_ln_address_toggle(
+    email: str,
+    enabled: bool,
+    wallet_name: str = "default",
+    password: str | None = None,
+) -> dict[str, Any]:
+    """Enable or disable the user's Lightning Address for `email`.
+
+    Ask the user first: enabling means JAN3/AQUA will deliver inbound Lightning
+    payments to their Lightning Address by handing out a batch of Liquid receive
+    addresses that this tool registers on their behalf (the received BTC lands on
+    those stored Liquid addresses). On enable, the address pool is populated
+    immediately (best-effort, reported under `ln_address_pool`). A `no_ln_username`
+    result means they must run `jan3_purchase_ln_username` first.
+
+    Args:
+        email: the JAN3 account email.
+        enabled: True to opt in (and populate the pool), False to opt out.
+        wallet_name: Liquid wallet whose addresses back the pool.
+        password: decrypts the wallet mnemonic if encrypted at rest.
+    """
+    return get_jan3_manager().ln_address_toggle(
+        email, enabled, wallet_name=wallet_name, password=password
+    )
+
+
+def jan3_ln_username_check_available(email: str, ln_username: str) -> dict[str, Any]:
+    """Check whether a Lightning username is free before buying it.
+
+    Call before `jan3_purchase_ln_username` to avoid paying L-BTC on a username
+    that's already taken. Requires an active JAN3 session for `email`.
+
+    Args:
+        email: the JAN3 account email (session used to authenticate the check).
+        ln_username: the desired username (local part, before the @domain).
+    """
+    return get_jan3_manager().ln_username_available(email, ln_username)
+
+
+def jan3_purchase_ln_username(
+    email: str,
+    ln_username: str,
+    wallet_name: str = "default",
+    password: str | None = None,
+    asset: str = "L-BTC",
+) -> dict[str, Any]:
+    """Purchase / update the Lightning username for a JAN3 account (on-chain L-BTC).
+
+    Creates an LN_USERNAME_UPDATE payment request, funds it with a signed L-BTC
+    tx to AQUA's address, and submits it. Check availability first with
+    `jan3_ln_username_check_available`. Requires an active JAN3 session for
+    `email` (either login flow).
+
+    Args:
+        email: the JAN3 account email.
+        ln_username: the desired username (local part, before the @domain).
+        wallet_name: Liquid wallet used to fund the purchase.
+        password: decrypts the wallet mnemonic if encrypted at rest.
+        asset: funding asset ticker (default L-BTC).
+
+    Returns:
+        payment_id, status, txid, ln_username, amount_sats, asset_ticker,
+        address, message.
+    """
+    return get_jan3_manager().purchase_ln_username(
+        email,
+        ln_username,
+        wallet_name=wallet_name,
+        password=password,
+        asset=asset,
+    )
 
 
 # Tool registry for MCP
@@ -2284,5 +2388,9 @@ TOOLS = {
     "jan3_session_info": jan3_session_info,
     "jan3_list_sessions": jan3_list_sessions,
     "jan3_logout": jan3_logout,
+    "jan3_get_user": jan3_get_user,
+    "jan3_ln_address_toggle": jan3_ln_address_toggle,
+    "jan3_ln_username_check_available": jan3_ln_username_check_available,
+    "jan3_purchase_ln_username": jan3_purchase_ln_username,
     "qr_decode": qr_decode,
 }

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -331,10 +331,7 @@ def lw_address(
 
     Args:
         wallet_name: Name of the wallet. Default: "default"
-        index: Specify to get a particular address. 
-            If omitted, returns next unused address (read-only). 
-            Does not advance counter; repeated calls return same address.
-       
+        index: Address index. If omitted, returns next unused address (read-only, idempotent).
 
     Returns:
         address: The Liquid address
@@ -2224,54 +2221,38 @@ def jan3_logout(email: str) -> dict[str, Any]:
 def jan3_user_info(
     email: str,
     wallet_name: str = "default",
-    password: str | None = None,
 ) -> dict[str, Any]:
     """Get the AQUA account profile for `email` (Lightning Address status included).
 
-    The `ln_username` field is the user's full Lightning Address as returned by
-    the backend — surface it verbatim, never append a domain. Also carries the
-    state the LN-address feature depends on: `ln_address_toggled`,
-    `new_addresses_needed`, and the server-side wallet `fingerprint`.
-
-    When LN-address is active this call automatically tops up the pool of unused
-    Liquid receive addresses the backend needs to deliver inbound Lightning
-    payments (best-effort — reported under `ln_address_pool`, never fails the
-    read). Requires a prior `jan3_login`+`jan3_verify` (or the captchaless flow).
+    ``ln_username`` is the full Lightning Address verbatim from the backend.
+    Auto-tops-up the LN-address pool when active (result under ``ln_address_pool``).
+    The top-up derives Liquid addresses from the wallet descriptor, so no password
+    is needed even for a wallet encrypted at rest.
 
     Args:
         email: the JAN3 account email.
         wallet_name: Liquid wallet whose addresses back the LN-address pool.
-        password: decrypts the wallet mnemonic if encrypted at rest (needed for
-            the automatic pool top-up on encrypted wallets).
     """
-    return get_jan3_manager().get_user(
-        email, wallet_name=wallet_name, password=password
-    )
+    return get_jan3_manager().get_user(email, wallet_name=wallet_name)
 
 
 def jan3_enable_lightning_address(
     email: str,
     enabled: bool,
     wallet_name: str = "default",
-    password: str | None = None,
 ) -> dict[str, Any]:
     """Enable or disable the user's Lightning Address for `email`.
 
-    Ask the user first: enabling means JAN3/AQUA will deliver inbound Lightning
-    payments to their Lightning Address by handing out a batch of Liquid receive
-    addresses that this tool registers on their behalf (the received BTC lands on
-    those stored Liquid addresses). On enable, the address pool is populated
-    immediately (best-effort, reported under `ln_address_pool`). A `no_ln_username`
-    result means they must run `jan3_purchase_ln_username` first.
+    On enable, registers Liquid receive addresses and populates the pool
+    (result under ``ln_address_pool``). Addresses are derived from the wallet descriptor.
 
     Args:
         email: the JAN3 account email.
         enabled: True to opt in (and populate the pool), False to opt out.
         wallet_name: Liquid wallet whose addresses back the pool.
-        password: decrypts the wallet mnemonic if encrypted at rest.
     """
     return get_jan3_manager().ln_address_toggle(
-        email, enabled, wallet_name=wallet_name, password=password
+        email, enabled, wallet_name=wallet_name
     )
 
 
@@ -2280,20 +2261,10 @@ def jan3_rebind_wallet(
     wallet_name: str = "default",
     confirm: bool = False,
 ) -> dict[str, Any]:
-    """Re-bind the account's Lightning Address to a different local wallet.
+    """Re-bind Lightning Address delivery to a different local wallet (DESTRUCTIVE).
 
-    Two-step handshake — DO NOT pass confirm=true on the first call:
-      1. Call with `confirm` omitted/false to get a non-mutating PREVIEW. It
-         returns the Lightning Address (`ln_username`), the `current_fingerprint`
-         → `new_fingerprint`, and a `warning`. SHOW that warning to the user and
-         obtain explicit consent.
-      2. Only after the user confirms, call again with `confirm=true` to execute.
-
-    The Lightning Address shown (`ln_username`, a full user@domain) is NOT the
-    JAN3 account login `email` — never substitute one for the other. If the
-    account is already bound to this wallet the call is a harmless no-op
-    (`already_bound`); if no wallet was bound yet it is a first bind (not
-    destructive). Requires a prior JAN3 login for `email`.
+    Two-step: ``confirm=False`` returns a preview (``ln_username``, fingerprint diff,
+    ``warning``); ``confirm=True`` executes after user consent.
 
     Args:
         email: the JAN3 account email (identifies the account/session).
@@ -2307,9 +2278,6 @@ def jan3_rebind_wallet(
 
 def jan3_ln_check_username(email: str, ln_username: str) -> dict[str, Any]:
     """Check whether a Lightning username is free before buying it.
-
-    Call before `jan3_purchase_ln_username` to avoid paying L-BTC on a username
-    that's already taken. Requires an active JAN3 session for `email`.
 
     Args:
         email: the JAN3 account email (session used to authenticate the check).
@@ -2326,11 +2294,6 @@ def jan3_purchase_ln_username(
     asset: str = "L-BTC",
 ) -> dict[str, Any]:
     """Purchase / update the Lightning username for a JAN3 account (on-chain L-BTC).
-
-    Creates an LN_USERNAME_UPDATE payment request, funds it with a signed L-BTC
-    tx to AQUA's address, and submits it. Check availability first with
-    `jan3_ln_check_username`. Requires an active JAN3 session for
-    `email` (either login flow).
 
     Args:
         email: the JAN3 account email.

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -2292,19 +2292,30 @@ def jan3_purchase_ln_username(
     wallet_name: str = "default",
     password: str | None = None,
     asset: str = "L-BTC",
+    confirm: bool = False,
 ) -> dict[str, Any]:
-    """Purchase / update the Lightning username for a JAN3 account (on-chain L-BTC).
+    """Purchase / update the Lightning username for a JAN3 account (on-chain).
+
+    Two-step so the user approves the price before any spend:
+
+    * ``confirm=False`` (default) returns a quote — ``requires_confirmation``,
+      ``display_amount`` (e.g. ``"2000 Sats"`` or ``"1.50 USDT"``),
+      ``amount_base_units``, ``amount``, ``expires_at`` — WITHOUT signing.
+    * ``confirm=True`` funds and submits the on-chain payment in ``asset``.
 
     Args:
         email: the JAN3 account email.
         ln_username: the desired username (local part, before the @domain).
         wallet_name: Liquid wallet used to fund the purchase.
-        password: decrypts the wallet mnemonic if encrypted at rest.
-        asset: funding asset ticker (default L-BTC).
+        password: decrypts the wallet mnemonic if encrypted at rest (confirm only).
+        asset: funding asset ticker — "L-BTC" or "USDt" (default L-BTC).
+        confirm: False previews the price; True pays.
 
     Returns:
-        payment_id, status, txid, ln_username, amount_sats, asset_ticker,
-        address, message.
+        Quote (confirm=False): requires_confirmation, ln_username, asset_ticker,
+        amount_base_units, amount, display_amount, expires_at, address, message.
+        Receipt (confirm=True): payment_id, status, txid, plus the same amount
+        fields.
     """
     return get_jan3_manager().purchase_ln_username(
         email,
@@ -2312,6 +2323,7 @@ def jan3_purchase_ln_username(
         wallet_name=wallet_name,
         password=password,
         asset=asset,
+        confirm=confirm,
     )
 
 

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -2275,6 +2275,36 @@ def jan3_enable_lightning_address(
     )
 
 
+def jan3_rebind_wallet(
+    email: str,
+    wallet_name: str = "default",
+    confirm: bool = False,
+) -> dict[str, Any]:
+    """Re-bind the account's Lightning Address to a different local wallet.
+
+    Two-step handshake — DO NOT pass confirm=true on the first call:
+      1. Call with `confirm` omitted/false to get a non-mutating PREVIEW. It
+         returns the Lightning Address (`ln_username`), the `current_fingerprint`
+         → `new_fingerprint`, and a `warning`. SHOW that warning to the user and
+         obtain explicit consent.
+      2. Only after the user confirms, call again with `confirm=true` to execute.
+
+    The Lightning Address shown (`ln_username`, a full user@domain) is NOT the
+    JAN3 account login `email` — never substitute one for the other. If the
+    account is already bound to this wallet the call is a harmless no-op
+    (`already_bound`); if no wallet was bound yet it is a first bind (not
+    destructive). Requires a prior JAN3 login for `email`.
+
+    Args:
+        email: the JAN3 account email (identifies the account/session).
+        wallet_name: the local Liquid wallet to bind delivery to.
+        confirm: False (default) previews without mutating; True executes.
+    """
+    return get_jan3_manager().rebind_wallet(
+        email, wallet_name=wallet_name, confirm=confirm
+    )
+
+
 def jan3_ln_check_username(email: str, ln_username: str) -> dict[str, Any]:
     """Check whether a Lightning username is free before buying it.
 
@@ -2393,6 +2423,7 @@ TOOLS = {
     "jan3_logout": jan3_logout,
     "jan3_user_info": jan3_user_info,
     "jan3_enable_lightning_address": jan3_enable_lightning_address,
+    "jan3_rebind_wallet": jan3_rebind_wallet,
     "jan3_ln_check_username": jan3_ln_check_username,
     "jan3_purchase_ln_username": jan3_purchase_ln_username,
     "qr_decode": qr_decode,

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -209,17 +209,9 @@ class WalletManager:
         return self._wollets[wallet_name]
 
     def sync_wallet(self, wallet_name: str):
-        """Sync wallet with blockchain.
+        """Sync wallet via full_scan_to_index(next_address_index + 1).
 
-        Scans up to wallet's next_address_index using lwk's full_scan_to_index, not the default full_scan.
-        This ensures all handed-out addresses (including off-chain usage) are checked for funds, beyond gap limit.
-        Prevents missing incoming funds to any address advanced off-chain and saved in next_address_index.
-        Using full_scan_to_index never scans less than default, only equal or more as needed.
-
-        Scans wallet addresses up to next_address_index + 1 to ensure all shown or handed-out addresses are covered.
-        Prevents missing funds on newly generated frontier addresses.
-        This covers all committed handouts and avoids gap limit issues.
-        Ensures no incoming funds fall outside the scan window, regardless of inclusivity rules.
+        Covers off-chain handed-out addresses that lwk's default gap limit would miss.
         """
         wallet = self.storage.load_wallet(wallet_name)
         if not wallet:
@@ -278,23 +270,9 @@ class WalletManager:
     ) -> Address:
         """Get a receive address.
 
-        With no ``index``, hands out the next previously-unhanded-out address
-        and bumps the wallet's persisted ``next_address_index`` counter so two
-        flows never share an address. lwk's own "next-unused" tip only advances
-        after the chain observes usage, which is too slow for off-chain
-        handouts (LN-address registration, Boltz claim addresses, …) — so we
-        max it against our own counter.
-
-        With an explicit ``index``, returns that exact address without
-        advancing the counter. Callers asserting a specific index are assumed
-        to know what they're doing.
-
-        Note: the no-arg path is NOT idempotent — each call writes to disk and
-        consumes an index. This is the right behavior for callers that COMMIT
-        the address to an external party (swap refund/settle, LN-address pool),
-        which must never be reused. For a pure "show me my address" display that
-        should stay idempotent and not grow the counter, use
-        :meth:`peek_address` instead.
+        No-arg advances ``next_address_index`` (not idempotent — commits an
+        index). Explicit ``index`` returns it without advancing. For display,
+        use :meth:`peek_address`.
         """
         if index is None:
             # The load → max(lwk_tip, counter) → derive → advance → save
@@ -309,12 +287,9 @@ class WalletManager:
         wallet_name: str,
         count: int,
     ) -> list[Address]:
-        """Hand out ``count`` fresh receive addresses in one shot.
+        """Hand out ``count`` fresh receive addresses, advancing the persisted counter in one save.
 
-        Same semantics as calling ``get_address(name)`` ``count`` times — each
-        address is distinct and the persisted counter is advanced past all of
-        them — but batched into a single load + save of the wallet record. Use
-        when minting many addresses at once (e.g. for LN-address registration).
+        Batched equivalent of calling ``get_address`` ``count`` times.
         """
         if count <= 0:
             raise ValueError("count must be positive")
@@ -337,9 +312,9 @@ class WalletManager:
         wallet_name: str,
         index: Optional[int] = None,
     ) -> Address:
-        """Return a receive address for display, without advancing the counter or saving state.
-        Without ``index``, returns the next unused address. With ``index``, returns that address.
-        Never returns an address already handed out. Does not write to disk or advance the index.
+        """Return a receive address for display without advancing the counter or writing to disk.
+
+        Without ``index``, returns the frontier (max of lwk tip and ``next_address_index``).
         """
 
         wollet = self._get_wollet(wallet_name)
@@ -361,19 +336,13 @@ class WalletManager:
     ) -> str:
         """Return the BIP32 master fingerprint (8 hex chars) for ``wallet_name``.
 
-        Format matches the AQUA Ankara backend's ``fingerprint`` field on
-        ``UserResponse`` / ``UserLiquidAddressesUpsert``: ``HASH160(master xpub)[:4]``
-        in hex. For hot wallets this comes straight from the LWK signer; for
-        watch-only wallets we parse the embedded ``[fp/derivation]`` block from
-        the stored descriptor.
+        Hot wallets: from the LWK signer. Watch-only: parsed from the
+        ``[fp/derivation]`` block in the descriptor.
         """
         if wallet_name in self._signers:
             return self._signers[wallet_name].fingerprint()
 
-        # ``load_wallet`` decrypts the mnemonic (if needed) and caches the
-        # resulting lwk.Signer in ``self._signers`` as a side effect — so for
-        # hot wallets the next check succeeds and we get the canonical
-        # BIP32-master fingerprint straight from the signer.
+        # Decrypts and caches the signer in self._signers as a side effect.
         wallet = self.load_wallet(wallet_name, password=password)
         if wallet_name in self._signers:
             return self._signers[wallet_name].fingerprint()

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -209,14 +209,25 @@ class WalletManager:
         return self._wollets[wallet_name]
 
     def sync_wallet(self, wallet_name: str):
-        """Sync wallet with blockchain."""
+        """Sync wallet with blockchain.
+
+        Scans up to wallet's next_address_index using lwk's full_scan_to_index, not the default full_scan.
+        This ensures all handed-out addresses (including off-chain usage) are checked for funds, beyond gap limit.
+        Prevents missing incoming funds to any address advanced off-chain and saved in next_address_index.
+        Using full_scan_to_index never scans less than default, only equal or more as needed.
+
+        Scans wallet addresses up to next_address_index + 1 to ensure all shown or handed-out addresses are covered.
+        Prevents missing funds on newly generated frontier addresses.
+        This covers all committed handouts and avoids gap limit issues.
+        Ensures no incoming funds fall outside the scan window, regardless of inclusivity rules.
+        """
         wallet = self.storage.load_wallet(wallet_name)
         if not wallet:
             raise ValueError(f"Wallet '{wallet_name}' not found")
 
         wollet = self._get_wollet(wallet_name)
         client = self._get_client(wallet.network)
-        update = client.full_scan(wollet)
+        update = client.full_scan_to_index(wollet, wallet.next_address_index + 1)
         if update:
             wollet.apply_update(update)
 
@@ -279,8 +290,11 @@ class WalletManager:
         to know what they're doing.
 
         Note: the no-arg path is NOT idempotent — each call writes to disk and
-        consumes an index. Callers that need to peek without committing should
-        pass an explicit ``index``.
+        consumes an index. This is the right behavior for callers that COMMIT
+        the address to an external party (swap refund/settle, LN-address pool),
+        which must never be reused. For a pure "show me my address" display that
+        should stay idempotent and not grow the counter, use
+        :meth:`peek_address` instead.
         """
         if index is None:
             # The load → max(lwk_tip, counter) → derive → advance → save
@@ -317,6 +331,28 @@ class WalletManager:
         wallet_record.next_address_index = start + count
         self.storage.save_wallet(wallet_record)
         return addresses
+
+    def peek_address(
+        self,
+        wallet_name: str,
+        index: Optional[int] = None,
+    ) -> Address:
+        """Return a receive address for display, without advancing the counter or saving state.
+        Without ``index``, returns the next unused address. With ``index``, returns that address.
+        Never returns an address already handed out. Does not write to disk or advance the index.
+        """
+
+        wollet = self._get_wollet(wallet_name)
+        if index is not None:
+            addr = wollet.address(index)
+            return Address(address=str(addr.address()), index=addr.index())
+        wallet_record = self.storage.load_wallet(wallet_name)
+        if wallet_record is None:
+            raise ValueError(f"Wallet {wallet_name!r} not found")
+        lwk_tip = wollet.address(None).index()
+        frontier = max(lwk_tip, wallet_record.next_address_index)
+        addr = wollet.address(frontier)
+        return Address(address=str(addr.address()), index=addr.index())
 
     def fingerprint(
         self,

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -1,5 +1,6 @@
 """Wallet management using LWK."""
 
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
@@ -7,6 +8,8 @@ import lwk
 
 from .assets import lookup_asset, resolve_asset_name
 from .storage import Storage, WalletData
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -270,13 +273,11 @@ class WalletManager:
     ) -> Address:
         """Get a receive address.
 
-        No-arg advances ``next_address_index`` (not idempotent — commits an
-        index). Explicit ``index`` returns it without advancing. For display,
-        use :meth:`peek_address`.
+        No-arg advances ``next_address_index`` (not idempotent). Explicit
+        ``index`` returns it without advancing; for display use :meth:`peek_address`.
         """
         if index is None:
-            # The load → max(lwk_tip, counter) → derive → advance → save
-            # sequence lives once, in reserve_addresses.
+            # The load/derive/advance/save sequence lives once, in reserve_addresses.
             return self.reserve_addresses(wallet_name, 1)[0]
         wollet = self._get_wollet(wallet_name)
         addr = wollet.address(index)
@@ -294,18 +295,61 @@ class WalletManager:
         if count <= 0:
             raise ValueError("count must be positive")
         wollet = self._get_wollet(wallet_name)
-        wallet_record = self.storage.load_wallet(wallet_name)
-        if wallet_record is None:
-            raise ValueError(f"Wallet {wallet_name!r} not found")
-        lwk_tip = wollet.address(None).index()
-        start = max(lwk_tip, wallet_record.next_address_index)
-        addresses: list[Address] = []
-        for offset in range(count):
-            addr = wollet.address(start + offset)
-            addresses.append(Address(address=str(addr.address()), index=addr.index()))
-        wallet_record.next_address_index = start + count
-        self.storage.save_wallet(wallet_record)
+        # Hold the cross-process lock so two writers can't hand out the same index.
+        with self.storage.wallet_lock(wallet_name):
+            wallet_record = self.storage.load_wallet(wallet_name)
+            if wallet_record is None:
+                raise ValueError(f"Wallet {wallet_name!r} not found")
+            lwk_tip = wollet.address(None).index()
+            start = max(lwk_tip, wallet_record.next_address_index)
+            addresses: list[Address] = []
+            for offset in range(count):
+                addr = wollet.address(start + offset)
+                addresses.append(
+                    Address(address=str(addr.address()), index=addr.index())
+                )
+            wallet_record.next_address_index = start + count
+            self.storage.save_wallet(wallet_record)
         return addresses
+
+    def ensure_counter_covers(
+        self,
+        wallet_name: str,
+        addresses: list[str],
+    ) -> int:
+        """Bump ``next_address_index`` past any of ``addresses`` this wallet derives.
+
+        Best-effort repair for a reset counter (e.g. seed reimport) so the frontier
+        never re-hands out indices the server already delivered to.
+        """
+        targets = set(addresses)
+        wollet = self._get_wollet(wallet_name)
+        with self.storage.wallet_lock(wallet_name):
+            wallet_record = self.storage.load_wallet(wallet_name)
+            if wallet_record is None:
+                raise ValueError(f"Wallet {wallet_name!r} not found")
+            if not targets:
+                return wallet_record.next_address_index
+            lwk_tip = wollet.address(None).index()
+            frontier = max(lwk_tip, wallet_record.next_address_index)
+            # Server-side pool batches are capped, so matches sit within a modest window.
+            horizon = frontier + 100
+            max_matched = -1
+            for i in range(horizon):
+                if str(wollet.address(i).address()) in targets:
+                    max_matched = i
+            if max_matched + 1 > wallet_record.next_address_index:
+                logger.info(
+                    "Wallet %r: advancing next_address_index %d -> %d to cover "
+                    "server-known pool addresses (counter was behind, e.g. "
+                    "after a seed reimport).",
+                    wallet_name,
+                    wallet_record.next_address_index,
+                    max_matched + 1,
+                )
+                wallet_record.next_address_index = max_matched + 1
+                self.storage.save_wallet(wallet_record)
+            return wallet_record.next_address_index
 
     def peek_address(
         self,

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -265,13 +265,94 @@ class WalletManager:
         wallet_name: str,
         index: Optional[int] = None,
     ) -> Address:
-        """Get receive address."""
+        """Get a receive address.
+
+        With no ``index``, hands out the next previously-unhanded-out address
+        and bumps the wallet's persisted ``next_address_index`` counter so two
+        flows never share an address. lwk's own "next-unused" tip only advances
+        after the chain observes usage, which is too slow for off-chain
+        handouts (LN-address registration, Boltz claim addresses, …) — so we
+        max it against our own counter.
+
+        With an explicit ``index``, returns that exact address without
+        advancing the counter. Callers asserting a specific index are assumed
+        to know what they're doing.
+
+        Note: the no-arg path is NOT idempotent — each call writes to disk and
+        consumes an index. Callers that need to peek without committing should
+        pass an explicit ``index``.
+        """
+        if index is None:
+            # The load → max(lwk_tip, counter) → derive → advance → save
+            # sequence lives once, in reserve_addresses.
+            return self.reserve_addresses(wallet_name, 1)[0]
         wollet = self._get_wollet(wallet_name)
         addr = wollet.address(index)
-        return Address(
-            address=str(addr.address()),
-            index=addr.index(),
-        )
+        return Address(address=str(addr.address()), index=addr.index())
+
+    def reserve_addresses(
+        self,
+        wallet_name: str,
+        count: int,
+    ) -> list[Address]:
+        """Hand out ``count`` fresh receive addresses in one shot.
+
+        Same semantics as calling ``get_address(name)`` ``count`` times — each
+        address is distinct and the persisted counter is advanced past all of
+        them — but batched into a single load + save of the wallet record. Use
+        when minting many addresses at once (e.g. for LN-address registration).
+        """
+        if count <= 0:
+            raise ValueError("count must be positive")
+        wollet = self._get_wollet(wallet_name)
+        wallet_record = self.storage.load_wallet(wallet_name)
+        if wallet_record is None:
+            raise ValueError(f"Wallet {wallet_name!r} not found")
+        lwk_tip = wollet.address(None).index()
+        start = max(lwk_tip, wallet_record.next_address_index)
+        addresses: list[Address] = []
+        for offset in range(count):
+            addr = wollet.address(start + offset)
+            addresses.append(Address(address=str(addr.address()), index=addr.index()))
+        wallet_record.next_address_index = start + count
+        self.storage.save_wallet(wallet_record)
+        return addresses
+
+    def fingerprint(
+        self,
+        wallet_name: str,
+        password: Optional[str] = None,
+    ) -> str:
+        """Return the BIP32 master fingerprint (8 hex chars) for ``wallet_name``.
+
+        Format matches the AQUA Ankara backend's ``fingerprint`` field on
+        ``UserResponse`` / ``UserLiquidAddressesUpsert``: ``HASH160(master xpub)[:4]``
+        in hex. For hot wallets this comes straight from the LWK signer; for
+        watch-only wallets we parse the embedded ``[fp/derivation]`` block from
+        the stored descriptor.
+        """
+        if wallet_name in self._signers:
+            return self._signers[wallet_name].fingerprint()
+
+        # ``load_wallet`` decrypts the mnemonic (if needed) and caches the
+        # resulting lwk.Signer in ``self._signers`` as a side effect — so for
+        # hot wallets the next check succeeds and we get the canonical
+        # BIP32-master fingerprint straight from the signer.
+        wallet = self.load_wallet(wallet_name, password=password)
+        if wallet_name in self._signers:
+            return self._signers[wallet_name].fingerprint()
+
+        # Watch-only: best-effort parse of the [fp/derivation]xpub block.
+        from .bitcoin import _extract_xpub_metadata
+
+        meta = _extract_xpub_metadata(wallet.descriptor)
+        fp = meta.get("fingerprint")
+        if not fp:
+            raise ValueError(
+                f"Cannot determine fingerprint for watch-only wallet {wallet_name!r}: "
+                "descriptor has no [fingerprint/derivation] block."
+            )
+        return fp
 
     def get_transactions(
         self,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2053,6 +2053,75 @@ class _FakeJAN3Manager:
             "fingerprint": "localfp",
         }
 
+    def get_user(self, email, wallet_name="default"):
+        self.calls.append(("get_user", {"email": email, "wallet_name": wallet_name}))
+        return {
+            "email": email,
+            "ln_username": "alice@aquabtc.com",
+            "ln_address_toggled": True,
+            "fingerprint": "samefp",
+            "new_addresses_needed": 0,
+            "ln_address_pool": {"refilled": False, "reason": "pool_full"},
+        }
+
+    def ln_address_toggle(self, email, enabled, wallet_name="default"):
+        self.calls.append((
+            "ln_address_toggle",
+            {"email": email, "enabled": enabled, "wallet_name": wallet_name},
+        ))
+        out = {"email": email, "enabled": enabled, "result": {"ln_address_toggled": enabled}}
+        if enabled:
+            out["ln_address_pool"] = {"refilled": True, "pool_size": 5}
+        return out
+
+    def ln_username_available(self, email, username):
+        self.calls.append((
+            "ln_username_available", {"email": email, "username": username}
+        ))
+        return {"is_available": True, "ln_username": username}
+
+    def purchase_ln_username(
+        self,
+        email,
+        ln_username,
+        wallet_name="default",
+        password=None,
+        asset="L-BTC",
+        confirm=False,
+        expected_amount_base_units=None,
+    ):
+        self.calls.append((
+            "purchase_ln_username",
+            {
+                "email": email,
+                "ln_username": ln_username,
+                "wallet_name": wallet_name,
+                "password": password,
+                "asset": asset,
+                "confirm": confirm,
+                "expected_amount_base_units": expected_amount_base_units,
+            },
+        ))
+        if not confirm:
+            return {
+                "requires_confirmation": True,
+                "confirmed": False,
+                "ln_username": ln_username,
+                "asset_ticker": asset,
+                "amount_base_units": 777,
+                "display_amount": "777 Sats",
+                "expires_at": "2026-07-03T18:13:55Z",
+            }
+        return {
+            "confirmed": True,
+            "payment_id": "pay1",
+            "status": "PENDING",
+            "txid": "txid1",
+            "ln_username": ln_username,
+            "amount_base_units": 777,
+            "display_amount": "777 Sats",
+        }
+
     def verify(self, email, otp_code, fingerprint=None, captcha_exempt=False):
         self.calls.append((
             "verify",
@@ -2234,10 +2303,7 @@ class TestWapuPayCli:
             input="y\n",
         )
         assert result.exit_code == 0
-        # The destructive warning (naming the LN address) is echoed before the
-        # prompt — the distinctive phrase only comes from the warning, not the
-        # result JSON. (The LN-address-vs-email rule is asserted at the manager
-        # level in test_warning_names_ln_address_not_account_email.)
+        # These phrases only come from the pre-prompt warning, not the result JSON.
         assert "moves delivery away" in result.output
         assert "alice@aquabtc.com" in result.output
         assert any(
@@ -2256,6 +2322,103 @@ class TestWapuPayCli:
         assert not any(
             c[0] == "rebind_wallet" and c[1]["confirm"] is True for c in auth_cli.calls
         )
+
+    def test_user_info(self, runner, auth_cli):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "jan3", "user-info",
+             "--email", "u@e.com", "--wallet-name", "w2"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ln_username"] == "alice@aquabtc.com"
+        assert data["ln_address_pool"]["reason"] == "pool_full"
+        assert auth_cli.calls[-1] == (
+            "get_user", {"email": "u@e.com", "wallet_name": "w2"}
+        )
+
+    def test_enable_lightning_address(self, runner, auth_cli):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "jan3", "enable-lightning-address",
+             "--email", "u@e.com", "--enable"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["enabled"] is True
+        assert data["ln_address_pool"]["refilled"] is True
+        assert auth_cli.calls[-1] == (
+            "ln_address_toggle",
+            {"email": "u@e.com", "enabled": True, "wallet_name": "default"},
+        )
+
+    def test_disable_lightning_address(self, runner, auth_cli):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "jan3", "enable-lightning-address",
+             "--email", "u@e.com", "--disable"],
+        )
+        assert result.exit_code == 0
+        assert json.loads(result.output)["enabled"] is False
+        assert auth_cli.calls[-1][1]["enabled"] is False
+
+    def test_ln_check_username(self, runner, auth_cli):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "jan3", "ln-check-username",
+             "--email", "u@e.com", "--ln-username", "alice"],
+        )
+        assert result.exit_code == 0
+        assert json.loads(result.output)["is_available"] is True
+        assert auth_cli.calls[-1] == (
+            "ln_username_available", {"email": "u@e.com", "username": "alice"}
+        )
+
+    def test_purchase_ln_username_accept_binds_quote(self, runner, auth_cli):
+        """Accepting the prompt executes confirm=True bound to the quoted
+        amount (expected_amount_base_units)."""
+        result = runner.invoke(
+            cli,
+            ["jan3", "purchase-ln-username",
+             "--email", "u@e.com", "--ln-username", "alice"],
+            input="y\n",
+        )
+        assert result.exit_code == 0
+        assert "777 Sats" in result.output  # quote echoed before the prompt
+        purchases = [c for c in auth_cli.calls if c[0] == "purchase_ln_username"]
+        assert purchases[0][1]["confirm"] is False   # quote first
+        assert purchases[-1][1]["confirm"] is True   # then execute
+        assert purchases[-1][1]["expected_amount_base_units"] == 777
+
+    def test_purchase_ln_username_decline_aborts_without_spending(
+        self, runner, auth_cli
+    ):
+        """Declining the price prompt aborts: the spending confirm=True call
+        is never made."""
+        result = runner.invoke(
+            cli,
+            ["jan3", "purchase-ln-username",
+             "--email", "u@e.com", "--ln-username", "alice"],
+            input="n\n",
+        )
+        assert result.exit_code != 0  # click.Abort
+        purchases = [c for c in auth_cli.calls if c[0] == "purchase_ln_username"]
+        assert purchases and all(c[1]["confirm"] is False for c in purchases)
+
+    def test_purchase_ln_username_yes_skips_quote(self, runner, auth_cli):
+        """--yes goes straight to the confirmed purchase: no quote call (which
+        would create an orphaned server-side order) and no amount bound."""
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "jan3", "purchase-ln-username",
+             "--email", "u@e.com", "--ln-username", "alice", "--yes"],
+        )
+        assert result.exit_code == 0
+        assert json.loads(result.output)["confirmed"] is True
+        purchases = [c for c in auth_cli.calls if c[0] == "purchase_ln_username"]
+        assert len(purchases) == 1
+        assert purchases[0][1]["confirm"] is True
+        assert purchases[0][1]["expected_amount_base_units"] is None
 
     def test_create_order_with_yes_skips_confirm(self, runner, wapupay_cli):
         result = runner.invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1998,10 +1998,60 @@ class _FakeJAN3Manager:
 
     def __init__(self):
         self.calls: list[tuple[str, dict]] = []
+        # When True, rebind_wallet reports an already-bound no-op (no confirm gate).
+        self.rebind_already_bound = False
 
     def login(self, email, language="en"):
         self.calls.append(("login", {"email": email, "language": language}))
         return {"email": email, "message": "OTP sent", "next_step": "verify"}
+
+    def rebind_wallet(self, email, wallet_name="default", confirm=False):
+        self.calls.append((
+            "rebind_wallet",
+            {
+                "email": email,
+                "wallet_name": wallet_name,
+                "confirm": confirm,
+            },
+        ))
+        if self.rebind_already_bound:
+            return {
+                "email": email,
+                "ln_username": "alice@aquabtc.com",
+                "wallet_name": wallet_name,
+                "fingerprint": "samefp",
+                "already_bound": True,
+                "requires_confirmation": False,
+                "rebound": False,
+                "ln_address_pool": {"reason": "pool_full"},
+            }
+        if not confirm:
+            return {
+                "email": email,
+                "ln_username": "alice@aquabtc.com",
+                "wallet_name": wallet_name,
+                "state": "rebind",
+                "current_fingerprint": "serverfp",
+                "new_fingerprint": "localfp",
+                "requires_confirmation": True,
+                "rebound": False,
+                "warning": (
+                    "Re-binding your Lightning Address alice@aquabtc.com to wallet "
+                    f"{wallet_name!r} [localfp] moves delivery away from [serverfp]."
+                ),
+            }
+        return {
+            "email": email,
+            "ln_username": "alice@aquabtc.com",
+            "wallet_name": wallet_name,
+            "state": "rebind",
+            "current_fingerprint": "serverfp",
+            "new_fingerprint": "localfp",
+            "rebound": True,
+            "requires_confirmation": False,
+            "pool_size": 5,
+            "fingerprint": "localfp",
+        }
 
     def verify(self, email, otp_code, fingerprint=None, captcha_exempt=False):
         self.calls.append((
@@ -2148,6 +2198,64 @@ class TestWapuPayCli:
         assert result.exit_code == 0
         assert json.loads(result.output)["logged_in"] is True
         assert auth_cli.calls[-1][1]["otp_code"] == "123456"
+
+    def test_rebind_wallet_yes_skips_prompt(self, runner, auth_cli):
+        """--yes runs the two-step handshake without prompting: preview
+        (confirm=False) then execute (confirm=True)."""
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "jan3", "rebind-wallet",
+             "--email", "u@e.com", "--wallet-name", "new", "--yes"],
+        )
+        assert result.exit_code == 0
+        assert json.loads(result.output)["rebound"] is True
+        rebinds = [c for c in auth_cli.calls if c[0] == "rebind_wallet"]
+        assert rebinds[0][1]["confirm"] is False   # preview first
+        assert rebinds[-1][1]["confirm"] is True    # then execute
+        assert rebinds[-1][1]["wallet_name"] == "new"
+
+    def test_rebind_wallet_decline_aborts_without_executing(self, runner, auth_cli):
+        """Declining the prompt aborts: the destructive confirm=True call is
+        never made."""
+        result = runner.invoke(
+            cli,
+            ["jan3", "rebind-wallet", "--email", "u@e.com", "--wallet-name", "new"],
+            input="n\n",
+        )
+        assert result.exit_code != 0  # click.Abort
+        rebinds = [c for c in auth_cli.calls if c[0] == "rebind_wallet"]
+        assert rebinds and all(c[1]["confirm"] is False for c in rebinds)
+
+    def test_rebind_wallet_accept_executes(self, runner, auth_cli):
+        """Accepting the prompt (y) runs the destructive execute call."""
+        result = runner.invoke(
+            cli,
+            ["jan3", "rebind-wallet", "--email", "u@e.com", "--wallet-name", "new"],
+            input="y\n",
+        )
+        assert result.exit_code == 0
+        # The destructive warning (naming the LN address) is echoed before the
+        # prompt — the distinctive phrase only comes from the warning, not the
+        # result JSON. (The LN-address-vs-email rule is asserted at the manager
+        # level in test_warning_names_ln_address_not_account_email.)
+        assert "moves delivery away" in result.output
+        assert "alice@aquabtc.com" in result.output
+        assert any(
+            c[0] == "rebind_wallet" and c[1]["confirm"] is True for c in auth_cli.calls
+        )
+
+    def test_rebind_wallet_already_bound_is_noop(self, runner, auth_cli):
+        """When already bound to this wallet, no prompt and no destructive
+        execute call."""
+        auth_cli.rebind_already_bound = True
+        result = runner.invoke(
+            cli, ["--format", "json", "jan3", "rebind-wallet", "--email", "u@e.com"]
+        )
+        assert result.exit_code == 0
+        assert json.loads(result.output)["already_bound"] is True
+        assert not any(
+            c[0] == "rebind_wallet" and c[1]["confirm"] is True for c in auth_cli.calls
+        )
 
     def test_create_order_with_yes_skips_confirm(self, runner, wapupay_cli):
         result = runner.invoke(

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -1110,9 +1110,15 @@ class TestGetUserAutoPool:
         assert out["ln_address_pool"]["reason"] == "pool_full"
         wm.reserve_addresses.assert_not_called()
 
-    def test_locked_wallet_never_breaks_read(self, storage):
-        mgr, wm = _ln_manager(storage)
-        wm.fingerprint.side_effect = ValueError("wallet is encrypted; password required")
+    def test_topup_backend_failure_never_breaks_read(self, storage):
+        # A REAL failure mode: the local reserve succeeds but the backend
+        # register POST fails (transient 500). It must be swallowed into a skip,
+        # not raised — the profile read still returns. (The previous version of
+        # this test injected a "password required" error from fingerprint(),
+        # which the real code cannot produce for an encrypted hot wallet:
+        # address derivation needs only the descriptor, not the mnemonic —
+        # see test_wallet.py::TestEncryptedWalletNoPassword.)
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
         _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
         profile = {
             "ln_username": "alice",
@@ -1121,13 +1127,19 @@ class TestGetUserAutoPool:
             "new_addresses_needed": 3,
         }
         with patch(
-            "urllib.request.urlopen", side_effect=_route({"/user/": profile})
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/user/": profile,
+                "/addresses/": _http_error(500, "backend down"),
+            }),
         ):
             out = mgr.get_user("me@example.com")
-        # Profile still returned; the failure is reported, not raised.
+        # Profile still returned; the topup failure is reported, not raised.
         assert out["ln_username"] == "alice"
+        assert out["ln_address_pool"]["refilled"] is False
         assert out["ln_address_pool"]["reason"] == "auto_topup_unavailable"
-        assert "encrypted" in out["ln_address_pool"]["detail"]
+        # The burn-before-POST ordering means reserve was attempted first.
+        wm.reserve_addresses.assert_called_once_with("default", 3)
 
 
 class TestLnAddressToggleManager:
@@ -1252,12 +1264,13 @@ class TestEnsureLnPool:
                 "new_addresses_needed": 3,
             },
         )
-        assert out == {
-            "refilled": False,
-            "reason": "fingerprint_mismatch",
-            "server_fingerprint": "serverfp",
-            "local_fingerprint": "localfp",
-        }
+        assert out["refilled"] is False
+        assert out["reason"] == "fingerprint_mismatch"
+        assert out["server_fingerprint"] == "serverfp"
+        assert out["local_fingerprint"] == "localfp"
+        # The skip must carry actionable guidance naming both fingerprints
+        # (the reason alone is a dead-end; there is no self-serve re-bind tool).
+        assert "serverfp" in out["message"] and "localfp" in out["message"]
         wm.reserve_addresses.assert_not_called()
 
     def test_no_username_skips(self, storage):

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from aqua.ankara import ANKARA_API_URL, SessionExpiredError
+from aqua.lnurl import resolve_lightning_address
 from aqua.jan3_accounts import (
     ASSET_TICKER_LBTC,
     DEFAULT_LN_ADDRESS_POOL,
@@ -142,12 +143,8 @@ def _route(mapping):
 
 
 def _capturing_route(mapping):
-    """Like :func:`_route` but records every request URL (with query string).
-
-    The returned side_effect exposes ``.calls`` — a list of ``req.full_url``
-    strings — so a test can assert whether ``?override_fingerprint=true`` was
-    (or was not) sent.
-    """
+    """Like :func:`_route` but also records each request's full URL in
+    ``.calls``, so a test can assert whether a query string was sent."""
     urls: list[str] = []
     base = _route(mapping)
 
@@ -156,6 +153,21 @@ def _capturing_route(mapping):
         return base(req, timeout=timeout)
 
     side_effect.calls = urls
+    return side_effect
+
+
+def _body_capturing_route(mapping):
+    """Like :func:`_route` but records ``(url, decoded body)`` per request,
+    exposed as ``.bodies``, so a test can assert what a POST actually carried.
+    """
+    bodies: list[tuple[str, str]] = []
+    base = _route(mapping)
+
+    def side_effect(req, timeout=None):
+        bodies.append((req.full_url, req.data.decode() if req.data else ""))
+        return base(req, timeout=timeout)
+
+    side_effect.bodies = bodies
     return side_effect
 
 
@@ -1129,13 +1141,9 @@ class TestGetUserAutoPool:
         wm.reserve_addresses.assert_not_called()
 
     def test_topup_backend_failure_never_breaks_read(self, storage):
-        # A REAL failure mode: the local reserve succeeds but the backend
-        # register POST fails (transient 500). It must be swallowed into a skip,
-        # not raised — the profile read still returns. (The previous version of
-        # this test injected a "password required" error from fingerprint(),
-        # which the real code cannot produce for an encrypted hot wallet:
-        # address derivation needs only the descriptor, not the mnemonic —
-        # see test_wallet.py::TestEncryptedWalletNoPassword.)
+        # A REAL failure mode: the backend register POST can fail (transient
+        # 500); it must be swallowed into a skip, not raised — the profile
+        # read still returns.
         mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
         _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
         profile = {
@@ -1158,6 +1166,141 @@ class TestGetUserAutoPool:
         assert out["ln_address_pool"]["reason"] == "auto_topup_unavailable"
         # The burn-before-POST ordering means reserve was attempted first.
         wm.reserve_addresses.assert_called_once_with("default", 3)
+
+
+class TestPendingBatchReuse:
+    """A failed register POST must not burn a fresh batch per retry.
+
+    The reserved batch is persisted on the session and re-uploaded verbatim
+    (the server ignores duplicate addresses), so an outage costs one batch
+    total instead of one batch per jan3_user_info call.
+    """
+
+    PROFILE = {
+        "ln_username": "alice",
+        "ln_address_toggled": True,
+        "fingerprint": "abcd1234",
+        "new_addresses_needed": 3,
+    }
+
+    @staticmethod
+    def _distinct_batches(wm):
+        """Make each reserve call return a distinguishable batch."""
+        calls = {"n": 0}
+
+        def reserve(name, count):
+            calls["n"] += 1
+            return [
+                MagicMock(address=f"lq1batch{calls['n']}addr{i}")
+                for i in range(count)
+            ]
+
+        wm.reserve_addresses.side_effect = reserve
+
+    def test_retry_reuses_batch_instead_of_burning(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
+        self._distinct_batches(wm)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+
+        # Attempt 1: reserve succeeds, POST 500s — batch 1 is now pending.
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/user/": self.PROFILE,
+                "/addresses/": _http_error(500, "backend down"),
+            }),
+        ):
+            out = mgr.get_user("me@example.com")
+        assert out["ln_address_pool"]["reason"] == "auto_topup_unavailable"
+        assert wm.reserve_addresses.call_count == 1
+
+        # Attempt 2: backend recovered. The SAME batch is re-POSTed; no new
+        # indices are reserved.
+        route = _body_capturing_route({
+            "/user/": self.PROFILE,
+            "/addresses/": {"addresses": ["a", "b", "c"]},
+        })
+        with patch("urllib.request.urlopen", side_effect=route):
+            out = mgr.get_user("me@example.com")
+        assert out["ln_address_pool"]["refilled"] is True
+        assert wm.reserve_addresses.call_count == 1  # still just the first burn
+        post_body = next(b for u, b in route.bodies if "/addresses/" in u)
+        assert "lq1batch1addr0" in post_body
+        assert "lq1batch2" not in post_body
+
+    def test_success_clears_pending(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
+        self._distinct_batches(wm)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+
+        ok_route = {
+            "/user/": self.PROFILE,
+            "/addresses/": {"addresses": ["a", "b", "c"]},
+        }
+        with patch("urllib.request.urlopen", side_effect=_route(ok_route)):
+            mgr.get_user("me@example.com")
+        assert (
+            mgr.load_session("me@example.com").pending_ln_registration is None
+        )
+        # Next top-up reserves a fresh batch — pending is not sticky.
+        with patch("urllib.request.urlopen", side_effect=_route(dict(ok_route))):
+            mgr.get_user("me@example.com")
+        assert wm.reserve_addresses.call_count == 2
+
+    def test_pool_response_reconciles_counter(self, storage):
+        # The register response returns the FULL unused pool; addresses we
+        # didn't just post (e.g. from a reimported seed) must reach ensure_counter_covers.
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/user/": self.PROFILE,
+                "/addresses/": {
+                    "addresses": ["lq1addr0", "lq1addr1", "lq1addr2", "lq1old9"]
+                },
+            }),
+        ):
+            out = mgr.get_user("me@example.com")
+        assert out["ln_address_pool"]["refilled"] is True
+        wm.ensure_counter_covers.assert_called_once_with("default", ["lq1old9"])
+
+    def test_no_reconciliation_when_pool_matches_posted(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/user/": self.PROFILE,
+                "/addresses/": {"addresses": ["lq1addr0", "lq1addr1", "lq1addr2"]},
+            }),
+        ):
+            mgr.get_user("me@example.com")
+        wm.ensure_counter_covers.assert_not_called()
+
+    def test_pending_for_other_wallet_not_reused(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
+        self._distinct_batches(wm)
+        session = _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        session.pending_ln_registration = {
+            "wallet_name": "other",
+            "fingerprint": "zzzz9999",
+            "addresses": ["lq1stale0", "lq1stale1"],
+        }
+        mgr.save_session(session)
+
+        route = _body_capturing_route({
+            "/user/": self.PROFILE,
+            "/addresses/": {"addresses": ["a", "b", "c"]},
+        })
+        with patch("urllib.request.urlopen", side_effect=route):
+            out = mgr.get_user("me@example.com")
+        assert out["ln_address_pool"]["refilled"] is True
+        # The stale batch (different wallet/fingerprint) must not be uploaded.
+        wm.reserve_addresses.assert_called_once_with("default", 3)
+        post_body = next(b for u, b in route.bodies if "/addresses/" in u)
+        assert "lq1stale" not in post_body
+        assert "lq1batch1addr0" in post_body
 
 
 class TestLnAddressToggleManager:
@@ -1434,8 +1577,7 @@ class TestEnsureLnPool:
         assert out["reason"] == "fingerprint_mismatch"
         assert out["server_fingerprint"] == "serverfp"
         assert out["local_fingerprint"] == "localfp"
-        # The skip must carry actionable guidance naming both fingerprints
-        # (the reason alone is a dead-end; there is no self-serve re-bind tool).
+        # The skip must carry actionable guidance naming both fingerprints.
         assert "serverfp" in out["message"] and "localfp" in out["message"]
         wm.reserve_addresses.assert_not_called()
 
@@ -1444,6 +1586,56 @@ class TestEnsureLnPool:
         _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
         out = mgr.ensure_ln_pool("me@example.com", profile={"ln_username": None})
         assert out["reason"] == "no_ln_username"
+
+    def test_fingerprint_unavailable_is_permanent_skip(self, storage):
+        # A bare-xpub watch-only wallet can never fingerprint; the skip must
+        # be distinguishable from a transient failure and carry remediation.
+        mgr, wm = _ln_manager(storage)
+        wm.fingerprint.side_effect = ValueError(
+            "Cannot determine fingerprint for watch-only wallet 'default': "
+            "descriptor has no [fingerprint/derivation] block."
+        )
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        out = mgr.ensure_ln_pool(
+            "me@example.com",
+            profile={
+                "ln_username": "alice",
+                "ln_address_toggled": True,
+                "fingerprint": "serverfp",
+                "new_addresses_needed": 3,
+            },
+        )
+        assert out["refilled"] is False
+        assert out["reason"] == "wallet_fingerprint_unavailable"
+        assert "permanent" in out["message"]
+        assert "re-import" in out["message"]
+        wm.reserve_addresses.assert_not_called()
+
+    def test_toggle_enable_surfaces_permanent_fingerprint_skip(self, storage):
+        # The toggle succeeding must not mask a wallet that can never
+        # register addresses: the pool result carries the permanent skip.
+        mgr, wm = _ln_manager(storage)
+        wm.fingerprint.side_effect = ValueError(
+            "Cannot determine fingerprint for watch-only wallet 'default': "
+            "descriptor has no [fingerprint/derivation] block."
+        )
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/ln-address-toggle/": {"ln_address_toggled": True},
+                "/user/": {
+                    "ln_username": "alice",
+                    "ln_address_toggled": True,
+                    "fingerprint": "serverfp",
+                    "new_addresses_needed": 3,
+                },
+            }),
+        ):
+            out = mgr.ln_address_toggle("me@example.com", True)
+        assert out["enabled"] is True
+        assert out["ln_address_pool"]["reason"] == "wallet_fingerprint_unavailable"
+        wm.reserve_addresses.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1521,9 +1713,278 @@ class TestPurchaseLnUsername:
             with pytest.raises(ValueError, match="missing fields"):
                 mgr.purchase_ln_username("me@example.com", "alice", confirm=True)
 
+    def _order(self, amount_base_units, payment_id="pay1", expires_at="2030-01-01T00:00:00Z"):
+        return {
+            "payment_id": payment_id,
+            "address": VAULT_ADDR,
+            "amount_base_units": amount_base_units,
+            "asset_ticker": "L-BTC",
+            "amount": "0.00000777",
+            "expires_at": expires_at,
+        }
+
+    def test_confirm_funds_the_quoted_order(self, storage):
+        # The quote locks an order server-side; confirm must fund THAT order —
+        # no second payment request, no repriced amount.
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "computed-txid"
+
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({"/payment-request/ln-username/": self._order(777)}),
+        ):
+            quote = mgr.purchase_ln_username("me@example.com", "alice")
+        assert quote["payment_id"] == "pay1"
+        assert mgr.load_session("me@example.com").pending_ln_purchase is not None
+
+        # The confirm route has NO payment-request mapping: any attempt to
+        # create a second order would fail the test.
+        route = _capturing_route({"/payment/submit-raw-tx/": {"status": "PENDING"}})
+        with (
+            patch("urllib.request.urlopen", side_effect=route),
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            out = mgr.purchase_ln_username("me@example.com", "alice", confirm=True)
+        assert out["confirmed"] is True
+        assert out["payment_id"] == "pay1"       # the quoted order was funded
+        assert out["amount_base_units"] == 777   # exactly the approved amount
+        wm.craft_raw_tx.assert_called_once()
+        assert wm.craft_raw_tx.call_args.kwargs["amount"] == 777
+        assert not any("/payment-request/" in u for u in route.calls)
+        # The quote is consumed once funded.
+        assert mgr.load_session("me@example.com").pending_ln_purchase is None
+
+    def test_confirm_raises_when_quote_expired(self, storage):
+        # An expired locked quote must not be silently repriced: fail loudly
+        # and spend nothing.
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/payment-request/ln-username/": self._order(
+                    777, expires_at="2020-01-01T00:00:00Z"
+                ),
+            }),
+        ):
+            mgr.purchase_ln_username("me@example.com", "alice")
+        with pytest.raises(ValueError, match="quote expired"):
+            mgr.purchase_ln_username("me@example.com", "alice", confirm=True)
+        wm.craft_raw_tx.assert_not_called()
+
+    def test_confirm_for_different_username_ignores_pending(self, storage):
+        # A pending quote for another username must not be funded (its order
+        # would set THAT username): fall back to a fresh order.
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "computed-txid"
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({"/payment-request/ln-username/": self._order(777)}),
+        ):
+            mgr.purchase_ln_username("me@example.com", "alice")
+
+        route = _capturing_route({
+            "/payment-request/ln-username/": self._order(888, payment_id="pay2"),
+            "/payment/submit-raw-tx/": {"status": "PENDING"},
+        })
+        with (
+            patch("urllib.request.urlopen", side_effect=route),
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            out = mgr.purchase_ln_username("me@example.com", "bobby", confirm=True)
+        assert out["payment_id"] == "pay2"
+        assert any("/payment-request/" in u for u in route.calls)
+
+    def test_confirm_without_quote_aborts_when_price_exceeds_approved(self, storage):
+        # Stateless path (no prior quote): the caller-approved ceiling bounds
+        # the spend. Nothing may be signed or submitted above it.
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        route = _capturing_route({"/payment-request/ln-username/": self._order(2000)})
+        with patch("urllib.request.urlopen", side_effect=route):
+            with pytest.raises(ValueError, match="Price changed"):
+                mgr.purchase_ln_username(
+                    "me@example.com",
+                    "alice",
+                    confirm=True,
+                    expected_amount_base_units=777,
+                )
+        wm.craft_raw_tx.assert_not_called()
+        assert not any("submit-raw-tx" in u for u in route.calls)
+
+    def test_confirm_without_quote_proceeds_when_price_within_approved(self, storage):
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "computed-txid"
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=_route({
+                    "/payment-request/ln-username/": self._order(777),
+                    "/payment/submit-raw-tx/": {"status": "PENDING"},
+                }),
+            ),
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            out = mgr.purchase_ln_username(
+                "me@example.com",
+                "alice",
+                confirm=True,
+                expected_amount_base_units=1000,
+            )
+        assert out["confirmed"] is True
+        assert out["amount_base_units"] == 777
+        wm.craft_raw_tx.assert_called_once()
+
+    def test_quote_ignores_expected_amount(self, storage):
+        # The ceiling applies to the spending step only; a dry-run quote with
+        # a stale expectation must still return the fresh price, not raise.
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({"/payment-request/ln-username/": self._order(2000)}),
+        ):
+            out = mgr.purchase_ln_username(
+                "me@example.com",
+                "alice",
+                confirm=False,
+                expected_amount_base_units=777,
+            )
+        assert out["requires_confirmation"] is True
+        assert out["amount_base_units"] == 2000
+        wm.craft_raw_tx.assert_not_called()
+
     def test_invalid_username_raises_before_network(self, storage):
         mgr, _ = _ln_manager(storage)
         _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
         with pytest.raises(ValueError, match="Invalid ln_username"):
             mgr.purchase_ln_username("me@example.com", "bad..name")
 
+
+
+# ---------------------------------------------------------------------------
+# Purchase + LNURL resolution linkage
+# ---------------------------------------------------------------------------
+
+
+def _lnurl_response(data: dict, final_url: str | None = None) -> MagicMock:
+    """urlopen response mock for LNURL-leg patches.
+
+    Distinct from ``_mock_response`` above because ``aqua.lnurl._http_get_json``
+    calls ``resp.geturl()`` to enforce the post-redirect https guard.
+    """
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(data).encode()
+    resp.geturl.return_value = final_url or "https://example.com/x"
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def _payreq(
+    *,
+    callback: str = "https://test.aqua.net/lnurlp/cb",
+    min_msat: int = 1_000,
+    max_msat: int = 100_000_000_000,
+    metadata: str = '[["text/plain","pay alice"]]',
+) -> dict:
+    return {
+        "tag": "payRequest",
+        "callback": callback,
+        "minSendable": min_msat,
+        "maxSendable": max_msat,
+        "metadata": metadata,
+    }
+
+
+class TestPurchaseThenResolve:
+    """End-to-end (mocked) linkage: buy a JAN3 LN username and resolve the
+    resulting ``<username>@<jan3-domain>`` Lightning Address via aqua.lnurl.
+
+    Proves our code wires the two halves together — that the bare
+    ``ln_username`` returned by ``purchase_ln_username`` composes cleanly
+    into a ``.well-known/lnurlp/`` lookup that yields a payable BOLT11.
+    """
+
+    LN_USERNAME = "alicebob"
+    LN_DOMAIN = "test.aqua.net"
+    AMOUNT_SATS = 100
+    INVOICE = "lnbc1u1ptest_jan3_invoice"
+
+    PR_RESPONSE = {
+        "payment_id": "11111111-1111-1111-1111-111111111111",
+        "status": "PENDING",
+        "product_type": "LN_USERNAME_UPDATE",
+        "asset_ticker": "L-BTC",
+        "amount_base_units": 1000,
+        "address": VAULT_ADDR,
+        "expires_at": "2026-06-16T01:00:00+00:00",
+    }
+    SUBMIT_RESPONSE = {**PR_RESPONSE, "status": "ACCEPTED"}
+
+    def _purchase(self, mgr: Jan3AccountsManager) -> dict:
+        """Drive ``purchase_ln_username`` with all HTTP + signing mocked."""
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "computed-txid"
+        with (
+            patch.object(
+                Jan3AccountsClient,
+                "create_ln_username_payment_request",
+                return_value=self.PR_RESPONSE,
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "submit_raw_tx",
+                return_value=self.SUBMIT_RESPONSE,
+            ),
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            return mgr.purchase_ln_username(
+                email="me@example.com",
+                ln_username=self.LN_USERNAME,
+                wallet_name="default",
+                confirm=True,
+            )
+
+    def test_purchase_then_resolve_returns_invoice(self, storage):
+        """Happy path: buy username → resolve <user>@<domain> → BOLT11."""
+        mgr = _manager(storage, raw_tx="DEADBEEF" * 16)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+
+        purchase = self._purchase(mgr)
+        assert purchase["confirmed"] is True
+        assert purchase["ln_username"] == self.LN_USERNAME
+        address = f"{purchase['ln_username']}@{self.LN_DOMAIN}"
+
+        with (
+            patch("aqua.lnurl.urllib.request.urlopen") as mock_urlopen,
+            patch(
+                "aqua.lnurl.decode_bolt11_amount_sats",
+                return_value=self.AMOUNT_SATS,
+            ),
+        ):
+            mock_urlopen.side_effect = [
+                _lnurl_response(
+                    _payreq(),
+                    final_url=(
+                        f"https://{self.LN_DOMAIN}/.well-known/lnurlp/"
+                        f"{self.LN_USERNAME}"
+                    ),
+                ),
+                _lnurl_response({"pr": self.INVOICE}),
+            ]
+            invoice = resolve_lightning_address(address, self.AMOUNT_SATS)
+
+        assert invoice == self.INVOICE
+        first_req = mock_urlopen.call_args_list[0].args[0]
+        assert first_req.full_url == (
+            f"https://{self.LN_DOMAIN}/.well-known/lnurlp/{self.LN_USERNAME}"
+        )
+        second_req = mock_urlopen.call_args_list[1].args[0]
+        assert f"amount={self.AMOUNT_SATS * 1000}" in second_req.full_url

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -141,6 +141,24 @@ def _route(mapping):
     return side_effect
 
 
+def _capturing_route(mapping):
+    """Like :func:`_route` but records every request URL (with query string).
+
+    The returned side_effect exposes ``.calls`` — a list of ``req.full_url``
+    strings — so a test can assert whether ``?override_fingerprint=true`` was
+    (or was not) sent.
+    """
+    urls: list[str] = []
+    base = _route(mapping)
+
+    def side_effect(req, timeout=None):
+        urls.append(req.full_url)
+        return base(req, timeout=timeout)
+
+    side_effect.calls = urls
+    return side_effect
+
+
 # ---------------------------------------------------------------------------
 # Pure helpers
 # ---------------------------------------------------------------------------
@@ -1249,6 +1267,154 @@ class TestRegisterLnAddresses:
             )
         wm.reserve_addresses.assert_called_once_with("default", DEFAULT_LN_ADDRESS_POOL)
         assert out["requested_count"] == DEFAULT_LN_ADDRESS_POOL
+
+
+# ---------------------------------------------------------------------------
+# Manager: rebind_wallet (self-serve override_fingerprint)
+# ---------------------------------------------------------------------------
+
+
+class TestRebindWallet:
+    """`rebind_wallet` re-binds the account's Lightning Address to a different
+    local wallet. Three states: first-bind (no server fp), no-op (server==local),
+    destructive re-bind (server!=local). confirm=False previews without mutating;
+    confirm=True executes with override_fingerprint=true.
+    """
+
+    def _profile(self, *, server_fp="serverfp", needed=2, ln_username="alice@aquabtc.com"):
+        return {
+            "email": "me@example.com",
+            "ln_username": ln_username,
+            "ln_address_toggled": True,
+            "fingerprint": server_fp,
+            "new_addresses_needed": needed,
+        }
+
+    # -- destructive re-bind (server_fp != local_fp) ------------------------
+
+    def test_preview_does_not_mutate_or_send_override(self, storage):
+        # confirm=False on a mismatch must PREVIEW only: no address minting,
+        # no POST to /addresses/, and certainly no override query. (AC-3)
+        mgr, wm = _ln_manager(storage, fingerprint="localfp")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        route = _capturing_route({"/user/": self._profile(server_fp="serverfp")})
+        with patch("urllib.request.urlopen", side_effect=route):
+            out = mgr.rebind_wallet("me@example.com", "default", confirm=False)
+        assert out["requires_confirmation"] is True
+        assert out["rebound"] is False
+        assert out["current_fingerprint"] == "serverfp"
+        assert out["new_fingerprint"] == "localfp"
+        assert "serverfp" in out["warning"] and "localfp" in out["warning"]
+        wm.reserve_addresses.assert_not_called()
+        assert not any("override_fingerprint" in u for u in route.calls)
+        assert not any("/addresses/" in u for u in route.calls)
+
+    def test_confirm_executes_and_sends_override(self, storage):
+        # confirm=True on a mismatch must call register with override_fingerprint,
+        # sending ?override_fingerprint=true to /addresses/. (AC-4, AC-5)
+        mgr, wm = _ln_manager(storage, fingerprint="localfp")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        route = _capturing_route({
+            "/user/": self._profile(server_fp="serverfp", needed=2),
+            "/addresses/": {"addresses": ["a", "b"]},
+        })
+        with patch("urllib.request.urlopen", side_effect=route):
+            out = mgr.rebind_wallet("me@example.com", "default", confirm=True)
+        assert out["rebound"] is True
+        assert out["new_fingerprint"] == "localfp"
+        assert out["pool_size"] == 2
+        wm.reserve_addresses.assert_called_once_with("default", 2)
+        assert any(
+            u.endswith("/api/v1/auth/user/addresses/?override_fingerprint=true")
+            for u in route.calls
+        )
+
+    def test_warning_names_ln_address_not_account_email(self, storage):
+        # D6: the warning must surface the Lightning Address (ln_username), never
+        # the JAN3 account login email.
+        mgr, _ = _ln_manager(storage, fingerprint="localfp")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        route = _capturing_route({
+            "/user/": self._profile(server_fp="serverfp", ln_username="alice@aquabtc.com"),
+        })
+        with patch("urllib.request.urlopen", side_effect=route):
+            out = mgr.rebind_wallet("me@example.com", "default", confirm=False)
+        assert "alice@aquabtc.com" in out["warning"]
+        assert "me@example.com" not in out["warning"]
+
+    # -- first bind (server_fp empty) --------------------------------------
+
+    def test_first_bind_preview_has_no_bogus_none(self, storage):
+        # AC-10: no wallet bound yet -> first bind, not a destructive re-bind.
+        # The warning must not render a "None" replaced-fingerprint.
+        mgr, wm = _ln_manager(storage, fingerprint="localfp")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        route = _capturing_route({"/user/": self._profile(server_fp=None)})
+        with patch("urllib.request.urlopen", side_effect=route):
+            out = mgr.rebind_wallet("me@example.com", "default", confirm=False)
+        assert out["state"] == "first_bind"
+        assert out["current_fingerprint"] is None
+        assert out["new_fingerprint"] == "localfp"
+        assert "None" not in out["warning"]
+        wm.reserve_addresses.assert_not_called()
+        assert not any("override_fingerprint" in u for u in route.calls)
+
+    def test_first_bind_confirm_executes(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="localfp")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        route = _capturing_route({
+            "/user/": self._profile(server_fp=None, needed=3),
+            "/addresses/": {"addresses": ["a", "b", "c"]},
+        })
+        with patch("urllib.request.urlopen", side_effect=route):
+            out = mgr.rebind_wallet("me@example.com", "default", confirm=True)
+        assert out["rebound"] is True
+        assert any("override_fingerprint=true" in u for u in route.calls)
+
+    # -- already bound (server_fp == local_fp) -----------------------------
+
+    def test_already_bound_is_noop_no_override(self, storage):
+        # AC-11: server fp already equals this wallet -> no-op, no confirmation,
+        # never sends a spurious destructive override.
+        mgr, wm = _ln_manager(storage, fingerprint="samefp")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        route = _capturing_route({"/user/": self._profile(server_fp="samefp", needed=0)})
+        with patch("urllib.request.urlopen", side_effect=route):
+            out = mgr.rebind_wallet("me@example.com", "default", confirm=False)
+        assert out["already_bound"] is True
+        assert out["requires_confirmation"] is False
+        assert out["rebound"] is False
+        assert not any("override_fingerprint" in u for u in route.calls)
+
+    # -- guards -------------------------------------------------------------
+
+    def test_no_username_raises(self, storage):
+        mgr, _ = _ln_manager(storage, fingerprint="localfp")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({"/user/": {"ln_username": None, "fingerprint": "serverfp"}}),
+        ):
+            with pytest.raises(ValueError, match="no LN username"):
+                mgr.rebind_wallet("me@example.com", "default", confirm=True)
+
+    def test_mismatch_skip_points_to_rebind_tool(self, storage):
+        # AC-8: the auto-path skip message must now point at the new self-serve
+        # tool instead of saying re-binding is unavailable.
+        mgr, _ = _ln_manager(storage, fingerprint="localfp")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        out = mgr.ensure_ln_pool(
+            "me@example.com",
+            profile={
+                "ln_username": "alice@aquabtc.com",
+                "ln_address_toggled": True,
+                "fingerprint": "serverfp",
+                "new_addresses_needed": 3,
+            },
+        )
+        assert out["reason"] == "fingerprint_mismatch"
+        assert "jan3_rebind_wallet" in out["message"]
+        assert "serverfp" in out["message"] and "localfp" in out["message"]
 
 
 class TestEnsureLnPool:

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -24,12 +24,15 @@ import pytest
 from aqua.ankara import ANKARA_API_URL, SessionExpiredError
 from aqua.jan3_accounts import (
     ASSET_TICKER_LBTC,
+    DEFAULT_LN_ADDRESS_POOL,
+    MAX_ADDRESSES_PER_REGISTRATION,
     Jan3AccountsClient,
     Jan3AccountsManager,
     Jan3Session,
     _email_to_filename,
     _token_preview,
     _validate_email,
+    _validate_ln_username,
 )
 from aqua.storage import Storage
 
@@ -524,6 +527,20 @@ class TestVerify:
         assert result["captcha_exempt"] is True
         assert mgr.load_session("me@example.com").captcha_exempt is True
 
+    def test_verify_cues_ln_address_offer(self, storage):
+        # The post-login UX: verify's return must cue the agent to offer the
+        # Lightning Address opt-in (this is why the toggle is user-facing).
+        mgr = _manager(storage)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route(
+                {"/api/v1/auth/verify/": {"access": "A" * 40, "refresh": "R" * 40}}
+            ),
+        ):
+            result = mgr.verify("me@example.com", "123456")
+        assert "lightning address" in result["next_step"].lower()
+        assert "jan3_ln_address_toggle" in result["next_step"]
+
     def test_propagates_invalid_otp_and_saves_nothing(self, storage):
         mgr = _manager(storage)
         with patch(
@@ -899,4 +916,405 @@ class TestProvisionWapupayToken:
         ):
             with pytest.raises(ValueError, match="token missing"):
                 mgr.provision_wapupay_token("me@example.com")
+
+
+# ---------------------------------------------------------------------------
+# LN username validation
+# ---------------------------------------------------------------------------
+
+
+class TestLnUsernameValidation:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("alice", "alice"),
+            ("ALICE", "alice"),
+            ("bob.smith", "bob.smith"),
+            ("user1234", "user1234"),
+            ("  Trimmed  ", "trimmed"),
+        ],
+    )
+    def test_valid_normalizes(self, raw, expected):
+        assert _validate_ln_username(raw) == expected
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["abc", "", "a_b", "ab.cd.ef", "with space", "under_score", "x" * 65, "no-dash"],
+    )
+    def test_invalid_rejected(self, bad):
+        with pytest.raises(ValueError, match="Invalid ln_username"):
+            _validate_ln_username(bad)
+
+
+# ---------------------------------------------------------------------------
+# LN client HTTP methods (urlopen seam)
+# ---------------------------------------------------------------------------
+
+
+class TestLnClientHttp:
+    @patch("urllib.request.urlopen")
+    def test_get_user_sends_bearer(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response(
+            {"email": "me@x.com", "ln_username": "alice"}
+        )
+        client = Jan3AccountsClient(base_url=BASE_URL, access_token="jwt.acc")
+        out = client.get_user()
+        assert out["ln_username"] == "alice"
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url.endswith("/api/v1/auth/user/")
+        assert req.get_method() == "GET"
+        assert req.get_header("Authorization") == "Bearer jwt.acc"
+
+    @patch("urllib.request.urlopen")
+    def test_ln_address_toggle_posts_enabled(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"ln_address_toggled": True})
+        client = Jan3AccountsClient(base_url=BASE_URL, access_token="jwt")
+        client.ln_address_toggle(True)
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url.endswith("/api/v1/auth/user/ln-address-toggle/")
+        assert json.loads(req.data.decode()) == {"enabled": True}
+
+    @patch("urllib.request.urlopen")
+    def test_ln_username_available_quotes_and_forwards_token(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"available": True})
+        client = Jan3AccountsClient(base_url=BASE_URL, access_token="jwt")
+        client.ln_username_available("alice.bob")
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url.endswith(
+            "/api/v1/auth/user/ln-username/alice.bob/is-available"
+        )
+        assert req.get_header("Authorization") == "Bearer jwt"
+
+    @patch("urllib.request.urlopen")
+    def test_ln_username_available_anonymous_without_token(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"available": True})
+        client = Jan3AccountsClient(base_url=BASE_URL)  # no access token
+        client.ln_username_available("alice")
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Authorization") is None
+
+    @patch("urllib.request.urlopen")
+    def test_register_addresses_override_adds_query(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"addresses": ["a", "b"]})
+        client = Jan3AccountsClient(base_url=BASE_URL, access_token="jwt")
+        client.register_addresses("fp1234", ["a", "b"], override_fingerprint=True)
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url.endswith("/api/v1/auth/user/addresses/?override_fingerprint=true")
+        assert json.loads(req.data.decode()) == {
+            "fingerprint": "fp1234",
+            "addresses": ["a", "b"],
+        }
+
+    @patch("urllib.request.urlopen")
+    def test_register_addresses_no_override_no_query(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"addresses": []})
+        client = Jan3AccountsClient(base_url=BASE_URL, access_token="jwt")
+        client.register_addresses("fp", [])
+        req = mock_urlopen.call_args[0][0]
+        assert "override_fingerprint" not in req.full_url
+
+    @patch("urllib.request.urlopen")
+    def test_create_payment_request_posts_body(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response(
+            {"payment_id": "p1", "address": VAULT_ADDR, "amount_base_units": 500}
+        )
+        client = Jan3AccountsClient(base_url=BASE_URL, access_token="jwt")
+        client.create_ln_username_payment_request("L-BTC", "alice")
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url.endswith(
+            "/api/v1/liquid-wallet/payment-request/ln-username/"
+        )
+        assert json.loads(req.data.decode()) == {"asset": "L-BTC", "ln_username": "alice"}
+
+    @patch("urllib.request.urlopen")
+    def test_submit_raw_tx_posts_body(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"status": "PENDING"})
+        client = Jan3AccountsClient(base_url=BASE_URL, access_token="jwt")
+        client.submit_raw_tx("p1", "deadbeef")
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url.endswith("/api/v1/liquid-wallet/payment/submit-raw-tx/")
+        assert json.loads(req.data.decode()) == {"payment_id": "p1", "raw_tx": "deadbeef"}
+
+
+# ---------------------------------------------------------------------------
+# Manager: LN-address pool (get_user auto-heal + toggle + register/ensure)
+# ---------------------------------------------------------------------------
+
+
+def _ln_manager(storage, *, fingerprint="abcd1234", raw_tx="0200deadbeef"):
+    """Manager wired to a wallet stub with controllable fingerprint + addresses."""
+    wm = _fake_wallet_manager(raw_tx)
+    wm.fingerprint.return_value = fingerprint
+    wm.reserve_addresses.side_effect = lambda name, count: [
+        MagicMock(address=f"lq1addr{i}") for i in range(count)
+    ]
+    mgr = Jan3AccountsManager(
+        storage=storage, wallet_manager=wm, base_url=BASE_URL
+    )
+    return mgr, wm
+
+
+class TestGetUserAutoPool:
+    def test_auto_refills_when_active(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        profile = {
+            "email": "me@example.com",
+            "ln_username": "alice",
+            "ln_address_toggled": True,
+            "fingerprint": "abcd1234",
+            "new_addresses_needed": 3,
+        }
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/addresses/": {"addresses": ["a", "b", "c"]},
+                "/user/": profile,
+            }),
+        ):
+            out = mgr.get_user("me@example.com")
+        assert out["ln_username"] == "alice"
+        assert out["ln_address_pool"]["refilled"] is True
+        assert out["ln_address_pool"]["requested_count"] == 3
+        wm.reserve_addresses.assert_called_once_with("default", 3)
+
+    def test_skips_when_toggle_off(self, storage):
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        profile = {
+            "ln_username": "alice",
+            "ln_address_toggled": False,
+            "fingerprint": "abcd1234",
+            "new_addresses_needed": 5,
+        }
+        with patch(
+            "urllib.request.urlopen", side_effect=_route({"/user/": profile})
+        ):
+            out = mgr.get_user("me@example.com")
+        assert out["ln_address_pool"]["reason"] == "ln_address_disabled"
+        wm.reserve_addresses.assert_not_called()
+
+    def test_pool_full_no_register(self, storage):
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        profile = {
+            "ln_username": "alice",
+            "ln_address_toggled": True,
+            "fingerprint": "abcd1234",
+            "new_addresses_needed": 0,
+        }
+        with patch(
+            "urllib.request.urlopen", side_effect=_route({"/user/": profile})
+        ):
+            out = mgr.get_user("me@example.com")
+        assert out["ln_address_pool"]["reason"] == "pool_full"
+        wm.reserve_addresses.assert_not_called()
+
+    def test_locked_wallet_never_breaks_read(self, storage):
+        mgr, wm = _ln_manager(storage)
+        wm.fingerprint.side_effect = ValueError("wallet is encrypted; password required")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        profile = {
+            "ln_username": "alice",
+            "ln_address_toggled": True,
+            "fingerprint": "abcd1234",
+            "new_addresses_needed": 3,
+        }
+        with patch(
+            "urllib.request.urlopen", side_effect=_route({"/user/": profile})
+        ):
+            out = mgr.get_user("me@example.com")
+        # Profile still returned; the failure is reported, not raised.
+        assert out["ln_username"] == "alice"
+        assert out["ln_address_pool"]["reason"] == "auto_topup_unavailable"
+        assert "encrypted" in out["ln_address_pool"]["detail"]
+
+
+class TestLnAddressToggleManager:
+    def test_enable_populates_pool(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        profile = {
+            "ln_username": "alice",
+            "ln_address_toggled": True,
+            "fingerprint": "abcd1234",
+            "new_addresses_needed": 2,
+        }
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/ln-address-toggle/": {"ln_address_toggled": True},
+                "/addresses/": {"addresses": ["a", "b"]},
+                "/user/": profile,
+            }),
+        ):
+            out = mgr.ln_address_toggle("me@example.com", True)
+        assert out["enabled"] is True
+        assert out["ln_address_pool"]["refilled"] is True
+        wm.reserve_addresses.assert_called_once_with("default", 2)
+
+    def test_disable_does_not_touch_pool(self, storage):
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({"/ln-address-toggle/": {"ln_address_toggled": False}}),
+        ):
+            out = mgr.ln_address_toggle("me@example.com", False)
+        assert out["enabled"] is False
+        assert "ln_address_pool" not in out
+        wm.reserve_addresses.assert_not_called()
+
+    def test_enable_without_username_reports_skip(self, storage):
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        profile = {"ln_username": None, "ln_address_toggled": True, "fingerprint": "fp"}
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/ln-address-toggle/": {"ok": True},
+                "/user/": profile,
+            }),
+        ):
+            out = mgr.ln_address_toggle("me@example.com", True)
+        assert out["ln_address_pool"]["reason"] == "no_ln_username"
+        wm.reserve_addresses.assert_not_called()
+
+
+class TestRegisterLnAddresses:
+    def test_raises_without_username(self, storage):
+        mgr, _ = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with pytest.raises(ValueError, match="no LN username"):
+            mgr.register_ln_addresses(
+                "me@example.com",
+                profile={"ln_username": None, "ln_address_toggled": True},
+            )
+
+    def test_fingerprint_mismatch_raises(self, storage):
+        mgr, _ = _ln_manager(storage, fingerprint="local999")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with pytest.raises(ValueError, match="fingerprint mismatch"):
+            mgr.register_ln_addresses(
+                "me@example.com",
+                profile={
+                    "ln_username": "alice",
+                    "ln_address_toggled": True,
+                    "fingerprint": "server111",
+                    "new_addresses_needed": 2,
+                },
+            )
+
+    def test_caps_count_at_max(self, storage):
+        mgr, _ = _ln_manager(storage, fingerprint="fp")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with pytest.raises(ValueError, match="cannot exceed"):
+            mgr.register_ln_addresses(
+                "me@example.com",
+                count=MAX_ADDRESSES_PER_REGISTRATION + 1,
+                profile={
+                    "ln_username": "alice",
+                    "ln_address_toggled": True,
+                    "fingerprint": "fp",
+                },
+            )
+
+    def test_default_count_when_none_needed(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="fp")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({"/addresses/": {"addresses": ["x"] * 5}}),
+        ):
+            out = mgr.register_ln_addresses(
+                "me@example.com",
+                profile={
+                    "ln_username": "alice",
+                    "ln_address_toggled": True,
+                    "fingerprint": "fp",
+                    "new_addresses_needed": 0,
+                },
+            )
+        wm.reserve_addresses.assert_called_once_with("default", DEFAULT_LN_ADDRESS_POOL)
+        assert out["requested_count"] == DEFAULT_LN_ADDRESS_POOL
+
+
+class TestEnsureLnPool:
+    def test_fingerprint_mismatch_skips(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="localfp")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        out = mgr.ensure_ln_pool(
+            "me@example.com",
+            profile={
+                "ln_username": "alice",
+                "ln_address_toggled": True,
+                "fingerprint": "serverfp",
+                "new_addresses_needed": 3,
+            },
+        )
+        assert out == {
+            "refilled": False,
+            "reason": "fingerprint_mismatch",
+            "server_fingerprint": "serverfp",
+            "local_fingerprint": "localfp",
+        }
+        wm.reserve_addresses.assert_not_called()
+
+    def test_no_username_skips(self, storage):
+        mgr, _ = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        out = mgr.ensure_ln_pool("me@example.com", profile={"ln_username": None})
+        assert out["reason"] == "no_ln_username"
+
+
+# ---------------------------------------------------------------------------
+# Manager: purchase LN username (on-chain L-BTC)
+# ---------------------------------------------------------------------------
+
+
+class TestPurchaseLnUsername:
+    def test_happy_path(self, storage):
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "computed-txid"
+        order = {
+            "payment_id": "pay1",
+            "address": VAULT_ADDR,
+            "amount_base_units": 777,
+            "asset_ticker": "L-BTC",
+        }
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=_route({
+                    "/payment-request/ln-username/": order,
+                    "/payment/submit-raw-tx/": {"status": "PENDING"},
+                }),
+            ),
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            out = mgr.purchase_ln_username("me@example.com", "alice")
+        assert out["txid"] == "computed-txid"
+        assert out["status"] == "PENDING"
+        assert out["ln_username"] == "alice"
+        assert out["amount_sats"] == 777
+        wm.craft_raw_tx.assert_called_once()
+
+    def test_missing_fields_raises(self, storage):
+        mgr, _ = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        order = {"payment_id": None, "address": None, "amount_base_units": 0}
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({"/payment-request/ln-username/": order}),
+        ):
+            with pytest.raises(ValueError, match="missing fields"):
+                mgr.purchase_ln_username("me@example.com", "alice")
+
+    def test_invalid_username_raises_before_network(self, storage):
+        mgr, _ = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with pytest.raises(ValueError, match="Invalid ln_username"):
+            mgr.purchase_ln_username("me@example.com", "bad..name")
 

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -1462,6 +1462,8 @@ class TestPurchaseLnUsername:
             "address": VAULT_ADDR,
             "amount_base_units": 777,
             "asset_ticker": "L-BTC",
+            "amount": "0.00000777",
+            "expires_at": "2026-07-03T18:13:55Z",
         }
         with (
             patch(
@@ -1473,12 +1475,40 @@ class TestPurchaseLnUsername:
             ),
             patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
         ):
-            out = mgr.purchase_ln_username("me@example.com", "alice")
+            out = mgr.purchase_ln_username("me@example.com", "alice", confirm=True)
+        assert out["confirmed"] is True
         assert out["txid"] == "computed-txid"
         assert out["status"] == "PENDING"
         assert out["ln_username"] == "alice"
-        assert out["amount_sats"] == 777
+        assert out["amount_base_units"] == 777
+        assert out["amount"] == "0.00000777"
+        assert out["expires_at"] == "2026-07-03T18:13:55Z"
+        assert out["display_amount"] == "777 Sats"
         wm.craft_raw_tx.assert_called_once()
+
+    def test_dry_run_quote_does_not_sign(self, storage):
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        order = {
+            "payment_id": "pay1",
+            "address": VAULT_ADDR,
+            "amount_base_units": 8_000_000,
+            "asset_ticker": "USDt",
+            "amount": "0.08000000",
+            "expires_at": "2026-07-03T18:13:55Z",
+        }
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({"/payment-request/ln-username/": order}),
+        ):
+            out = mgr.purchase_ln_username("me@example.com", "alice", asset="USDt")
+        assert out["requires_confirmation"] is True
+        assert out["confirmed"] is False
+        assert out["amount_base_units"] == 8_000_000
+        assert out["display_amount"] == "0.08 USDT"
+        assert out["expires_at"] == "2026-07-03T18:13:55Z"
+        assert "txid" not in out
+        wm.craft_raw_tx.assert_not_called()
 
     def test_missing_fields_raises(self, storage):
         mgr, _ = _ln_manager(storage)
@@ -1489,7 +1519,7 @@ class TestPurchaseLnUsername:
             side_effect=_route({"/payment-request/ln-username/": order}),
         ):
             with pytest.raises(ValueError, match="missing fields"):
-                mgr.purchase_ln_username("me@example.com", "alice")
+                mgr.purchase_ln_username("me@example.com", "alice", confirm=True)
 
     def test_invalid_username_raises_before_network(self, storage):
         mgr, _ = _ln_manager(storage)

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -539,7 +539,7 @@ class TestVerify:
         ):
             result = mgr.verify("me@example.com", "123456")
         assert "lightning address" in result["next_step"].lower()
-        assert "jan3_ln_address_toggle" in result["next_step"]
+        assert "jan3_enable_lightning_address" in result["next_step"]
 
     def test_propagates_invalid_otp_and_saves_nothing(self, storage):
         mgr = _manager(storage)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,6 +6,8 @@ import os
 import stat
 import sys
 import tempfile
+import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -63,6 +65,61 @@ class TestWalletDataAddressCounter:
         })
         assert w.next_address_index == 0
         assert not hasattr(w, "some_future_field")
+
+
+class TestWalletLock:
+    """Cross-process lock guarding wallet-record read-modify-writes."""
+
+    def test_serializes_concurrent_holders(self, temp_storage):
+        order = []
+
+        def holder():
+            with temp_storage.wallet_lock("w"):
+                order.append("a-in")
+                time.sleep(0.3)
+                order.append("a-out")
+
+        t = threading.Thread(target=holder)
+        t.start()
+        time.sleep(0.1)  # let the thread grab the lock first
+        with temp_storage.wallet_lock("w"):
+            order.append("b-in")
+        t.join(timeout=5)
+        assert order == ["a-in", "a-out", "b-in"]
+
+    def test_timeout_raises(self, temp_storage):
+        release = threading.Event()
+        held = threading.Event()
+
+        def holder():
+            with temp_storage.wallet_lock("w"):
+                held.set()
+                release.wait(timeout=5)
+
+        t = threading.Thread(target=holder)
+        t.start()
+        assert held.wait(timeout=5)
+        with pytest.raises(TimeoutError, match="another aqua process"):
+            with temp_storage.wallet_lock("w", timeout_seconds=0.15):
+                pass
+        release.set()
+        t.join(timeout=5)
+
+    def test_reacquire_after_release(self, temp_storage):
+        for _ in range(2):
+            with temp_storage.wallet_lock("w"):
+                pass
+
+    def test_locks_are_per_wallet(self, temp_storage):
+        # A lock on wallet "a" must not exclude wallet "b".
+        with temp_storage.wallet_lock("a"):
+            with temp_storage.wallet_lock("b", timeout_seconds=0.5):
+                pass
+
+    def test_lock_file_not_listed_as_wallet(self, temp_storage):
+        with temp_storage.wallet_lock("w"):
+            pass
+        assert "w" not in temp_storage.list_wallets()
 
 
 class TestStorage:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -29,6 +29,42 @@ def temp_storage():
         yield Storage(Path(tmpdir))
 
 
+class TestWalletDataAddressCounter:
+    """The ``next_address_index`` counter + its legacy migration."""
+
+    def test_defaults_to_zero(self):
+        w = WalletData(name="w", network="mainnet", descriptor="ct")
+        assert w.next_address_index == 0
+
+    def test_roundtrip_preserves_counter(self):
+        w = WalletData(
+            name="w", network="mainnet", descriptor="ct", next_address_index=7
+        )
+        assert WalletData.from_dict(w.to_dict()).next_address_index == 7
+
+    def test_migrates_legacy_ln_addr_next_index(self):
+        w = WalletData.from_dict({
+            "name": "w", "network": "mainnet", "descriptor": "ct",
+            "ln_addr_next_index": 12,
+        })
+        assert w.next_address_index == 12
+
+    def test_new_key_wins_over_legacy(self):
+        w = WalletData.from_dict({
+            "name": "w", "network": "mainnet", "descriptor": "ct",
+            "ln_addr_next_index": 12, "next_address_index": 99,
+        })
+        assert w.next_address_index == 99
+
+    def test_drops_unknown_future_keys(self):
+        w = WalletData.from_dict({
+            "name": "w", "network": "mainnet", "descriptor": "ct",
+            "some_future_field": "x",
+        })
+        assert w.next_address_index == 0
+        assert not hasattr(w, "some_future_field")
+
+
 class TestStorage:
     """Tests for Storage class."""
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1237,6 +1237,7 @@ class TestToolRegistry:
             "jan3_logout",
             "jan3_user_info",
             "jan3_enable_lightning_address",
+            "jan3_rebind_wallet",
             "jan3_ln_check_username",
             "jan3_purchase_ln_username",
         }

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1223,6 +1223,10 @@ class TestToolRegistry:
             "jan3_session_info",
             "jan3_list_sessions",
             "jan3_logout",
+            "jan3_get_user",
+            "jan3_ln_address_toggle",
+            "jan3_ln_username_check_available",
+            "jan3_purchase_ln_username",
         }
         assert set(TOOLS.keys()) == expected
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -251,6 +251,18 @@ class TestAddress:
         addr = result["address"]
         assert addr.startswith("lq1") or addr.startswith("VJL") or addr.startswith("VTp")
 
+    def test_no_index_is_idempotent(self):
+        """Repeated no-index calls show the SAME address (read-only display peek).
+
+        lw_address is a pure display path: it must not advance the counter, so
+        re-showing "my address" returns the same one until it is funded.
+        """
+        lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="peek_test")
+        r1 = lw_address(wallet_name="peek_test")
+        r2 = lw_address(wallet_name="peek_test")
+        assert r1["address"] == r2["address"]
+        assert r1["index"] == r2["index"]
+
     def test_specific_index(self):
         """Requesting a specific index returns that index."""
         lw_import_mnemonic(mnemonic=TEST_MNEMONIC, wallet_name="idx_test")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1223,9 +1223,9 @@ class TestToolRegistry:
             "jan3_session_info",
             "jan3_list_sessions",
             "jan3_logout",
-            "jan3_get_user",
-            "jan3_ln_address_toggle",
-            "jan3_ln_username_check_available",
+            "jan3_user_info",
+            "jan3_enable_lightning_address",
+            "jan3_ln_check_username",
             "jan3_purchase_ln_username",
         }
         assert set(TOOLS.keys()) == expected

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -73,3 +73,114 @@ class TestFingerprint:
         assert wallet_manager.fingerprint("default") == wallet_manager.fingerprint(
             "default"
         )
+
+
+class TestEncryptedWalletNoPassword:
+    """An at-rest-encrypted wallet still yields a fingerprint and fresh receive
+    addresses WITHOUT the password — deriving addresses needs only the
+    descriptor (xpub), not the mnemonic. This is the real behavior behind the
+    LN-address pool self-heal: jan3_user_info can top up the pool of a
+    password-encrypted wallet without ever decrypting the seed.
+    """
+
+    def test_fingerprint_and_reserve_without_password(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = Storage(Path(tmpdir))
+            # Import with an at-rest password, then drop the cached signer by
+            # using a FRESH manager over the same storage (as a new process
+            # would) so no mnemonic is available in-memory.
+            WalletManager(storage=storage).import_mnemonic(
+                TEST_MNEMONIC, "enc", "testnet", password="pw-123-strong"
+            )
+            fresh = WalletManager(storage=storage)
+
+            # No password supplied: fingerprint falls back to the descriptor's
+            # [fp/derivation] block and reserve_addresses derives from the
+            # descriptor — neither needs the decrypted mnemonic.
+            fp = fresh.fingerprint("enc")
+            assert len(fp) == 8
+            int(fp, 16)
+            addrs = fresh.reserve_addresses("enc", 2)
+            assert len({a.address for a in addrs}) == 2
+
+    def test_descriptor_fingerprint_matches_signer(self):
+        # The watch-only descriptor parse must yield the SAME fingerprint the
+        # loaded signer reports, so the account↔wallet binding is consistent
+        # whether or not the wallet is unlocked.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storage = Storage(Path(tmpdir))
+            hot = WalletManager(storage=storage)
+            hot.import_mnemonic(
+                TEST_MNEMONIC, "enc", "testnet", password="pw-123-strong"
+            )
+            signer_fp = hot.fingerprint("enc")  # from the cached signer
+
+            descriptor_fp = WalletManager(storage=storage).fingerprint("enc")
+            assert descriptor_fp == signer_fp
+
+
+class TestPeekAddress:
+    """peek_address is the idempotent DISPLAY path (backs lw_address): it must
+    never advance the counter, never write to disk, and never surface an index
+    already committed to a swap/pool reserve.
+    """
+
+    def test_peek_is_idempotent(self, wallet_manager):
+        a = wallet_manager.peek_address("default")
+        b = wallet_manager.peek_address("default")
+        assert a.address == b.address
+        assert a.index == b.index
+
+    def test_peek_does_not_advance_counter(self, wallet_manager):
+        before = wallet_manager.storage.load_wallet("default").next_address_index
+        wallet_manager.peek_address("default")
+        wallet_manager.peek_address("default")
+        after = wallet_manager.storage.load_wallet("default").next_address_index
+        assert after == before
+
+    def test_peek_frontier_is_never_below_committed(self, wallet_manager):
+        # Reserve (commit) indices 0..4, advancing the counter to 5.
+        reserved = wallet_manager.reserve_addresses("default", 5)
+        committed = {a.index for a in reserved}
+        counter = wallet_manager.storage.load_wallet("default").next_address_index
+        peek = wallet_manager.peek_address("default")
+        # Display must land ON the frontier, never on an already-committed index.
+        assert peek.index >= counter
+        assert peek.index not in committed
+
+    def test_peek_explicit_index_does_not_advance(self, wallet_manager):
+        before = wallet_manager.storage.load_wallet("default").next_address_index
+        got = wallet_manager.peek_address("default", index=3)
+        after = wallet_manager.storage.load_wallet("default").next_address_index
+        assert got.index == 3
+        assert after == before
+
+    def test_peek_moves_forward_after_reserve(self, wallet_manager):
+        # A pure display peek is idempotent, but once an address is COMMITTED via
+        # reserve the frontier advances, so the next peek shows a new address —
+        # display never re-shows an index handed to an external party.
+        first = wallet_manager.peek_address("default")
+        wallet_manager.reserve_addresses("default", 1)
+        second = wallet_manager.peek_address("default")
+        assert second.index > first.index
+
+    def test_sync_scans_strictly_past_peek_frontier(self, wallet_manager, monkeypatch):
+        # Fund-safety invariant: peek can display an address AT next_address_index
+        # (the frontier). sync_wallet must scan STRICTLY past it, so a payment to
+        # a freshly-displayed high-index address is discovered regardless of
+        # whether lwk's full_scan_to_index bound is inclusive or exclusive.
+        from unittest.mock import MagicMock
+
+        wallet_manager.reserve_addresses("default", 5)  # counter -> 5
+        counter = wallet_manager.storage.load_wallet("default").next_address_index
+        peek = wallet_manager.peek_address("default")
+        assert peek.index == counter  # frontier sits exactly at the scan boundary
+
+        fake = MagicMock()
+        fake.full_scan_to_index.return_value = None
+        monkeypatch.setattr(wallet_manager, "_get_client", lambda network: fake)
+        wallet_manager.sync_wallet("default")
+
+        fake.full_scan_to_index.assert_called_once()
+        scanned_to = fake.full_scan_to_index.call_args.args[1]
+        assert scanned_to > peek.index

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -62,6 +62,89 @@ class TestAddressCounter:
         indices = {one.index} | {a.index for a in batch}
         assert len(indices) == 4  # all distinct — no reuse across the two paths
 
+    def test_counter_promoted_when_lwk_tip_is_higher(self, wallet_manager):
+        """The handout frontier is max(lwk tip, counter): a handed-out index is
+        never below the persisted counter, and the counter advances past it."""
+        record = wallet_manager.storage.load_wallet("default")
+        record.next_address_index = 100
+        wallet_manager.storage.save_wallet(record)
+        out = wallet_manager.get_address("default")
+        assert out.index >= 100
+        after = wallet_manager.storage.load_wallet("default").next_address_index
+        assert after == out.index + 1
+
+    def test_reserve_waits_for_wallet_lock(self, wallet_manager):
+        # reserve_addresses must hold the cross-process wallet lock for its
+        # read-modify-write: while another holder has it, the reserve blocks.
+        import threading
+        import time
+
+        got: list[int] = []
+
+        def reserve():
+            got.append(wallet_manager.get_address("default").index)
+
+        with wallet_manager.storage.wallet_lock("default"):
+            t = threading.Thread(target=reserve)
+            t.start()
+            time.sleep(0.3)
+            assert not got  # blocked while the lock is held elsewhere
+        t.join(timeout=5)
+        assert got  # proceeded once the lock was released
+
+    def test_ensure_counter_covers_repairs_reset_counter(self, wallet_manager):
+        # Simulate a seed reimport: server pool holds indices 5..7 but the
+        # local counter is 0; reconciliation must bump it past the highest.
+        pool = [
+            wallet_manager.peek_address("default", index=i).address
+            for i in (5, 6, 7)
+        ]
+        assert wallet_manager.storage.load_wallet("default").next_address_index == 0
+        new_counter = wallet_manager.ensure_counter_covers("default", pool)
+        assert new_counter == 8
+        rec = wallet_manager.storage.load_wallet("default")
+        assert rec.next_address_index == 8
+        # The next handout must sit above the recovered pool.
+        assert wallet_manager.get_address("default").index >= 8
+
+    def test_ensure_counter_covers_is_idempotent_and_never_lowers(
+        self, wallet_manager
+    ):
+        wallet_manager.reserve_addresses("default", 10)
+        pool = [wallet_manager.peek_address("default", index=2).address]
+        counter = wallet_manager.ensure_counter_covers("default", pool)
+        assert counter == 10  # already covered — unchanged
+
+    def test_ensure_counter_covers_ignores_foreign_addresses(self, wallet_manager):
+        counter = wallet_manager.ensure_counter_covers(
+            "default", ["lq1qqnotfromthiswallet"]
+        )
+        assert counter == 0
+
+    def test_concurrent_reserves_never_share_an_index(self, wallet_manager):
+        # Two racing reservers must produce disjoint index ranges and a
+        # counter equal to the total handed out.
+        import threading
+
+        results: list[list[int]] = [[], []]
+
+        def reserve(slot):
+            results[slot] = [
+                a.index for a in wallet_manager.reserve_addresses("default", 5)
+            ]
+
+        threads = [
+            threading.Thread(target=reserve, args=(i,)) for i in range(2)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+        all_indices = results[0] + results[1]
+        assert len(set(all_indices)) == 10  # no shared index
+        rec = wallet_manager.storage.load_wallet("default")
+        assert rec.next_address_index == max(all_indices) + 1
+
 
 class TestFingerprint:
     def test_hot_wallet_fingerprint_is_8_hex(self, wallet_manager):

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1,0 +1,75 @@
+"""Tests for WalletManager's persistent address counter + fingerprint.
+
+These back the LN-address feature: ``reserve_addresses`` mints unused Liquid
+receive addresses for the JAN3 LN-address pool, and ``fingerprint`` binds the
+account to a wallet. The no-arg ``get_address`` was changed to advance a
+persisted counter so off-chain handouts never reuse an index.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from aqua.storage import Storage
+from aqua.wallet import WalletManager
+from tests.conftest import TEST_MNEMONIC
+
+
+@pytest.fixture
+def wallet_manager():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        wm = WalletManager(storage=Storage(Path(tmpdir)))
+        wm.import_mnemonic(TEST_MNEMONIC, "default", "testnet")
+        yield wm
+
+
+class TestAddressCounter:
+    def test_get_address_no_arg_advances_and_is_unique(self, wallet_manager):
+        a = wallet_manager.get_address("default")
+        b = wallet_manager.get_address("default")
+        assert a.address != b.address
+        assert b.index > a.index
+
+    def test_get_address_persists_counter(self, wallet_manager):
+        first = wallet_manager.get_address("default")
+        rec = wallet_manager.storage.load_wallet("default")
+        assert rec.next_address_index > first.index
+
+    def test_explicit_index_does_not_advance_counter(self, wallet_manager):
+        before = wallet_manager.storage.load_wallet("default").next_address_index
+        got = wallet_manager.get_address("default", index=0)
+        after = wallet_manager.storage.load_wallet("default").next_address_index
+        assert got.index == 0
+        assert after == before
+
+    def test_reserve_addresses_batches_distinct(self, wallet_manager):
+        addrs = wallet_manager.reserve_addresses("default", 5)
+        assert len(addrs) == 5
+        assert len({a.address for a in addrs}) == 5
+        rec = wallet_manager.storage.load_wallet("default")
+        assert rec.next_address_index >= addrs[-1].index + 1
+
+    def test_reserve_addresses_rejects_nonpositive(self, wallet_manager):
+        with pytest.raises(ValueError, match="positive"):
+            wallet_manager.reserve_addresses("default", 0)
+
+    def test_get_address_and_reserve_never_collide(self, wallet_manager):
+        one = wallet_manager.get_address("default")
+        batch = wallet_manager.reserve_addresses("default", 3)
+        indices = {one.index} | {a.index for a in batch}
+        assert len(indices) == 4  # all distinct — no reuse across the two paths
+
+
+class TestFingerprint:
+    def test_hot_wallet_fingerprint_is_8_hex(self, wallet_manager):
+        fp = wallet_manager.fingerprint("default")
+        assert len(fp) == 8
+        int(fp, 16)  # must parse as hex
+
+    def test_fingerprint_is_stable(self, wallet_manager):
+        assert wallet_manager.fingerprint("default") == wallet_manager.fingerprint(
+            "default"
+        )


### PR DESCRIPTION
### Purpose

Implement Lightning Address support for JAN3/AQUA users. Closes #108 Feature: Implement Lightning Address.

Each user gets a Lightning Address (`username@domain`) backed by a rotating pool of Liquid receive addresses registered with the AQUA backend. The wallet↔account binding is maintained via a fingerprint hash.

#### Main Changes

- ✨ Added `jan3_user_info` — fetch account profile; auto-tops-up LN address pool when active
- ✨ Added `jan3_enable_lightning_address` — toggle LN-address delivery; populates address pool on enable
- ✨ Added `jan3_ln_check_username` / `jan3_purchase_ln_username` — check availability and buy/update a Lightning Address username (funded via signed L-BTC tx)
- ✨ Added `jan3_rebind_wallet` — re-register the wallet↔account binding (fingerprint + email hash)
- ♻️ Expanded `Jan3AccountsManager` with `register_ln_addresses`, `ensure_ln_pool`, `rebind_wallet`, `purchase_ln_username`
- 🗃️ `WalletData` gains `next_address_index` for sequential, non-reusing address handouts
- ✅ Tests for all new tools, manager methods, CLI commands, and storage migration

### Checklist

- [x] No hardcoded values (they should go in constants.py, .env, or our database)
- [x] Added/updated tests (if necessary)
- [x] Added/updated relevant documentation (if necessary)
