### PR TITLE
:eyes: 108 jan3 ln address PR Review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,14 @@ which now builds a `Jan3AccountsManager`) and delegates provisioning to it.
     `WalletManager.fingerprint` (account↔wallet binding); the no-arg
     `get_address` advances a persisted `WalletData.next_address_index` counter so
     off-chain handouts never reuse an index.
+  - `next_address_index` caveats: the counter lives **only in the local wallet
+    JSON**. A seed reimport (or deleted `~/.aqua`) resets it to 0 while the
+    server still delivers to the previously registered pool; the first
+    successful pool registration repairs it (`ensure_counter_covers` matches
+    the server's unused pool against derivations and bumps the counter), but
+    until then no-arg `get_address` can re-hand pool indices. **Downgrade
+    break**: releases ≤ v0.4.2 construct `WalletData` strictly and crash on
+    wallet files containing this key — call it out in release notes.
 
 ## WapuPay (Argentine direct-fiat)
 

--- a/src/aqua/cli/jan3.py
+++ b/src/aqua/cli/jan3.py
@@ -264,8 +264,7 @@ def purchase_ln_username(ctx, email, ln_username, wallet_name, asset, assume_yes
     """
     expected_amount_base_units = None
     if not assume_yes:
-        # 1) Non-spending price quote (no signing, no password). The server
-        # locks the price on this order; the confirm step funds it verbatim.
+        # 1) Non-spending price quote — the server locks the price on this order.
         try:
             quote = jan3_purchase_ln_username(
                 email=email,

--- a/src/aqua/cli/jan3.py
+++ b/src/aqua/cli/jan3.py
@@ -258,27 +258,32 @@ def ln_check_username(ctx, email, ln_username):
 def purchase_ln_username(ctx, email, ln_username, wallet_name, asset, assume_yes, password_stdin):
     """Buy / update the Lightning username with an on-chain payment (L-BTC or USDt).
 
-    Quotes the price first and asks for confirmation unless --yes is given.
+    Quotes the price and asks for confirmation; the payment then funds that
+    exact quoted order (aborting if it expired). --yes skips the quote and
+    accepts the current price.
     """
-    # 1) Non-spending price quote (no signing, no password).
-    try:
-        quote = jan3_purchase_ln_username(
-            email=email,
-            ln_username=ln_username,
-            wallet_name=wallet_name,
-            asset=asset,
-            confirm=False,
-        )
-    except Exception as e:
-        raise click.UsageError(f"Could not fetch the price quote: {e}") from e
-
+    expected_amount_base_units = None
     if not assume_yes:
+        # 1) Non-spending price quote (no signing, no password). The server
+        # locks the price on this order; the confirm step funds it verbatim.
+        try:
+            quote = jan3_purchase_ln_username(
+                email=email,
+                ln_username=ln_username,
+                wallet_name=wallet_name,
+                asset=asset,
+                confirm=False,
+            )
+        except Exception as e:
+            raise click.UsageError(f"Could not fetch the price quote: {e}") from e
+
         click.echo(
             f"Lightning Address {ln_username!r} costs "
             f"{quote.get('display_amount')} (quote expires {quote.get('expires_at')}).",
             err=True,
         )
         click.confirm("Proceed with the payment?", abort=True, err=True)
+        expected_amount_base_units = quote.get("amount_base_units")
 
     # 2) Confirmed — resolve the password and fund the purchase.
     password = resolve_secret(
@@ -295,6 +300,7 @@ def purchase_ln_username(ctx, email, ln_username, wallet_name, asset, assume_yes
                 "asset": asset,
                 "password": password,
                 "confirm": True,
+                "expected_amount_base_units": expected_amount_base_units,
             },
         ),
     )

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -1000,7 +1000,24 @@ class Jan3AccountsManager:
             )
 
         server_fp = user.get("fingerprint")
-        local_fp = self.wallet_manager.fingerprint(wallet_name)
+        try:
+            local_fp = self.wallet_manager.fingerprint(wallet_name)
+        except ValueError as e:
+            # Permanent for this wallet (e.g. a watch-only import from a bare
+            # descriptor with no [fingerprint/derivation] block) — unlike a
+            # transient backend error, retrying can never succeed. Use a
+            # distinct reason with remediation so it isn't mistaken for the
+            # generic auto_topup_unavailable.
+            return _skip(
+                "wallet_fingerprint_unavailable",
+                message=(
+                    f"The pool was NOT topped up: wallet {wallet_name!r} cannot "
+                    f"produce a fingerprint ({e}). This is permanent for this "
+                    "wallet — re-import it from its mnemonic, or from a "
+                    "descriptor that includes the [fingerprint/derivation] "
+                    "key-origin block, then retry."
+                ),
+            )
         if server_fp and server_fp != local_fp:
             return _skip(
                 "fingerprint_mismatch",

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -67,8 +67,7 @@ ASSET_TICKER_USDT = "USDt"
 LN_USERNAME_PAYMENT_REQUEST_PATH = "/api/v1/liquid-wallet/payment-request/ln-username/"
 SUBMIT_RAW_TX_PATH = "/api/v1/liquid-wallet/payment/submit-raw-tx/"
 
-# Server-side per-call cap on address registration, and the app's default pool
-# size to register when the server doesn't report how many are needed.
+# Server-side per-call cap on address registration; default pool size otherwise.
 MAX_ADDRESSES_PER_REGISTRATION = 15
 DEFAULT_LN_ADDRESS_POOL = 5
 
@@ -76,20 +75,14 @@ DEFAULT_LN_ADDRESS_POOL = 5
 # catches obvious mistakes before we make a network call.
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
-# Mirrors aqua-ankara's common.constants.LN_USERNAME_REGEX so we fail fast
-# before a network call: lowercase alphanumerics with at most one dot.
+# Mirrors aqua-ankara's LN_USERNAME_REGEX to fail fast before a network call.
 LN_USERNAME_REGEX = re.compile(r"^[a-z0-9]+(\.[a-z0-9]+)?$")
 
 
 def _format_display_amount(amount_base_units: int, asset_ticker: str) -> str:
     """Render a human-facing price string for the agent to surface verbatim.
 
-    ``amount_base_units`` is the technical integer the wallet actually funds — the
-    single source of truth — but for the user it must be shown per-asset:
-
-    * **L-BTC** — base units *are* satoshis → ``"2000 Sats"``.
-    * **USDt** (and other 8-decimal Liquid assets) → a 2-decimal fiat-style
-      amount (``base_units / 1e8``) → ``"1.50 USDT"``.
+    L-BTC is shown in Sats; other assets (e.g. USDt) as a 2-decimal fiat-style amount.
     """
     ticker = (asset_ticker or "").strip()
     if ticker.upper() in ("L-BTC", "LBTC", "BTC"):
@@ -852,12 +845,8 @@ class Jan3AccountsManager:
     ) -> dict:
         """Mint ``count`` unused Liquid receive addresses and POST to /auth/user/addresses/.
 
-        Internal — not an MCP tool. Raises on hard errors (no username, disabled,
-        fingerprint mismatch); callers on the auto path wrap these into skip dicts.
-
-        If the previous POST for this wallet failed, its batch (persisted on the
-        session) is re-uploaded verbatim — ``count`` is ignored for that attempt —
-        so retries never mint additional indices.
+        Internal — not an MCP tool. A previously failed POST's batch is re-uploaded
+        verbatim (``count`` ignored) so retries never mint additional indices.
         """
         email = _validate_email(email)
         user = (
@@ -900,10 +889,7 @@ class Jan3AccountsManager:
                 "(server-side per-call limit)"
             )
 
-        # A previous POST for this wallet may have failed with unknown outcome.
-        # Re-upload that exact batch instead of burning fresh indices (the
-        # server ignores duplicates), so a backend outage costs one batch total
-        # rather than one batch per attempt.
+        # Re-upload a batch left pending by a previous failed POST (the server dedups).
         session = self.load_session(email)
         pending = session.pending_ln_registration if session else None
         if (
@@ -919,8 +905,7 @@ class Jan3AccountsManager:
                 for a in self.wallet_manager.reserve_addresses(wallet_name, count)
             ]
             if session is not None:
-                # Persist before the POST: if it fails (or secretly succeeds),
-                # the batch is retried verbatim next time, never re-minted.
+                # Persist before the POST so a failed/unknown outcome retries verbatim.
                 session.pending_ln_registration = {
                     "wallet_name": wallet_name,
                     "fingerprint": local_fp,
@@ -935,17 +920,13 @@ class Jan3AccountsManager:
             ),
         )
 
-        # Registered — clear the pending batch. Re-load first: the POST may
-        # have refreshed tokens and rewritten the session file.
+        # Clear the pending batch; re-load since the POST may have rewritten the session.
         session = self.load_session(email)
         if session is not None and session.pending_ln_registration is not None:
             session.pending_ln_registration = None
             self.save_session(session)
 
-        # The response carries the wallet's FULL unused pool. Addresses we did
-        # not just upload can predate this install (seed reimport reset the
-        # local counter to 0 while the server kept delivering to them) —
-        # advance the counter past them so no other flow re-hands them out.
+        # Advance past pool addresses we didn't just upload (e.g. post-reimport).
         pool = resp.get("addresses", []) or []
         posted = set(addresses)
         unknown = [a for a in pool if a not in posted]
@@ -1003,11 +984,7 @@ class Jan3AccountsManager:
         try:
             local_fp = self.wallet_manager.fingerprint(wallet_name)
         except ValueError as e:
-            # Permanent for this wallet (e.g. a watch-only import from a bare
-            # descriptor with no [fingerprint/derivation] block) — unlike a
-            # transient backend error, retrying can never succeed. Use a
-            # distinct reason with remediation so it isn't mistaken for the
-            # generic auto_topup_unavailable.
+            # Distinct from auto_topup_unavailable: this is permanent, not transient.
             return _skip(
                 "wallet_fingerprint_unavailable",
                 message=(
@@ -1170,18 +1147,11 @@ class Jan3AccountsManager:
     ) -> dict:
         """Buy / update the Lightning username for ``email`` (on-chain payment).
 
-        Two-step to avoid spending without consent:
-
-        * ``confirm=False`` (default) — creates a payment request (the server
-          locks the price and expiry on that order) and returns a **quote**
-          including its ``payment_id``; nothing is signed or broadcast. The
-          quote is remembered on the session.
-        * ``confirm=True`` — funds the quoted order exactly: same
-          ``payment_id``, same amount the user approved. The backend rejects
-          expired orders and any tx whose amount/address differ from the
-          order's. Without a prior matching quote (e.g. CLI ``--yes``), it
-          creates a fresh order and funds it in one go —
-          ``expected_amount_base_units`` bounds what that path may spend.
+        Two-step to avoid spending without consent: ``confirm=False`` (default)
+        locks in a price quote without signing/broadcasting; ``confirm=True`` funds
+        that exact quoted order (rejecting it if expired or altered). Without a
+        prior matching quote it creates and funds a fresh order in one go, bounded
+        by ``expected_amount_base_units``.
         """
         email = _validate_email(email)
         ln_username = _validate_ln_username(ln_username)
@@ -1205,8 +1175,7 @@ class Jan3AccountsManager:
             }
 
         def _create_order() -> dict:
-            # NOTE: the backend expires any previous pending LN_USERNAME order
-            # for this user before creating the new one.
+            # The backend expires any previous pending LN_USERNAME order for this user.
             return _parse_order(
                 self._with_auth_retry(
                     email,
@@ -1217,8 +1186,7 @@ class Jan3AccountsManager:
             )
 
         if not confirm:
-            # Dry-run quote: no signing, no broadcast. The caller must show
-            # ``display_amount`` to the user and re-call with confirm=True.
+            # Dry-run quote: no signing/broadcast; caller re-calls with confirm=True.
             fields = _create_order()
             display_amount = _format_display_amount(
                 fields["amount_base_units"], fields["asset_ticker"]
@@ -1260,8 +1228,7 @@ class Jan3AccountsManager:
             fields = {k: v for k, v in pending.items() if k != "ln_username"}
 
         if fields is None:
-            # No matching quote (--yes / stateless path): create and fund in
-            # one go, bounded by the caller-approved ceiling when given.
+            # No matching quote (--yes / stateless path): create and fund in one go.
             fields = _create_order()
 
         if (
@@ -1293,8 +1260,7 @@ class Jan3AccountsManager:
             asset_id=asset_id,
             password=password,
         )
-        # The API response omits the txid; compute it locally from the finalized
-        # raw tx so the caller has something to track on a block explorer.
+        # The API response omits the txid; compute it locally from the finalized raw tx.
         txid = str(lwk.Transaction(raw_tx).txid())
 
         result = self._with_auth_retry(
@@ -1304,8 +1270,7 @@ class Jan3AccountsManager:
             ),
         )
 
-        # Funded — consume the quote. Re-load first: the submit may have
-        # refreshed tokens and rewritten the session file.
+        # Funded — consume the quote; re-load since the submit may have rewritten the session.
         session = self.load_session(email)
         if session is not None and session.pending_ln_purchase is not None:
             session.pending_ln_purchase = None

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -176,6 +176,11 @@ class Jan3Session:
     #  "asset_ticker", "amount", "expires_at"}. confirm=True funds THIS order
     # instead of re-quoting; cleared once funded.
     pending_ln_purchase: Optional[dict] = None
+    # LN-address batch whose registration POST failed with unknown outcome:
+    # {"wallet_name", "fingerprint", "addresses"}. Retried verbatim on the next
+    # registration instead of burning fresh indices (the server dedups
+    # re-uploads), cleared once a POST succeeds.
+    pending_ln_registration: Optional[dict] = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -188,6 +193,7 @@ class Jan3Session:
         data.setdefault("refreshed_at", None)
         data.setdefault("captcha_exempt", False)
         data.setdefault("pending_ln_purchase", None)
+        data.setdefault("pending_ln_registration", None)
         return cls(**data)
 
 
@@ -848,6 +854,10 @@ class Jan3AccountsManager:
 
         Internal — not an MCP tool. Raises on hard errors (no username, disabled,
         fingerprint mismatch); callers on the auto path wrap these into skip dicts.
+
+        If the previous POST for this wallet failed, its batch (persisted on the
+        session) is re-uploaded verbatim — ``count`` is ignored for that attempt —
+        so retries never mint additional indices.
         """
         email = _validate_email(email)
         user = (
@@ -890,15 +900,48 @@ class Jan3AccountsManager:
                 "(server-side per-call limit)"
             )
 
-        addresses = [
-            a.address for a in self.wallet_manager.reserve_addresses(wallet_name, count)
-        ]
+        # A previous POST for this wallet may have failed with unknown outcome.
+        # Re-upload that exact batch instead of burning fresh indices (the
+        # server ignores duplicates), so a backend outage costs one batch total
+        # rather than one batch per attempt.
+        session = self.load_session(email)
+        pending = session.pending_ln_registration if session else None
+        if (
+            pending
+            and pending.get("addresses")
+            and pending.get("wallet_name") == wallet_name
+            and pending.get("fingerprint") == local_fp
+        ):
+            addresses = list(pending["addresses"])
+        else:
+            addresses = [
+                a.address
+                for a in self.wallet_manager.reserve_addresses(wallet_name, count)
+            ]
+            if session is not None:
+                # Persist before the POST: if it fails (or secretly succeeds),
+                # the batch is retried verbatim next time, never re-minted.
+                session.pending_ln_registration = {
+                    "wallet_name": wallet_name,
+                    "fingerprint": local_fp,
+                    "addresses": addresses,
+                }
+                self.save_session(session)
+
         resp = self._with_auth_retry(
             email,
             lambda access: self._authed_client(access).register_addresses(
                 local_fp, addresses, override_fingerprint=override_fingerprint
             ),
         )
+
+        # Registered — clear the pending batch. Re-load first: the POST may
+        # have refreshed tokens and rewritten the session file.
+        session = self.load_session(email)
+        if session is not None and session.pending_ln_registration is not None:
+            session.pending_ln_registration = None
+            self.save_session(session)
+
         return {
             "requested_count": len(addresses),
             "pool_size": len(resp.get("addresses", [])),

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -942,11 +942,28 @@ class Jan3AccountsManager:
             session.pending_ln_registration = None
             self.save_session(session)
 
+        # The response carries the wallet's FULL unused pool. Addresses we did
+        # not just upload can predate this install (seed reimport reset the
+        # local counter to 0 while the server kept delivering to them) —
+        # advance the counter past them so no other flow re-hands them out.
+        pool = resp.get("addresses", []) or []
+        posted = set(addresses)
+        unknown = [a for a in pool if a not in posted]
+        if unknown:
+            try:
+                self.wallet_manager.ensure_counter_covers(wallet_name, unknown)
+            except Exception as e:  # best-effort repair; registration succeeded
+                logger.warning(
+                    "LN-pool counter reconciliation skipped for wallet %r: %s",
+                    wallet_name,
+                    e,
+                )
+
         return {
             "requested_count": len(addresses),
-            "pool_size": len(resp.get("addresses", [])),
+            "pool_size": len(pool),
             "fingerprint": local_fp,
-            "addresses": resp.get("addresses", []),
+            "addresses": pool,
         }
 
     def ensure_ln_pool(

--- a/src/aqua/jan3_accounts.py
+++ b/src/aqua/jan3_accounts.py
@@ -103,6 +103,17 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _order_expired(iso_ts: Optional[str]) -> bool:
+    """True when an order's ISO ``expires_at`` is in the past (unparseable → False)."""
+    if not iso_ts:
+        return False
+    try:
+        dt = datetime.fromisoformat(str(iso_ts).replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return dt <= datetime.now(UTC)
+
+
 def _token_preview(token: str) -> str:
     """Return a short, log-safe preview of a token (``abcd…wxyz``).
 
@@ -160,6 +171,11 @@ class Jan3Session:
     created_at: str
     refreshed_at: Optional[str] = None
     captcha_exempt: bool = False
+    # Locked quote from purchase_ln_username(confirm=False):
+    # {"ln_username", "payment_id", "address", "amount_base_units",
+    #  "asset_ticker", "amount", "expires_at"}. confirm=True funds THIS order
+    # instead of re-quoting; cleared once funded.
+    pending_ln_purchase: Optional[dict] = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -171,6 +187,7 @@ class Jan3Session:
         data = {k: v for k, v in data.items() if k in known}
         data.setdefault("refreshed_at", None)
         data.setdefault("captcha_exempt", False)
+        data.setdefault("pending_ln_purchase", None)
         return cls(**data)
 
 
@@ -1072,69 +1089,130 @@ class Jan3AccountsManager:
         password: Optional[str] = None,
         asset: str = ASSET_TICKER_LBTC,
         confirm: bool = False,
+        expected_amount_base_units: Optional[int] = None,
     ) -> dict:
         """Buy / update the Lightning username for ``email`` (on-chain payment).
 
         Two-step to avoid spending without consent:
 
-        * ``confirm=False`` (default) — creates a payment request to fetch the
-          live price and returns a **quote** (``requires_confirmation=True``); it
-          does NOT sign or broadcast anything. Show the price to the user first.
-        * ``confirm=True`` — re-quotes and funds it: crafts a signed tx in
-          ``asset`` (``"L-BTC"`` or ``"USDt"``) to AQUA's address and submits it.
-
-        Each call creates a fresh payment request, so the confirmed price is
-        always current (the quote may have expired). Orphaned unfunded orders
-        expire server-side.
+        * ``confirm=False`` (default) — creates a payment request (the server
+          locks the price and expiry on that order) and returns a **quote**
+          including its ``payment_id``; nothing is signed or broadcast. The
+          quote is remembered on the session.
+        * ``confirm=True`` — funds the quoted order exactly: same
+          ``payment_id``, same amount the user approved. The backend rejects
+          expired orders and any tx whose amount/address differ from the
+          order's. Without a prior matching quote (e.g. CLI ``--yes``), it
+          creates a fresh order and funds it in one go —
+          ``expected_amount_base_units`` bounds what that path may spend.
         """
         email = _validate_email(email)
         ln_username = _validate_ln_username(ln_username)
 
-        order = self._with_auth_retry(
-            email,
-            lambda access: self._authed_client(
-                access
-            ).create_ln_username_payment_request(asset, ln_username),
-        )
-        payment_id = order.get("payment_id")
-        address = order.get("address")
-        amount_base_units = int(order.get("amount_base_units") or 0)
-        asset_ticker = order.get("asset_ticker") or asset
-        amount = order.get("amount")
-        expires_at = order.get("expires_at")
-        if not payment_id or not address or amount_base_units <= 0:
-            raise ValueError(
-                "AQUA payment-request response is missing fields "
-                f"(payment_id/address/amount): {order!r}"
-            )
+        def _parse_order(order: dict) -> dict:
+            payment_id = order.get("payment_id")
+            address = order.get("address")
+            amount_base_units = int(order.get("amount_base_units") or 0)
+            if not payment_id or not address or amount_base_units <= 0:
+                raise ValueError(
+                    "AQUA payment-request response is missing fields "
+                    f"(payment_id/address/amount): {order!r}"
+                )
+            return {
+                "payment_id": payment_id,
+                "address": address,
+                "amount_base_units": amount_base_units,
+                "asset_ticker": order.get("asset_ticker") or asset,
+                "amount": order.get("amount"),
+                "expires_at": order.get("expires_at"),
+            }
 
-        display_amount = _format_display_amount(amount_base_units, asset_ticker)
+        def _create_order() -> dict:
+            # NOTE: the backend expires any previous pending LN_USERNAME order
+            # for this user before creating the new one.
+            return _parse_order(
+                self._with_auth_retry(
+                    email,
+                    lambda access: self._authed_client(
+                        access
+                    ).create_ln_username_payment_request(asset, ln_username),
+                )
+            )
 
         if not confirm:
             # Dry-run quote: no signing, no broadcast. The caller must show
             # ``display_amount`` to the user and re-call with confirm=True.
+            fields = _create_order()
+            display_amount = _format_display_amount(
+                fields["amount_base_units"], fields["asset_ticker"]
+            )
+            session = self.load_session(email)
+            if session is not None:
+                session.pending_ln_purchase = {"ln_username": ln_username, **fields}
+                self.save_session(session)
             return {
                 "requires_confirmation": True,
                 "confirmed": False,
                 "ln_username": ln_username,
-                "asset_ticker": asset_ticker,
-                "amount_base_units": amount_base_units,
-                "amount": amount,
+                **fields,
                 "display_amount": display_amount,
-                "expires_at": expires_at,
-                "address": address,
                 "message": (
                     f"Purchasing the Lightning Address {ln_username!r} costs "
-                    f"{display_amount}. Show this to the user; on their approval "
-                    "re-call with confirm=true to pay."
+                    f"{display_amount} (quote locked until "
+                    f"{fields['expires_at']}). Show this to the user; on their "
+                    "approval re-call with confirm=true to pay exactly this."
                 ),
             }
 
-        asset_id = self._resolve_asset_id(wallet_name, asset_ticker)
+        # confirm=True — prefer funding the order quoted in step 1.
+        session = self.load_session(email)
+        pending = session.pending_ln_purchase if session else None
+        fields = None
+        if (
+            pending
+            and pending.get("ln_username") == ln_username
+            and (pending.get("asset_ticker") or "").strip().upper()
+            == (asset or "").strip().upper()
+        ):
+            if _order_expired(pending.get("expires_at")):
+                raise ValueError(
+                    f"The approved quote expired at {pending['expires_at']!r}. "
+                    "Nothing was signed or spent — re-quote with confirm=false "
+                    "and show the new price to the user."
+                )
+            fields = {k: v for k, v in pending.items() if k != "ln_username"}
+
+        if fields is None:
+            # No matching quote (--yes / stateless path): create and fund in
+            # one go, bounded by the caller-approved ceiling when given.
+            fields = _create_order()
+
+        if (
+            expected_amount_base_units is not None
+            and fields["amount_base_units"] > int(expected_amount_base_units)
+        ):
+            expected_display = _format_display_amount(
+                int(expected_amount_base_units), fields["asset_ticker"]
+            )
+            current_display = _format_display_amount(
+                fields["amount_base_units"], fields["asset_ticker"]
+            )
+            raise ValueError(
+                f"Price changed: the approved quote was {expected_display} but "
+                f"the current price is {current_display}. Nothing was signed "
+                "or spent. Show the new price to the user and, on their "
+                "approval, re-call with confirm=true and the updated "
+                f"expected_amount_base_units={fields['amount_base_units']}."
+            )
+
+        display_amount = _format_display_amount(
+            fields["amount_base_units"], fields["asset_ticker"]
+        )
+        asset_id = self._resolve_asset_id(wallet_name, fields["asset_ticker"])
         raw_tx = self.wallet_manager.craft_raw_tx(
             wallet_name=wallet_name,
-            address=address,
-            amount=amount_base_units,
+            address=fields["address"],
+            amount=fields["amount_base_units"],
             asset_id=asset_id,
             password=password,
         )
@@ -1145,21 +1223,24 @@ class Jan3AccountsManager:
         result = self._with_auth_retry(
             email,
             lambda access: self._authed_client(access).submit_raw_tx(
-                payment_id=payment_id, raw_tx=raw_tx
+                payment_id=fields["payment_id"], raw_tx=raw_tx
             ),
         )
+
+        # Funded — consume the quote. Re-load first: the submit may have
+        # refreshed tokens and rewritten the session file.
+        session = self.load_session(email)
+        if session is not None and session.pending_ln_purchase is not None:
+            session.pending_ln_purchase = None
+            self.save_session(session)
+
         return {
             "confirmed": True,
-            "payment_id": payment_id,
             "status": result.get("status"),
             "txid": txid,
             "ln_username": ln_username,
-            "asset_ticker": asset_ticker,
-            "amount_base_units": amount_base_units,
-            "amount": amount,
+            **fields,
             "display_amount": display_amount,
-            "expires_at": expires_at,
-            "address": address,
             "message": (
                 f"Submitted raw_tx for {ln_username!r} ({display_amount}). "
                 f"Server reports {result.get('status', 'UNKNOWN')}."

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1549,13 +1549,16 @@ TOOL_SCHEMAS = {
             "Purchase / update the Lightning username for a JAN3 account with an "
             "on-chain payment (fund in L-BTC or USDt). TWO-STEP, do NOT pass "
             "confirm=true first: (1) call with confirm=false (default) to get a "
-            "price quote WITHOUT spending — it returns display_amount (already "
-            "formatted for the user, e.g. '2000 Sats' for L-BTC or '1.50 USDT' "
-            "for USDt), amount_base_units (technical), amount, asset_ticker and "
-            "expires_at; SHOW display_amount to the user and get explicit consent; "
-            "(2) only then call with confirm=true to sign and submit. When telling "
-            "the user the price, use display_amount verbatim — never surface the "
-            "raw amount/amount_base_units. Check availability first with "
+            "price quote WITHOUT spending — the server locks the price on that "
+            "order; it returns display_amount (already formatted for the user, "
+            "e.g. '2000 Sats' for L-BTC or '1.50 USDT' for USDt), "
+            "amount_base_units (technical), amount, asset_ticker, payment_id "
+            "and expires_at; SHOW display_amount to the user and get explicit "
+            "consent; (2) only then call with confirm=true — it funds exactly "
+            "the quoted order (same payment_id and amount) and errors if the "
+            "quote expired (re-quote and re-confirm). When telling the user "
+            "the price, use display_amount verbatim — never surface the raw "
+            "amount/amount_base_units. Check availability first with "
             "jan3_ln_check_username. Requires an active JAN3 session (either flow)."
         ),
         "inputSchema": {
@@ -1587,8 +1590,14 @@ TOOL_SCHEMAS = {
                     "type": "boolean",
                     "default": False,
                     "description": "False (default) returns a non-spending price "
-                    "quote; True signs and submits the payment. Only set True "
-                    "after the user approves the quoted display_amount.",
+                    "quote; True funds the previously quoted order. Only set "
+                    "True after the user approves the quoted display_amount.",
+                },
+                "expected_amount_base_units": {
+                    "type": "integer",
+                    "description": "With confirm=true and no prior quote, the "
+                    "amount_base_units the user approved; the purchase aborts "
+                    "(nothing spent) if the current price exceeds it.",
                 },
             },
             "required": ["email", "ln_username"],

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -7,6 +7,8 @@ import os
 import re
 import shutil
 import sys
+import time
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field, fields, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -15,6 +17,11 @@ from typing import Optional
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
 
 logger = logging.getLogger(__name__)
 
@@ -360,6 +367,52 @@ class Storage:
         """Get path to wallet file."""
         _validate_wallet_name(name)
         return self.wallets_dir / f"{name}.json"
+
+    @contextmanager
+    def wallet_lock(self, name: str, timeout_seconds: float = 30.0):
+        """Cross-process exclusive lock for read-modify-write of a wallet record.
+
+        ``save_wallet`` is a whole-record last-writer-wins overwrite, so any
+        writer that derives new state from the current file contents (e.g.
+        advancing ``next_address_index``) must load AND save while holding
+        this lock — otherwise a concurrent CLI/MCP-server process against the
+        same ``~/.aqua`` can interleave and hand out the same index twice.
+
+        The OS releases the lock automatically if the holder dies. Raises
+        ``TimeoutError`` if the lock cannot be acquired in ``timeout_seconds``.
+        """
+        _validate_wallet_name(name)
+        lock_path = self.wallets_dir / f"{name}.lock"
+        # "a" creates the file if missing without ever truncating it.
+        fh = open(lock_path, "a")
+        try:
+            deadline = time.monotonic() + timeout_seconds
+            while True:
+                try:
+                    if sys.platform == "win32":
+                        fh.seek(0)
+                        msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
+                    else:
+                        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            f"Could not lock wallet {name!r} within "
+                            f"{timeout_seconds:.0f}s — another aqua process "
+                            "is holding it."
+                        ) from None
+                    time.sleep(0.05)
+            try:
+                yield
+            finally:
+                if sys.platform == "win32":
+                    fh.seek(0)
+                    msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        finally:
+            fh.close()
 
     def wallet_exists(self, name: str) -> bool:
         """Check if wallet exists."""

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -79,16 +79,12 @@ class WalletData:
         data = {**data}
         data.setdefault("btc_descriptor", None)
         data.setdefault("btc_change_descriptor", None)
-        # The address counter used to be named ``ln_addr_next_index`` when it
-        # only tracked LN-address registrations. Migrate the legacy key in-place
-        # so existing wallets keep their burned-index history; it's dropped on
-        # the next save.
+        # Migrate the legacy ``ln_addr_next_index`` key so wallets keep their history.
         legacy = data.pop("ln_addr_next_index", None)
         if "next_address_index" not in data and legacy is not None:
             data["next_address_index"] = legacy
         data.setdefault("next_address_index", 0)
-        # Forward compatibility: drop any other unknown keys written by future
-        # branches so this branch can still load the wallet file.
+        # Forward compatibility: drop unknown keys written by future branches.
         known = {f.name for f in fields(cls)}
         data = {k: v for k, v in data.items() if k in known}
         return cls(**data)
@@ -372,14 +368,9 @@ class Storage:
     def wallet_lock(self, name: str, timeout_seconds: float = 30.0):
         """Cross-process exclusive lock for read-modify-write of a wallet record.
 
-        ``save_wallet`` is a whole-record last-writer-wins overwrite, so any
-        writer that derives new state from the current file contents (e.g.
-        advancing ``next_address_index``) must load AND save while holding
-        this lock — otherwise a concurrent CLI/MCP-server process against the
-        same ``~/.aqua`` can interleave and hand out the same index twice.
-
-        The OS releases the lock automatically if the holder dies. Raises
-        ``TimeoutError`` if the lock cannot be acquired in ``timeout_seconds``.
+        ``save_wallet`` is a last-writer-wins overwrite, so counter-advancing
+        writers must load-and-save while holding this lock to avoid two
+        processes handing out the same index. Raises ``TimeoutError`` on timeout.
         """
         _validate_wallet_name(name)
         lock_path = self.wallets_dir / f"{name}.lock"

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -2297,16 +2297,10 @@ def jan3_purchase_ln_username(
 ) -> dict[str, Any]:
     """Purchase / update the Lightning username for a JAN3 account (on-chain).
 
-    Two-step so the user approves the price before any spend:
-
-    * ``confirm=False`` (default) returns a quote — ``requires_confirmation``,
-      ``display_amount`` (e.g. ``"2000 Sats"`` or ``"1.50 USDT"``),
-      ``amount_base_units``, ``amount``, ``payment_id``, ``expires_at`` —
-      WITHOUT signing. The server locks the price on that order.
-    * ``confirm=True`` funds the quoted order exactly (same payment_id, same
-      amount) and errors if the quote expired. Without a prior quote it
-      creates a fresh order and funds it, bounded by
-      ``expected_amount_base_units`` when given.
+    Two-step so the user approves the price before any spend: ``confirm=False``
+    (default) locks in a quote without signing; ``confirm=True`` funds that exact
+    quoted order, erroring if it expired. Without a prior quote it creates and
+    funds a fresh order, bounded by ``expected_amount_base_units`` when given.
 
     Args:
         email: the JAN3 account email.
@@ -2315,16 +2309,11 @@ def jan3_purchase_ln_username(
         password: decrypts the wallet mnemonic if encrypted at rest (confirm only).
         asset: funding asset ticker — "L-BTC" or "USDt" (default L-BTC).
         confirm: False previews the price; True pays.
-        expected_amount_base_units: the ``amount_base_units`` the user approved;
-            a no-prior-quote confirm aborts (nothing spent) if the current
-            price exceeds it.
+        expected_amount_base_units: ceiling on confirm=True when there's no prior quote.
 
     Returns:
-        Quote (confirm=False): requires_confirmation, ln_username, asset_ticker,
-        amount_base_units, amount, display_amount, payment_id, expires_at,
-        address, message.
-        Receipt (confirm=True): payment_id, status, txid, plus the same amount
-        fields.
+        Quote (confirm=False): display_amount, amount_base_units, payment_id, expires_at.
+        Receipt (confirm=True): payment_id, status, txid.
     """
     return get_jan3_manager().purchase_ln_username(
         email,

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -2293,6 +2293,7 @@ def jan3_purchase_ln_username(
     password: str | None = None,
     asset: str = "L-BTC",
     confirm: bool = False,
+    expected_amount_base_units: int | None = None,
 ) -> dict[str, Any]:
     """Purchase / update the Lightning username for a JAN3 account (on-chain).
 
@@ -2300,8 +2301,12 @@ def jan3_purchase_ln_username(
 
     * ``confirm=False`` (default) returns a quote — ``requires_confirmation``,
       ``display_amount`` (e.g. ``"2000 Sats"`` or ``"1.50 USDT"``),
-      ``amount_base_units``, ``amount``, ``expires_at`` — WITHOUT signing.
-    * ``confirm=True`` funds and submits the on-chain payment in ``asset``.
+      ``amount_base_units``, ``amount``, ``payment_id``, ``expires_at`` —
+      WITHOUT signing. The server locks the price on that order.
+    * ``confirm=True`` funds the quoted order exactly (same payment_id, same
+      amount) and errors if the quote expired. Without a prior quote it
+      creates a fresh order and funds it, bounded by
+      ``expected_amount_base_units`` when given.
 
     Args:
         email: the JAN3 account email.
@@ -2310,10 +2315,14 @@ def jan3_purchase_ln_username(
         password: decrypts the wallet mnemonic if encrypted at rest (confirm only).
         asset: funding asset ticker — "L-BTC" or "USDt" (default L-BTC).
         confirm: False previews the price; True pays.
+        expected_amount_base_units: the ``amount_base_units`` the user approved;
+            a no-prior-quote confirm aborts (nothing spent) if the current
+            price exceeds it.
 
     Returns:
         Quote (confirm=False): requires_confirmation, ln_username, asset_ticker,
-        amount_base_units, amount, display_amount, expires_at, address, message.
+        amount_base_units, amount, display_amount, payment_id, expires_at,
+        address, message.
         Receipt (confirm=True): payment_id, status, txid, plus the same amount
         fields.
     """
@@ -2324,6 +2333,7 @@ def jan3_purchase_ln_username(
         password=password,
         asset=asset,
         confirm=confirm,
+        expected_amount_base_units=expected_amount_base_units,
     )
 
 

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -1,5 +1,6 @@
 """Wallet management using LWK."""
 
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
@@ -7,6 +8,8 @@ import lwk
 
 from .assets import lookup_asset, resolve_asset_name
 from .storage import Storage, WalletData
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -312,6 +315,50 @@ class WalletManager:
             wallet_record.next_address_index = start + count
             self.storage.save_wallet(wallet_record)
         return addresses
+
+    def ensure_counter_covers(
+        self,
+        wallet_name: str,
+        addresses: list[str],
+    ) -> int:
+        """Bump ``next_address_index`` past any of ``addresses`` this wallet derives.
+
+        Best-effort repair for a reset counter (seed reimport, deleted
+        ``~/.aqua``): the JAN3 backend still holds unused pool addresses from
+        the previous install, and without this the frontier would re-hand
+        those same indices to swaps/receives. Matches the given addresses
+        against derivations within a bounded horizon above the current
+        frontier and returns the (possibly unchanged) counter.
+        """
+        targets = set(addresses)
+        wollet = self._get_wollet(wallet_name)
+        with self.storage.wallet_lock(wallet_name):
+            wallet_record = self.storage.load_wallet(wallet_name)
+            if wallet_record is None:
+                raise ValueError(f"Wallet {wallet_name!r} not found")
+            if not targets:
+                return wallet_record.next_address_index
+            lwk_tip = wollet.address(None).index()
+            frontier = max(lwk_tip, wallet_record.next_address_index)
+            # Pool batches are capped server-side, so anything from a previous
+            # install sits within a modest window above the old frontier.
+            horizon = frontier + 100
+            max_matched = -1
+            for i in range(horizon):
+                if str(wollet.address(i).address()) in targets:
+                    max_matched = i
+            if max_matched + 1 > wallet_record.next_address_index:
+                logger.info(
+                    "Wallet %r: advancing next_address_index %d -> %d to cover "
+                    "server-known pool addresses (counter was behind, e.g. "
+                    "after a seed reimport).",
+                    wallet_name,
+                    wallet_record.next_address_index,
+                    max_matched + 1,
+                )
+                wallet_record.next_address_index = max_matched + 1
+                self.storage.save_wallet(wallet_record)
+            return wallet_record.next_address_index
 
     def peek_address(
         self,

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -273,13 +273,11 @@ class WalletManager:
     ) -> Address:
         """Get a receive address.
 
-        No-arg advances ``next_address_index`` (not idempotent — commits an
-        index). Explicit ``index`` returns it without advancing. For display,
-        use :meth:`peek_address`.
+        No-arg advances ``next_address_index`` (not idempotent). Explicit
+        ``index`` returns it without advancing; for display use :meth:`peek_address`.
         """
         if index is None:
-            # The load → max(lwk_tip, counter) → derive → advance → save
-            # sequence lives once, in reserve_addresses.
+            # The load/derive/advance/save sequence lives once, in reserve_addresses.
             return self.reserve_addresses(wallet_name, 1)[0]
         wollet = self._get_wollet(wallet_name)
         addr = wollet.address(index)
@@ -297,9 +295,7 @@ class WalletManager:
         if count <= 0:
             raise ValueError("count must be positive")
         wollet = self._get_wollet(wallet_name)
-        # The counter update is a read-modify-write; hold the cross-process
-        # lock so a concurrent CLI/MCP-server pair can't hand out the same
-        # index or roll the counter back (last-writer-wins save).
+        # Hold the cross-process lock so two writers can't hand out the same index.
         with self.storage.wallet_lock(wallet_name):
             wallet_record = self.storage.load_wallet(wallet_name)
             if wallet_record is None:
@@ -323,12 +319,8 @@ class WalletManager:
     ) -> int:
         """Bump ``next_address_index`` past any of ``addresses`` this wallet derives.
 
-        Best-effort repair for a reset counter (seed reimport, deleted
-        ``~/.aqua``): the JAN3 backend still holds unused pool addresses from
-        the previous install, and without this the frontier would re-hand
-        those same indices to swaps/receives. Matches the given addresses
-        against derivations within a bounded horizon above the current
-        frontier and returns the (possibly unchanged) counter.
+        Best-effort repair for a reset counter (e.g. seed reimport) so the frontier
+        never re-hands out indices the server already delivered to.
         """
         targets = set(addresses)
         wollet = self._get_wollet(wallet_name)
@@ -340,8 +332,7 @@ class WalletManager:
                 return wallet_record.next_address_index
             lwk_tip = wollet.address(None).index()
             frontier = max(lwk_tip, wallet_record.next_address_index)
-            # Pool batches are capped server-side, so anything from a previous
-            # install sits within a modest window above the old frontier.
+            # Server-side pool batches are capped, so matches sit within a modest window.
             horizon = frontier + 100
             max_matched = -1
             for i in range(horizon):

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -294,17 +294,23 @@ class WalletManager:
         if count <= 0:
             raise ValueError("count must be positive")
         wollet = self._get_wollet(wallet_name)
-        wallet_record = self.storage.load_wallet(wallet_name)
-        if wallet_record is None:
-            raise ValueError(f"Wallet {wallet_name!r} not found")
-        lwk_tip = wollet.address(None).index()
-        start = max(lwk_tip, wallet_record.next_address_index)
-        addresses: list[Address] = []
-        for offset in range(count):
-            addr = wollet.address(start + offset)
-            addresses.append(Address(address=str(addr.address()), index=addr.index()))
-        wallet_record.next_address_index = start + count
-        self.storage.save_wallet(wallet_record)
+        # The counter update is a read-modify-write; hold the cross-process
+        # lock so a concurrent CLI/MCP-server pair can't hand out the same
+        # index or roll the counter back (last-writer-wins save).
+        with self.storage.wallet_lock(wallet_name):
+            wallet_record = self.storage.load_wallet(wallet_name)
+            if wallet_record is None:
+                raise ValueError(f"Wallet {wallet_name!r} not found")
+            lwk_tip = wollet.address(None).index()
+            start = max(lwk_tip, wallet_record.next_address_index)
+            addresses: list[Address] = []
+            for offset in range(count):
+                addr = wollet.address(start + offset)
+                addresses.append(
+                    Address(address=str(addr.address()), index=addr.index())
+                )
+            wallet_record.next_address_index = start + count
+            self.storage.save_wallet(wallet_record)
         return addresses
 
     def peek_address(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2053,6 +2053,75 @@ class _FakeJAN3Manager:
             "fingerprint": "localfp",
         }
 
+    def get_user(self, email, wallet_name="default"):
+        self.calls.append(("get_user", {"email": email, "wallet_name": wallet_name}))
+        return {
+            "email": email,
+            "ln_username": "alice@aquabtc.com",
+            "ln_address_toggled": True,
+            "fingerprint": "samefp",
+            "new_addresses_needed": 0,
+            "ln_address_pool": {"refilled": False, "reason": "pool_full"},
+        }
+
+    def ln_address_toggle(self, email, enabled, wallet_name="default"):
+        self.calls.append((
+            "ln_address_toggle",
+            {"email": email, "enabled": enabled, "wallet_name": wallet_name},
+        ))
+        out = {"email": email, "enabled": enabled, "result": {"ln_address_toggled": enabled}}
+        if enabled:
+            out["ln_address_pool"] = {"refilled": True, "pool_size": 5}
+        return out
+
+    def ln_username_available(self, email, username):
+        self.calls.append((
+            "ln_username_available", {"email": email, "username": username}
+        ))
+        return {"is_available": True, "ln_username": username}
+
+    def purchase_ln_username(
+        self,
+        email,
+        ln_username,
+        wallet_name="default",
+        password=None,
+        asset="L-BTC",
+        confirm=False,
+        expected_amount_base_units=None,
+    ):
+        self.calls.append((
+            "purchase_ln_username",
+            {
+                "email": email,
+                "ln_username": ln_username,
+                "wallet_name": wallet_name,
+                "password": password,
+                "asset": asset,
+                "confirm": confirm,
+                "expected_amount_base_units": expected_amount_base_units,
+            },
+        ))
+        if not confirm:
+            return {
+                "requires_confirmation": True,
+                "confirmed": False,
+                "ln_username": ln_username,
+                "asset_ticker": asset,
+                "amount_base_units": 777,
+                "display_amount": "777 Sats",
+                "expires_at": "2026-07-03T18:13:55Z",
+            }
+        return {
+            "confirmed": True,
+            "payment_id": "pay1",
+            "status": "PENDING",
+            "txid": "txid1",
+            "ln_username": ln_username,
+            "amount_base_units": 777,
+            "display_amount": "777 Sats",
+        }
+
     def verify(self, email, otp_code, fingerprint=None, captcha_exempt=False):
         self.calls.append((
             "verify",
@@ -2256,6 +2325,103 @@ class TestWapuPayCli:
         assert not any(
             c[0] == "rebind_wallet" and c[1]["confirm"] is True for c in auth_cli.calls
         )
+
+    def test_user_info(self, runner, auth_cli):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "jan3", "user-info",
+             "--email", "u@e.com", "--wallet-name", "w2"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["ln_username"] == "alice@aquabtc.com"
+        assert data["ln_address_pool"]["reason"] == "pool_full"
+        assert auth_cli.calls[-1] == (
+            "get_user", {"email": "u@e.com", "wallet_name": "w2"}
+        )
+
+    def test_enable_lightning_address(self, runner, auth_cli):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "jan3", "enable-lightning-address",
+             "--email", "u@e.com", "--enable"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["enabled"] is True
+        assert data["ln_address_pool"]["refilled"] is True
+        assert auth_cli.calls[-1] == (
+            "ln_address_toggle",
+            {"email": "u@e.com", "enabled": True, "wallet_name": "default"},
+        )
+
+    def test_disable_lightning_address(self, runner, auth_cli):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "jan3", "enable-lightning-address",
+             "--email", "u@e.com", "--disable"],
+        )
+        assert result.exit_code == 0
+        assert json.loads(result.output)["enabled"] is False
+        assert auth_cli.calls[-1][1]["enabled"] is False
+
+    def test_ln_check_username(self, runner, auth_cli):
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "jan3", "ln-check-username",
+             "--email", "u@e.com", "--ln-username", "alice"],
+        )
+        assert result.exit_code == 0
+        assert json.loads(result.output)["is_available"] is True
+        assert auth_cli.calls[-1] == (
+            "ln_username_available", {"email": "u@e.com", "username": "alice"}
+        )
+
+    def test_purchase_ln_username_accept_binds_quote(self, runner, auth_cli):
+        """Accepting the prompt executes confirm=True bound to the quoted
+        amount (expected_amount_base_units)."""
+        result = runner.invoke(
+            cli,
+            ["jan3", "purchase-ln-username",
+             "--email", "u@e.com", "--ln-username", "alice"],
+            input="y\n",
+        )
+        assert result.exit_code == 0
+        assert "777 Sats" in result.output  # quote echoed before the prompt
+        purchases = [c for c in auth_cli.calls if c[0] == "purchase_ln_username"]
+        assert purchases[0][1]["confirm"] is False   # quote first
+        assert purchases[-1][1]["confirm"] is True   # then execute
+        assert purchases[-1][1]["expected_amount_base_units"] == 777
+
+    def test_purchase_ln_username_decline_aborts_without_spending(
+        self, runner, auth_cli
+    ):
+        """Declining the price prompt aborts: the spending confirm=True call
+        is never made."""
+        result = runner.invoke(
+            cli,
+            ["jan3", "purchase-ln-username",
+             "--email", "u@e.com", "--ln-username", "alice"],
+            input="n\n",
+        )
+        assert result.exit_code != 0  # click.Abort
+        purchases = [c for c in auth_cli.calls if c[0] == "purchase_ln_username"]
+        assert purchases and all(c[1]["confirm"] is False for c in purchases)
+
+    def test_purchase_ln_username_yes_skips_quote(self, runner, auth_cli):
+        """--yes goes straight to the confirmed purchase: no quote call (which
+        would create an orphaned server-side order) and no amount bound."""
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "jan3", "purchase-ln-username",
+             "--email", "u@e.com", "--ln-username", "alice", "--yes"],
+        )
+        assert result.exit_code == 0
+        assert json.loads(result.output)["confirmed"] is True
+        purchases = [c for c in auth_cli.calls if c[0] == "purchase_ln_username"]
+        assert len(purchases) == 1
+        assert purchases[0][1]["confirm"] is True
+        assert purchases[0][1]["expected_amount_base_units"] is None
 
     def test_create_order_with_yes_skips_confirm(self, runner, wapupay_cli):
         result = runner.invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2303,10 +2303,7 @@ class TestWapuPayCli:
             input="y\n",
         )
         assert result.exit_code == 0
-        # The destructive warning (naming the LN address) is echoed before the
-        # prompt — the distinctive phrase only comes from the warning, not the
-        # result JSON. (The LN-address-vs-email rule is asserted at the manager
-        # level in test_warning_names_ln_address_not_account_email.)
+        # These phrases only come from the pre-prompt warning, not the result JSON.
         assert "moves delivery away" in result.output
         assert "alice@aquabtc.com" in result.output
         assert any(

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -159,6 +159,21 @@ def _capturing_route(mapping):
     return side_effect
 
 
+def _body_capturing_route(mapping):
+    """Like :func:`_route` but records ``(url, decoded body)`` per request,
+    exposed as ``.bodies``, so a test can assert what a POST actually carried.
+    """
+    bodies: list[tuple[str, str]] = []
+    base = _route(mapping)
+
+    def side_effect(req, timeout=None):
+        bodies.append((req.full_url, req.data.decode() if req.data else ""))
+        return base(req, timeout=timeout)
+
+    side_effect.bodies = bodies
+    return side_effect
+
+
 # ---------------------------------------------------------------------------
 # Pure helpers
 # ---------------------------------------------------------------------------
@@ -1158,6 +1173,110 @@ class TestGetUserAutoPool:
         assert out["ln_address_pool"]["reason"] == "auto_topup_unavailable"
         # The burn-before-POST ordering means reserve was attempted first.
         wm.reserve_addresses.assert_called_once_with("default", 3)
+
+
+class TestPendingBatchReuse:
+    """A failed register POST must not burn a fresh batch per retry.
+
+    The reserved batch is persisted on the session and re-uploaded verbatim
+    (the server ignores duplicate addresses), so an outage costs one batch
+    total instead of one batch per jan3_user_info call.
+    """
+
+    PROFILE = {
+        "ln_username": "alice",
+        "ln_address_toggled": True,
+        "fingerprint": "abcd1234",
+        "new_addresses_needed": 3,
+    }
+
+    @staticmethod
+    def _distinct_batches(wm):
+        """Make each reserve call return a distinguishable batch."""
+        calls = {"n": 0}
+
+        def reserve(name, count):
+            calls["n"] += 1
+            return [
+                MagicMock(address=f"lq1batch{calls['n']}addr{i}")
+                for i in range(count)
+            ]
+
+        wm.reserve_addresses.side_effect = reserve
+
+    def test_retry_reuses_batch_instead_of_burning(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
+        self._distinct_batches(wm)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+
+        # Attempt 1: reserve succeeds, POST 500s — batch 1 is now pending.
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/user/": self.PROFILE,
+                "/addresses/": _http_error(500, "backend down"),
+            }),
+        ):
+            out = mgr.get_user("me@example.com")
+        assert out["ln_address_pool"]["reason"] == "auto_topup_unavailable"
+        assert wm.reserve_addresses.call_count == 1
+
+        # Attempt 2: backend recovered. The SAME batch is re-POSTed; no new
+        # indices are reserved.
+        route = _body_capturing_route({
+            "/user/": self.PROFILE,
+            "/addresses/": {"addresses": ["a", "b", "c"]},
+        })
+        with patch("urllib.request.urlopen", side_effect=route):
+            out = mgr.get_user("me@example.com")
+        assert out["ln_address_pool"]["refilled"] is True
+        assert wm.reserve_addresses.call_count == 1  # still just the first burn
+        post_body = next(b for u, b in route.bodies if "/addresses/" in u)
+        assert "lq1batch1addr0" in post_body
+        assert "lq1batch2" not in post_body
+
+    def test_success_clears_pending(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
+        self._distinct_batches(wm)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+
+        ok_route = {
+            "/user/": self.PROFILE,
+            "/addresses/": {"addresses": ["a", "b", "c"]},
+        }
+        with patch("urllib.request.urlopen", side_effect=_route(ok_route)):
+            mgr.get_user("me@example.com")
+        assert (
+            mgr.load_session("me@example.com").pending_ln_registration is None
+        )
+        # Next top-up reserves a fresh batch — pending is not sticky.
+        with patch("urllib.request.urlopen", side_effect=_route(dict(ok_route))):
+            mgr.get_user("me@example.com")
+        assert wm.reserve_addresses.call_count == 2
+
+    def test_pending_for_other_wallet_not_reused(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
+        self._distinct_batches(wm)
+        session = _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        session.pending_ln_registration = {
+            "wallet_name": "other",
+            "fingerprint": "zzzz9999",
+            "addresses": ["lq1stale0", "lq1stale1"],
+        }
+        mgr.save_session(session)
+
+        route = _body_capturing_route({
+            "/user/": self.PROFILE,
+            "/addresses/": {"addresses": ["a", "b", "c"]},
+        })
+        with patch("urllib.request.urlopen", side_effect=route):
+            out = mgr.get_user("me@example.com")
+        assert out["ln_address_pool"]["refilled"] is True
+        # The stale batch (different wallet/fingerprint) must not be uploaded.
+        wm.reserve_addresses.assert_called_once_with("default", 3)
+        post_body = next(b for u, b in route.bodies if "/addresses/" in u)
+        assert "lq1stale" not in post_body
+        assert "lq1batch1addr0" in post_body
 
 
 class TestLnAddressToggleManager:

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -1596,6 +1596,58 @@ class TestEnsureLnPool:
         out = mgr.ensure_ln_pool("me@example.com", profile={"ln_username": None})
         assert out["reason"] == "no_ln_username"
 
+    def test_fingerprint_unavailable_is_permanent_skip(self, storage):
+        # A bare-xpub watch-only wallet can never produce a fingerprint; the
+        # skip must be distinguishable from a transient backend failure and
+        # carry remediation, not fall through to auto_topup_unavailable.
+        mgr, wm = _ln_manager(storage)
+        wm.fingerprint.side_effect = ValueError(
+            "Cannot determine fingerprint for watch-only wallet 'default': "
+            "descriptor has no [fingerprint/derivation] block."
+        )
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        out = mgr.ensure_ln_pool(
+            "me@example.com",
+            profile={
+                "ln_username": "alice",
+                "ln_address_toggled": True,
+                "fingerprint": "serverfp",
+                "new_addresses_needed": 3,
+            },
+        )
+        assert out["refilled"] is False
+        assert out["reason"] == "wallet_fingerprint_unavailable"
+        assert "permanent" in out["message"]
+        assert "re-import" in out["message"]
+        wm.reserve_addresses.assert_not_called()
+
+    def test_toggle_enable_surfaces_permanent_fingerprint_skip(self, storage):
+        # The enable tool must not report a healthy pool when the wallet can
+        # never register addresses: the toggle succeeds but the pool result
+        # carries the permanent skip.
+        mgr, wm = _ln_manager(storage)
+        wm.fingerprint.side_effect = ValueError(
+            "Cannot determine fingerprint for watch-only wallet 'default': "
+            "descriptor has no [fingerprint/derivation] block."
+        )
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/ln-address-toggle/": {"ln_address_toggled": True},
+                "/user/": {
+                    "ln_username": "alice",
+                    "ln_address_toggled": True,
+                    "fingerprint": "serverfp",
+                    "new_addresses_needed": 3,
+                },
+            }),
+        ):
+            out = mgr.ln_address_toggle("me@example.com", True)
+        assert out["enabled"] is True
+        assert out["ln_address_pool"]["reason"] == "wallet_fingerprint_unavailable"
+        wm.reserve_addresses.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Manager: purchase LN username (on-chain L-BTC)

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -1521,6 +1521,153 @@ class TestPurchaseLnUsername:
             with pytest.raises(ValueError, match="missing fields"):
                 mgr.purchase_ln_username("me@example.com", "alice", confirm=True)
 
+    def _order(self, amount_base_units, payment_id="pay1", expires_at="2030-01-01T00:00:00Z"):
+        return {
+            "payment_id": payment_id,
+            "address": VAULT_ADDR,
+            "amount_base_units": amount_base_units,
+            "asset_ticker": "L-BTC",
+            "amount": "0.00000777",
+            "expires_at": expires_at,
+        }
+
+    def test_confirm_funds_the_quoted_order(self, storage):
+        # The quote locks an order server-side; confirm must fund THAT order —
+        # no second payment request, no repriced amount.
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "computed-txid"
+
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({"/payment-request/ln-username/": self._order(777)}),
+        ):
+            quote = mgr.purchase_ln_username("me@example.com", "alice")
+        assert quote["payment_id"] == "pay1"
+        assert mgr.load_session("me@example.com").pending_ln_purchase is not None
+
+        # The confirm route has NO payment-request mapping: any attempt to
+        # create a second order would fail the test.
+        route = _capturing_route({"/payment/submit-raw-tx/": {"status": "PENDING"}})
+        with (
+            patch("urllib.request.urlopen", side_effect=route),
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            out = mgr.purchase_ln_username("me@example.com", "alice", confirm=True)
+        assert out["confirmed"] is True
+        assert out["payment_id"] == "pay1"       # the quoted order was funded
+        assert out["amount_base_units"] == 777   # exactly the approved amount
+        wm.craft_raw_tx.assert_called_once()
+        assert wm.craft_raw_tx.call_args.kwargs["amount"] == 777
+        assert not any("/payment-request/" in u for u in route.calls)
+        # The quote is consumed once funded.
+        assert mgr.load_session("me@example.com").pending_ln_purchase is None
+
+    def test_confirm_raises_when_quote_expired(self, storage):
+        # An expired locked quote must not be silently repriced: fail loudly
+        # and spend nothing.
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/payment-request/ln-username/": self._order(
+                    777, expires_at="2020-01-01T00:00:00Z"
+                ),
+            }),
+        ):
+            mgr.purchase_ln_username("me@example.com", "alice")
+        with pytest.raises(ValueError, match="quote expired"):
+            mgr.purchase_ln_username("me@example.com", "alice", confirm=True)
+        wm.craft_raw_tx.assert_not_called()
+
+    def test_confirm_for_different_username_ignores_pending(self, storage):
+        # A pending quote for another username must not be funded (its order
+        # would set THAT username): fall back to a fresh order.
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "computed-txid"
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({"/payment-request/ln-username/": self._order(777)}),
+        ):
+            mgr.purchase_ln_username("me@example.com", "alice")
+
+        route = _capturing_route({
+            "/payment-request/ln-username/": self._order(888, payment_id="pay2"),
+            "/payment/submit-raw-tx/": {"status": "PENDING"},
+        })
+        with (
+            patch("urllib.request.urlopen", side_effect=route),
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            out = mgr.purchase_ln_username("me@example.com", "bobby", confirm=True)
+        assert out["payment_id"] == "pay2"
+        assert any("/payment-request/" in u for u in route.calls)
+
+    def test_confirm_without_quote_aborts_when_price_exceeds_approved(self, storage):
+        # Stateless path (no prior quote): the caller-approved ceiling bounds
+        # the spend. Nothing may be signed or submitted above it.
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        route = _capturing_route({"/payment-request/ln-username/": self._order(2000)})
+        with patch("urllib.request.urlopen", side_effect=route):
+            with pytest.raises(ValueError, match="Price changed"):
+                mgr.purchase_ln_username(
+                    "me@example.com",
+                    "alice",
+                    confirm=True,
+                    expected_amount_base_units=777,
+                )
+        wm.craft_raw_tx.assert_not_called()
+        assert not any("submit-raw-tx" in u for u in route.calls)
+
+    def test_confirm_without_quote_proceeds_when_price_within_approved(self, storage):
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "computed-txid"
+        with (
+            patch(
+                "urllib.request.urlopen",
+                side_effect=_route({
+                    "/payment-request/ln-username/": self._order(777),
+                    "/payment/submit-raw-tx/": {"status": "PENDING"},
+                }),
+            ),
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            out = mgr.purchase_ln_username(
+                "me@example.com",
+                "alice",
+                confirm=True,
+                expected_amount_base_units=1000,
+            )
+        assert out["confirmed"] is True
+        assert out["amount_base_units"] == 777
+        wm.craft_raw_tx.assert_called_once()
+
+    def test_quote_ignores_expected_amount(self, storage):
+        # The ceiling applies to the spending step only; a dry-run quote with
+        # a stale expectation must still return the fresh price, not raise.
+        mgr, wm = _ln_manager(storage)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({"/payment-request/ln-username/": self._order(2000)}),
+        ):
+            out = mgr.purchase_ln_username(
+                "me@example.com",
+                "alice",
+                confirm=False,
+                expected_amount_base_units=777,
+            )
+        assert out["requires_confirmation"] is True
+        assert out["amount_base_units"] == 2000
+        wm.craft_raw_tx.assert_not_called()
+
     def test_invalid_username_raises_before_network(self, storage):
         mgr, _ = _ln_manager(storage)
         _seed_session(mgr, "me@example.com", access=FUTURE_JWT)

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from aqua.ankara import ANKARA_API_URL, SessionExpiredError
+from aqua.lnurl import resolve_lightning_address
 from aqua.jan3_accounts import (
     ASSET_TICKER_LBTC,
     DEFAULT_LN_ADDRESS_POOL,
@@ -1877,3 +1878,125 @@ class TestPurchaseLnUsername:
         with pytest.raises(ValueError, match="Invalid ln_username"):
             mgr.purchase_ln_username("me@example.com", "bad..name")
 
+
+
+# ---------------------------------------------------------------------------
+# Purchase + LNURL resolution linkage
+# ---------------------------------------------------------------------------
+
+
+def _lnurl_response(data: dict, final_url: str | None = None) -> MagicMock:
+    """urlopen response mock for LNURL-leg patches.
+
+    Distinct from ``_mock_response`` above because ``aqua.lnurl._http_get_json``
+    calls ``resp.geturl()`` to enforce the post-redirect https guard.
+    """
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(data).encode()
+    resp.geturl.return_value = final_url or "https://example.com/x"
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def _payreq(
+    *,
+    callback: str = "https://test.aqua.net/lnurlp/cb",
+    min_msat: int = 1_000,
+    max_msat: int = 100_000_000_000,
+    metadata: str = '[["text/plain","pay alice"]]',
+) -> dict:
+    return {
+        "tag": "payRequest",
+        "callback": callback,
+        "minSendable": min_msat,
+        "maxSendable": max_msat,
+        "metadata": metadata,
+    }
+
+
+class TestPurchaseThenResolve:
+    """End-to-end (mocked) linkage: buy a JAN3 LN username and resolve the
+    resulting ``<username>@<jan3-domain>`` Lightning Address via aqua.lnurl.
+
+    Proves our code wires the two halves together — that the bare
+    ``ln_username`` returned by ``purchase_ln_username`` composes cleanly
+    into a ``.well-known/lnurlp/`` lookup that yields a payable BOLT11.
+    """
+
+    LN_USERNAME = "alicebob"
+    LN_DOMAIN = "test.aqua.net"
+    AMOUNT_SATS = 100
+    INVOICE = "lnbc1u1ptest_jan3_invoice"
+
+    PR_RESPONSE = {
+        "payment_id": "11111111-1111-1111-1111-111111111111",
+        "status": "PENDING",
+        "product_type": "LN_USERNAME_UPDATE",
+        "asset_ticker": "L-BTC",
+        "amount_base_units": 1000,
+        "address": VAULT_ADDR,
+        "expires_at": "2026-06-16T01:00:00+00:00",
+    }
+    SUBMIT_RESPONSE = {**PR_RESPONSE, "status": "ACCEPTED"}
+
+    def _purchase(self, mgr: Jan3AccountsManager) -> dict:
+        """Drive ``purchase_ln_username`` with all HTTP + signing mocked."""
+        fake_tx = MagicMock()
+        fake_tx.txid.return_value = "computed-txid"
+        with (
+            patch.object(
+                Jan3AccountsClient,
+                "create_ln_username_payment_request",
+                return_value=self.PR_RESPONSE,
+            ),
+            patch.object(
+                Jan3AccountsClient,
+                "submit_raw_tx",
+                return_value=self.SUBMIT_RESPONSE,
+            ),
+            patch("aqua.jan3_accounts.lwk.Transaction", return_value=fake_tx),
+        ):
+            return mgr.purchase_ln_username(
+                email="me@example.com",
+                ln_username=self.LN_USERNAME,
+                wallet_name="default",
+                confirm=True,
+            )
+
+    def test_purchase_then_resolve_returns_invoice(self, storage):
+        """Happy path: buy username → resolve <user>@<domain> → BOLT11."""
+        mgr = _manager(storage, raw_tx="DEADBEEF" * 16)
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+
+        purchase = self._purchase(mgr)
+        assert purchase["confirmed"] is True
+        assert purchase["ln_username"] == self.LN_USERNAME
+        address = f"{purchase['ln_username']}@{self.LN_DOMAIN}"
+
+        with (
+            patch("aqua.lnurl.urllib.request.urlopen") as mock_urlopen,
+            patch(
+                "aqua.lnurl.decode_bolt11_amount_sats",
+                return_value=self.AMOUNT_SATS,
+            ),
+        ):
+            mock_urlopen.side_effect = [
+                _lnurl_response(
+                    _payreq(),
+                    final_url=(
+                        f"https://{self.LN_DOMAIN}/.well-known/lnurlp/"
+                        f"{self.LN_USERNAME}"
+                    ),
+                ),
+                _lnurl_response({"pr": self.INVOICE}),
+            ]
+            invoice = resolve_lightning_address(address, self.AMOUNT_SATS)
+
+        assert invoice == self.INVOICE
+        first_req = mock_urlopen.call_args_list[0].args[0]
+        assert first_req.full_url == (
+            f"https://{self.LN_DOMAIN}/.well-known/lnurlp/{self.LN_USERNAME}"
+        )
+        second_req = mock_urlopen.call_args_list[1].args[0]
+        assert f"amount={self.AMOUNT_SATS * 1000}" in second_req.full_url

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -143,12 +143,8 @@ def _route(mapping):
 
 
 def _capturing_route(mapping):
-    """Like :func:`_route` but records every request URL (with query string).
-
-    The returned side_effect exposes ``.calls`` — a list of ``req.full_url``
-    strings — so a test can assert whether ``?override_fingerprint=true`` was
-    (or was not) sent.
-    """
+    """Like :func:`_route` but also records each request's full URL in
+    ``.calls``, so a test can assert whether a query string was sent."""
     urls: list[str] = []
     base = _route(mapping)
 
@@ -1145,13 +1141,9 @@ class TestGetUserAutoPool:
         wm.reserve_addresses.assert_not_called()
 
     def test_topup_backend_failure_never_breaks_read(self, storage):
-        # A REAL failure mode: the local reserve succeeds but the backend
-        # register POST fails (transient 500). It must be swallowed into a skip,
-        # not raised — the profile read still returns. (The previous version of
-        # this test injected a "password required" error from fingerprint(),
-        # which the real code cannot produce for an encrypted hot wallet:
-        # address derivation needs only the descriptor, not the mnemonic —
-        # see test_wallet.py::TestEncryptedWalletNoPassword.)
+        # A REAL failure mode: the backend register POST can fail (transient
+        # 500); it must be swallowed into a skip, not raised — the profile
+        # read still returns.
         mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
         _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
         profile = {
@@ -1256,9 +1248,8 @@ class TestPendingBatchReuse:
         assert wm.reserve_addresses.call_count == 2
 
     def test_pool_response_reconciles_counter(self, storage):
-        # The register response returns the FULL unused pool. Addresses we did
-        # not just post (a previous install's pool, i.e. reimported seed) must
-        # be fed to ensure_counter_covers so their indices are never re-handed.
+        # The register response returns the FULL unused pool; addresses we
+        # didn't just post (e.g. from a reimported seed) must reach ensure_counter_covers.
         mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
         _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
         with patch(
@@ -1586,8 +1577,7 @@ class TestEnsureLnPool:
         assert out["reason"] == "fingerprint_mismatch"
         assert out["server_fingerprint"] == "serverfp"
         assert out["local_fingerprint"] == "localfp"
-        # The skip must carry actionable guidance naming both fingerprints
-        # (the reason alone is a dead-end; there is no self-serve re-bind tool).
+        # The skip must carry actionable guidance naming both fingerprints.
         assert "serverfp" in out["message"] and "localfp" in out["message"]
         wm.reserve_addresses.assert_not_called()
 
@@ -1598,9 +1588,8 @@ class TestEnsureLnPool:
         assert out["reason"] == "no_ln_username"
 
     def test_fingerprint_unavailable_is_permanent_skip(self, storage):
-        # A bare-xpub watch-only wallet can never produce a fingerprint; the
-        # skip must be distinguishable from a transient backend failure and
-        # carry remediation, not fall through to auto_topup_unavailable.
+        # A bare-xpub watch-only wallet can never fingerprint; the skip must
+        # be distinguishable from a transient failure and carry remediation.
         mgr, wm = _ln_manager(storage)
         wm.fingerprint.side_effect = ValueError(
             "Cannot determine fingerprint for watch-only wallet 'default': "
@@ -1623,9 +1612,8 @@ class TestEnsureLnPool:
         wm.reserve_addresses.assert_not_called()
 
     def test_toggle_enable_surfaces_permanent_fingerprint_skip(self, storage):
-        # The enable tool must not report a healthy pool when the wallet can
-        # never register addresses: the toggle succeeds but the pool result
-        # carries the permanent skip.
+        # The toggle succeeding must not mask a wallet that can never
+        # register addresses: the pool result carries the permanent skip.
         mgr, wm = _ln_manager(storage)
         wm.fingerprint.side_effect = ValueError(
             "Cannot determine fingerprint for watch-only wallet 'default': "

--- a/tests/test_jan3_accounts.py
+++ b/tests/test_jan3_accounts.py
@@ -1254,6 +1254,38 @@ class TestPendingBatchReuse:
             mgr.get_user("me@example.com")
         assert wm.reserve_addresses.call_count == 2
 
+    def test_pool_response_reconciles_counter(self, storage):
+        # The register response returns the FULL unused pool. Addresses we did
+        # not just post (a previous install's pool, i.e. reimported seed) must
+        # be fed to ensure_counter_covers so their indices are never re-handed.
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/user/": self.PROFILE,
+                "/addresses/": {
+                    "addresses": ["lq1addr0", "lq1addr1", "lq1addr2", "lq1old9"]
+                },
+            }),
+        ):
+            out = mgr.get_user("me@example.com")
+        assert out["ln_address_pool"]["refilled"] is True
+        wm.ensure_counter_covers.assert_called_once_with("default", ["lq1old9"])
+
+    def test_no_reconciliation_when_pool_matches_posted(self, storage):
+        mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
+        _seed_session(mgr, "me@example.com", access=FUTURE_JWT)
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=_route({
+                "/user/": self.PROFILE,
+                "/addresses/": {"addresses": ["lq1addr0", "lq1addr1", "lq1addr2"]},
+            }),
+        ):
+            mgr.get_user("me@example.com")
+        wm.ensure_counter_covers.assert_not_called()
+
     def test_pending_for_other_wallet_not_reused(self, storage):
         mgr, wm = _ln_manager(storage, fingerprint="abcd1234")
         self._distinct_batches(wm)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,6 +6,8 @@ import os
 import stat
 import sys
 import tempfile
+import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -63,6 +65,61 @@ class TestWalletDataAddressCounter:
         })
         assert w.next_address_index == 0
         assert not hasattr(w, "some_future_field")
+
+
+class TestWalletLock:
+    """Cross-process lock guarding wallet-record read-modify-writes."""
+
+    def test_serializes_concurrent_holders(self, temp_storage):
+        order = []
+
+        def holder():
+            with temp_storage.wallet_lock("w"):
+                order.append("a-in")
+                time.sleep(0.3)
+                order.append("a-out")
+
+        t = threading.Thread(target=holder)
+        t.start()
+        time.sleep(0.1)  # let the thread grab the lock first
+        with temp_storage.wallet_lock("w"):
+            order.append("b-in")
+        t.join(timeout=5)
+        assert order == ["a-in", "a-out", "b-in"]
+
+    def test_timeout_raises(self, temp_storage):
+        release = threading.Event()
+        held = threading.Event()
+
+        def holder():
+            with temp_storage.wallet_lock("w"):
+                held.set()
+                release.wait(timeout=5)
+
+        t = threading.Thread(target=holder)
+        t.start()
+        assert held.wait(timeout=5)
+        with pytest.raises(TimeoutError, match="another aqua process"):
+            with temp_storage.wallet_lock("w", timeout_seconds=0.15):
+                pass
+        release.set()
+        t.join(timeout=5)
+
+    def test_reacquire_after_release(self, temp_storage):
+        for _ in range(2):
+            with temp_storage.wallet_lock("w"):
+                pass
+
+    def test_locks_are_per_wallet(self, temp_storage):
+        # A lock on wallet "a" must not exclude wallet "b".
+        with temp_storage.wallet_lock("a"):
+            with temp_storage.wallet_lock("b", timeout_seconds=0.5):
+                pass
+
+    def test_lock_file_not_listed_as_wallet(self, temp_storage):
+        with temp_storage.wallet_lock("w"):
+            pass
+        assert "w" not in temp_storage.list_wallets()
 
 
 class TestStorage:

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -93,9 +93,8 @@ class TestAddressCounter:
         assert got  # proceeded once the lock was released
 
     def test_ensure_counter_covers_repairs_reset_counter(self, wallet_manager):
-        # Simulate a seed reimport: the server still holds pool addresses at
-        # indices 5..7 but the local counter is 0. Reconciliation must bump
-        # the counter past the highest server-known index.
+        # Simulate a seed reimport: server pool holds indices 5..7 but the
+        # local counter is 0; reconciliation must bump it past the highest.
         pool = [
             wallet_manager.peek_address("default", index=i).address
             for i in (5, 6, 7)

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -62,6 +62,17 @@ class TestAddressCounter:
         indices = {one.index} | {a.index for a in batch}
         assert len(indices) == 4  # all distinct — no reuse across the two paths
 
+    def test_counter_promoted_when_lwk_tip_is_higher(self, wallet_manager):
+        """The handout frontier is max(lwk tip, counter): a handed-out index is
+        never below the persisted counter, and the counter advances past it."""
+        record = wallet_manager.storage.load_wallet("default")
+        record.next_address_index = 100
+        wallet_manager.storage.save_wallet(record)
+        out = wallet_manager.get_address("default")
+        assert out.index >= 100
+        after = wallet_manager.storage.load_wallet("default").next_address_index
+        assert after == out.index + 1
+
     def test_reserve_waits_for_wallet_lock(self, wallet_manager):
         # reserve_addresses must hold the cross-process wallet lock for its
         # read-modify-write: while another holder has it, the reserve blocks.

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -62,6 +62,49 @@ class TestAddressCounter:
         indices = {one.index} | {a.index for a in batch}
         assert len(indices) == 4  # all distinct — no reuse across the two paths
 
+    def test_reserve_waits_for_wallet_lock(self, wallet_manager):
+        # reserve_addresses must hold the cross-process wallet lock for its
+        # read-modify-write: while another holder has it, the reserve blocks.
+        import threading
+        import time
+
+        got: list[int] = []
+
+        def reserve():
+            got.append(wallet_manager.get_address("default").index)
+
+        with wallet_manager.storage.wallet_lock("default"):
+            t = threading.Thread(target=reserve)
+            t.start()
+            time.sleep(0.3)
+            assert not got  # blocked while the lock is held elsewhere
+        t.join(timeout=5)
+        assert got  # proceeded once the lock was released
+
+    def test_concurrent_reserves_never_share_an_index(self, wallet_manager):
+        # Two racing reservers must produce disjoint index ranges and a
+        # counter equal to the total handed out.
+        import threading
+
+        results: list[list[int]] = [[], []]
+
+        def reserve(slot):
+            results[slot] = [
+                a.index for a in wallet_manager.reserve_addresses("default", 5)
+            ]
+
+        threads = [
+            threading.Thread(target=reserve, args=(i,)) for i in range(2)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+        all_indices = results[0] + results[1]
+        assert len(set(all_indices)) == 10  # no shared index
+        rec = wallet_manager.storage.load_wallet("default")
+        assert rec.next_address_index == max(all_indices) + 1
+
 
 class TestFingerprint:
     def test_hot_wallet_fingerprint_is_8_hex(self, wallet_manager):

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -81,6 +81,36 @@ class TestAddressCounter:
         t.join(timeout=5)
         assert got  # proceeded once the lock was released
 
+    def test_ensure_counter_covers_repairs_reset_counter(self, wallet_manager):
+        # Simulate a seed reimport: the server still holds pool addresses at
+        # indices 5..7 but the local counter is 0. Reconciliation must bump
+        # the counter past the highest server-known index.
+        pool = [
+            wallet_manager.peek_address("default", index=i).address
+            for i in (5, 6, 7)
+        ]
+        assert wallet_manager.storage.load_wallet("default").next_address_index == 0
+        new_counter = wallet_manager.ensure_counter_covers("default", pool)
+        assert new_counter == 8
+        rec = wallet_manager.storage.load_wallet("default")
+        assert rec.next_address_index == 8
+        # The next handout must sit above the recovered pool.
+        assert wallet_manager.get_address("default").index >= 8
+
+    def test_ensure_counter_covers_is_idempotent_and_never_lowers(
+        self, wallet_manager
+    ):
+        wallet_manager.reserve_addresses("default", 10)
+        pool = [wallet_manager.peek_address("default", index=2).address]
+        counter = wallet_manager.ensure_counter_covers("default", pool)
+        assert counter == 10  # already covered — unchanged
+
+    def test_ensure_counter_covers_ignores_foreign_addresses(self, wallet_manager):
+        counter = wallet_manager.ensure_counter_covers(
+            "default", ["lq1qqnotfromthiswallet"]
+        )
+        assert counter == 0
+
     def test_concurrent_reserves_never_share_an_index(self, wallet_manager):
         # Two racing reservers must produce disjoint index ranges and a
         # counter equal to the total handed out.


### PR DESCRIPTION
## 🔧 Code-review fixes — 2026-07-06

**Scope:** follow-up to the code review of #113, on top of `108-jan3-ln-address`. Seven issues addressed, **one commit per issue** — each collapsible section below maps 1:1 to a commit, in commit order (most severe first).

I prompted Claude to check my original branch and I think some of these got lost in the port from my original branch to yours. Feel free to remove any commit before merging but I think they all make sense to add. Not here to discuss them, you make the call. 

<details>
<summary><b>1. Fund the exact quoted order on purchase confirm</b> · <code>80b9a6f</code></summary>

**Issue:** the two-step purchase consent was not binding. `purchase_ln_username(confirm=True)` created a *fresh* payment request and signed whatever amount it returned, so a backend reprice or quote expiry between the steps silently spent a price nobody consented to. Every completed purchase also stranded the unfunded step-1 order, and CLI `--yes` created an extra orphan by fetching a quote nobody read.

</details>

<details>
<summary><b>2. Reuse the pending batch when LN-address registration retries</b> · <code>b86b76f</code></summary>

**Issue:** burn-before-POST is the correct ordering (an ambiguous HTTP failure may have registered server-side), but nothing remembered the burned batch — during an `/addresses/`-endpoint outage, every retry reserved and discarded up to 15 fresh indices. A few consecutive failures create >20 consecutive never-funded indices, breaking seed-only restore in gap-20 wallet software.

</details>

<details>
<summary><b>3. Guard the address counter with a cross-process wallet lock</b> · <code>574ac9b</code></summary>

**Issue:** `reserve_addresses` did load → `max` → derive → save with no file lock, and `save_wallet` is a whole-record last-writer-wins overwrite. A CLI process (`aqua lightning receive`) racing the MCP server's auto top-up could hand the same index to Boltz and the JAN3 pool, then roll the counter back so the next several handouts *serially* re-issue pool-registered addresses.

</details>

<details>
<summary><b>4. Reconcile the address counter with the server pool; document caveats</b> · <code>fc99815</code></summary>

**Issue:** the counter protects external state (the server-registered pool) but lives only in the local wallet JSON. Reimporting the seed on a new machine resets it to 0 while the server still delivers LN payments to the previously registered indices — the next swap/receive re-hands those same addresses. Additionally, released binaries (≤ v0.4.2) construct `WalletData` strictly and hard-crash on wallet files containing the new `next_address_index` key.

</details>

<details>
<summary><b>5. Add CLI smoke tests for the four untested jan3 LN commands</b> · <code>94453ab</code></summary>

**Issue:** `src/aqua/cli/AGENTS.md` requires a smoke test in `tests/test_cli.py` for every new CLI command; only `rebind-wallet` had one. `user-info`, `enable-lightning-address`, `ln-check-username`, and — most importantly — the funds-spending `purchase-ln-username` had zero CLI tests, so none of the purchase consent gating was exercised.

</details>

<details>
<summary><b>6. Report a distinct, actionable skip when the wallet has no fingerprint</b> · <code>85c5bc7</code></summary>

**Issue:** for watch-only wallets imported from a bare descriptor without a `[fingerprint/derivation]` origin block, `fingerprint()` raises after the toggle POST already succeeded — leaving the account permanently "enabled with 0 addresses" while the failure shared the `auto_topup_unavailable` reason code with transient backend 500s and carried no actionable message.

</details>

<details>
<summary><b>7. Restore two test suites dropped in the port from the original LN branch</b> · <code>5a94387</code></summary>

**Issue:** the port-completeness check against `108-jan3-lightning-addresses` found two suites with no equivalent on this branch: `TestPurchaseThenResolve` (the only cross-module assertion covering purchase → `resolve_lightning_address` → BOLT11 invoice) and `test_counter_promoted_when_lwk_tip_is_higher` (a stale persisted counter must jump forward to the lwk tip).

</details>

