### PR TITLE
Add `aqua doctor` config diagnostic/repair tool

### DIFF
--- a/src/aqua/cli/commands.py
+++ b/src/aqua/cli/commands.py
@@ -81,9 +81,7 @@ def register_commands(cli: click.Group, config: Config | None = None) -> None:
     # `qr` is gated as a group above (its `decode` subcommand maps to `qr_decode`).
     cli.add_command(serve)
 
-    # `doctor` diagnoses/repairs config.json — always available (it is most
-    # needed precisely when the config is broken), so it is never gated off the
-    # CLI even though it has an MCP twin (which IS gateable, like every tool).
+    # Always registered — most needed when config is broken (its MCP twin is gateable).
     cli.add_command(doctor)
 
     # `balance` is gated by `unified_balance`'s flag.

--- a/src/aqua/cli/commands.py
+++ b/src/aqua/cli/commands.py
@@ -32,6 +32,7 @@ def register_commands(cli: click.Group, config: Config | None = None) -> None:
 
     from .btc import btc
     from .changelly import changelly
+    from .doctor import doctor
     from .jan3 import jan3
     from .lightning import lightning
     from .liquid import liquid
@@ -79,6 +80,11 @@ def register_commands(cli: click.Group, config: Config | None = None) -> None:
     # Top-level commands. `serve` is CLI-only (no MCP twin) — always register.
     # `qr` is gated as a group above (its `decode` subcommand maps to `qr_decode`).
     cli.add_command(serve)
+
+    # `doctor` diagnoses/repairs config.json — always available (it is most
+    # needed precisely when the config is broken), so it is never gated off the
+    # CLI even though it has an MCP twin (which IS gateable, like every tool).
+    cli.add_command(doctor)
 
     # `balance` is gated by `unified_balance`'s flag.
     if is_tool_enabled("unified_balance", config):

--- a/src/aqua/cli/doctor.py
+++ b/src/aqua/cli/doctor.py
@@ -1,0 +1,35 @@
+"""Doctor command — diagnose and optionally repair ~/.aqua/config.json."""
+
+import sys
+
+import click
+
+from .output import render, render_error
+
+
+@click.command("doctor")
+@click.option("--fix", is_flag=True, help="Apply the repairs (default: diagnose only).")
+@click.pass_obj
+def doctor(ctx, fix):
+    """Diagnose (and with --fix, repair) your AQUA config file.
+
+    By default this only reports issues. Exit code is 0 when the config is
+    healthy (or was fully repaired) and 1 when fixable issues remain or manual
+    intervention is needed.
+    """
+    from ..doctor import run_doctor
+
+    # Match the CLI convention (see cli/output.run_tool): render the error
+    # envelope instead of dumping a raw traceback if the fix write path raises
+    # (e.g. read-only FS, disk full, permission denied).
+    try:
+        report = run_doctor(fix=fix)
+    except Exception as exc:  # noqa: BLE001 — surface any failure as an envelope
+        click.echo(render_error(type(exc).__name__, str(exc), ctx.fmt), err=True)
+        sys.exit(1)
+
+    click.echo(render(report, ctx.fmt))
+
+    # `healthy` already reflects the post-fix state (False if any manual-only
+    # finding remains), so it is the single source of truth for the exit code.
+    sys.exit(0 if report["healthy"] else 1)

--- a/src/aqua/cli/doctor.py
+++ b/src/aqua/cli/doctor.py
@@ -4,7 +4,7 @@ import sys
 
 import click
 
-from .output import render, render_error
+from .output import run_tool
 
 
 @click.command("doctor")
@@ -17,14 +17,6 @@ def doctor(ctx, fix):
     """
     from ..doctor import run_doctor
 
-    # Match cli.output.run_tool's error envelope instead of a raw traceback.
-    try:
-        report = run_doctor(fix=fix)
-    except Exception as exc:  # noqa: BLE001 — surface any failure as an envelope
-        click.echo(render_error(type(exc).__name__, str(exc), ctx.fmt), err=True)
-        sys.exit(1)
-
-    click.echo(render(report, ctx.fmt))
-
+    report = run_tool(ctx, lambda: run_doctor(fix=fix))
     # healthy already reflects post-fix state, so it's the sole exit-code source.
     sys.exit(0 if report["healthy"] else 1)

--- a/src/aqua/cli/doctor.py
+++ b/src/aqua/cli/doctor.py
@@ -13,15 +13,11 @@ from .output import render, render_error
 def doctor(ctx, fix):
     """Diagnose (and with --fix, repair) your AQUA config file.
 
-    By default this only reports issues. Exit code is 0 when the config is
-    healthy (or was fully repaired) and 1 when fixable issues remain or manual
-    intervention is needed.
+    Exit code 0 if healthy or fully repaired, 1 if issues remain.
     """
     from ..doctor import run_doctor
 
-    # Match the CLI convention (see cli/output.run_tool): render the error
-    # envelope instead of dumping a raw traceback if the fix write path raises
-    # (e.g. read-only FS, disk full, permission denied).
+    # Match cli.output.run_tool's error envelope instead of a raw traceback.
     try:
         report = run_doctor(fix=fix)
     except Exception as exc:  # noqa: BLE001 — surface any failure as an envelope
@@ -30,6 +26,5 @@ def doctor(ctx, fix):
 
     click.echo(render(report, ctx.fmt))
 
-    # `healthy` already reflects the post-fix state (False if any manual-only
-    # finding remains), so it is the single source of truth for the exit code.
+    # healthy already reflects post-fix state, so it's the sole exit-code source.
     sys.exit(0 if report["healthy"] else 1)

--- a/src/aqua/cli/output.py
+++ b/src/aqua/cli/output.py
@@ -59,10 +59,14 @@ def render_error(code: str, message: str, fmt: str | None = None) -> str:
 
 
 def run_tool(ctx, fn):
-    """Execute fn(), render the result or exit with a formatted error."""
+    """Execute fn(), render the result or exit with a formatted error.
+
+    Returns the result so callers can derive an exit code from it.
+    """
     try:
         result = fn()
-        click.echo(render(result, ctx.fmt))
     except Exception as e:
         click.echo(render_error(type(e).__name__, str(e), ctx.fmt), err=True)
         sys.exit(1)
+    click.echo(render(result, ctx.fmt))
+    return result

--- a/src/aqua/doctor.py
+++ b/src/aqua/doctor.py
@@ -1,0 +1,209 @@
+"""Config diagnostics and repair — the `doctor` tool.
+
+Reads ``~/.aqua/config.json`` as **raw JSON** (never via ``Config.from_dict``,
+which does ``cls(**data)`` and crashes on an unknown top-level key — a crash
+that would otherwise break *every* aqua invocation, doctor included). It then
+reports, and optionally repairs, three classes of drift:
+
+- **orphan tools**: keys under ``enabled_tools`` that name a tool no longer in
+  ``TOOLS`` (these produce the ``Unknown tool in enabled_tools`` startup
+  warning);
+- **default-matching entries**: keys whose boolean value equals the current
+  shipped default — prunable so the file stays *sparse* (only genuine user
+  overrides persist, and future default changes flow through);
+- **unknown top-level keys**: keys outside the ``Config`` schema that would
+  crash ``Config.from_dict``.
+
+The config model is *sparse*: a tool absent from the file uses its shipped
+default (see ``features.is_tool_enabled``). ``doctor --fix`` is the only code
+path that rewrites the file. Non-boolean ``enabled_tools`` entries and genuine
+overrides (boolean value differing from the default) are left untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import fields
+from typing import Any
+
+from .features import SHIPPED_DEFAULTS_ENABLED_TOOLS
+from .storage import Config, Storage
+from .tools import TOOLS
+
+logger = logging.getLogger(__name__)
+
+# Top-level keys the Config schema accepts. Anything else crashes from_dict.
+_KNOWN_CONFIG_KEYS: frozenset[str] = frozenset(f.name for f in fields(Config))
+
+# A real config is a few KB. Refuse to parse anything wildly larger so a
+# corrupt/adversarial file cannot OOM the process.
+_MAX_CONFIG_BYTES = 5_000_000
+
+
+def _is_prunable_default(name: str, value: Any) -> bool:
+    """True if ``name=value`` is a known tool whose bool value equals its default."""
+    return (
+        name in TOOLS
+        and isinstance(value, bool)
+        and value == SHIPPED_DEFAULTS_ENABLED_TOOLS.get(name)
+    )
+
+
+def run_doctor(storage: Storage | None = None, fix: bool = False) -> dict[str, Any]:
+    """Diagnose (and with ``fix=True`` repair) the AQUA config file.
+
+    Returns a report dict with keys: ``config_path``, ``healthy`` (bool),
+    ``fix_applied`` (bool), ``findings`` (list of ``{type, key, detail,
+    action}``) and ``summary``. ``action`` is ``"remove"`` for auto-fixable
+    drift or ``"manual"`` for issues doctor will not touch (corrupt file, etc.).
+    ``healthy`` reflects the state *after* any repair: with ``fix=True`` it is
+    True once every removable finding has been applied (only ``manual`` findings
+    can keep it False); ``findings`` still lists what was repaired.
+    """
+    if storage is None:
+        storage = Storage()
+    path = storage.config_path
+
+    report: dict[str, Any] = {
+        "config_path": str(path),
+        "healthy": True,
+        "fix_applied": False,
+        "findings": [],
+        "summary": "",
+    }
+    findings: list[dict[str, Any]] = report["findings"]
+
+    if not path.exists():
+        report["summary"] = (
+            "No config file found; all tools use shipped defaults. Nothing to do."
+        )
+        return report
+
+    try:
+        if path.stat().st_size > _MAX_CONFIG_BYTES:
+            raise ValueError(
+                f"config file is implausibly large ({path.stat().st_size} bytes)"
+            )
+        with open(path) as f:
+            # ValueError covers json.JSONDecodeError; RecursionError covers a
+            # deeply-nested adversarial document.
+            raw = json.load(f)
+    except (OSError, ValueError, RecursionError) as exc:
+        report["healthy"] = False
+        findings.append({
+            "type": "unreadable_config",
+            "key": None,
+            "detail": f"Could not read/parse {path}: {exc}",
+            "action": "manual",
+        })
+        report["summary"] = (
+            "Config file is unreadable or corrupt; fix or delete it by hand."
+        )
+        return report
+
+    if not isinstance(raw, dict):
+        report["healthy"] = False
+        findings.append({
+            "type": "invalid_config_root",
+            "key": None,
+            "detail": f"Config root must be a JSON object, got {type(raw).__name__}.",
+            "action": "manual",
+        })
+        report["summary"] = "Config root is not an object; fix it by hand."
+        return report
+
+    # --- Unknown top-level keys (crash Config.from_dict) ---
+    unknown_top = [k for k in raw if k not in _KNOWN_CONFIG_KEYS]
+    for key in unknown_top:
+        findings.append({
+            "type": "unknown_top_level_key",
+            "key": key,
+            "detail": f"Unknown top-level key {key!r} (would crash config loading).",
+            "action": "remove",
+        })
+
+    # --- enabled_tools analysis ---
+    enabled = raw.get("enabled_tools")
+    orphans: list[str] = []
+    default_matches: list[str] = []
+    if isinstance(enabled, dict):
+        for key, value in enabled.items():
+            if key not in TOOLS:
+                orphans.append(key)
+                findings.append({
+                    "type": "orphan_tool",
+                    "key": key,
+                    "detail": (
+                        f"{key!r} is not a known tool (source of the startup "
+                        "'Unknown tool in enabled_tools' warning)."
+                    ),
+                    "action": "remove",
+                })
+            elif _is_prunable_default(key, value):
+                default_matches.append(key)
+                findings.append({
+                    "type": "matches_default",
+                    "key": key,
+                    "detail": (
+                        f"{key!r}={value} equals the shipped default; prunable to "
+                        "keep the config sparse."
+                    ),
+                    "action": "remove",
+                })
+            # else: genuine override (bool != default) or non-bool value → leave it.
+    elif enabled is not None:
+        findings.append({
+            "type": "invalid_enabled_tools",
+            "key": "enabled_tools",
+            "detail": "'enabled_tools' must be an object mapping tool name -> bool.",
+            "action": "manual",
+        })
+
+    removable = [f for f in findings if f["action"] == "remove"]
+    manual = [f for f in findings if f["action"] == "manual"]
+
+    if fix and removable:
+        cleaned: dict[str, Any] = {k: v for k, v in raw.items() if k in _KNOWN_CONFIG_KEYS}
+        if isinstance(enabled, dict):
+            sparse = {
+                k: v
+                for k, v in enabled.items()
+                if k in TOOLS and not _is_prunable_default(k, v)
+            }
+            if sparse:
+                cleaned["enabled_tools"] = sparse
+            else:
+                cleaned.pop("enabled_tools", None)
+        storage.save_raw_config(cleaned)
+        report["fix_applied"] = True
+        # Only the (untouched) manual findings can remain after a repair.
+        report["healthy"] = not manual
+        repaired = (
+            f"Repaired {path}: removed {len(orphans)} orphan tool key(s), "
+            f"pruned {len(default_matches)} default-matching entry(ies), "
+            f"removed {len(unknown_top)} unknown top-level key(s)."
+        )
+        report["summary"] = (
+            f"{repaired} {len(manual)} issue(s) still need manual attention."
+            if manual
+            else repaired
+        )
+    elif not findings:
+        report["healthy"] = True
+        report["summary"] = "Config is healthy; nothing to fix."
+    else:
+        report["healthy"] = False
+        if removable:
+            report["summary"] = (
+                f"Found {len(removable)} auto-fixable issue(s)"
+                + (f" and {len(manual)} needing manual attention" if manual else "")
+                + ". Run `aqua doctor --fix` to apply the fixable ones."
+            )
+        else:
+            report["summary"] = (
+                f"{len(manual)} issue(s) need manual attention; "
+                "nothing can be auto-fixed."
+            )
+
+    return report

--- a/src/aqua/doctor.py
+++ b/src/aqua/doctor.py
@@ -1,23 +1,14 @@
 """Config diagnostics and repair — the `doctor` tool.
 
-Reads ``~/.aqua/config.json`` as **raw JSON** (never via ``Config.from_dict``,
-which does ``cls(**data)`` and crashes on an unknown top-level key — a crash
-that would otherwise break *every* aqua invocation, doctor included). It then
-reports, and optionally repairs, three classes of drift:
+Reads ``~/.aqua/config.json`` as raw JSON, never via ``Config.from_dict``
+(which crashes on an unknown top-level key) — this lets doctor repair the
+exact configs that would otherwise break config loading entirely.
 
-- **orphan tools**: keys under ``enabled_tools`` that name a tool no longer in
-  ``TOOLS`` (these produce the ``Unknown tool in enabled_tools`` startup
-  warning);
-- **default-matching entries**: keys whose boolean value equals the current
-  shipped default — prunable so the file stays *sparse* (only genuine user
-  overrides persist, and future default changes flow through);
-- **unknown top-level keys**: keys outside the ``Config`` schema that would
-  crash ``Config.from_dict``.
-
-The config model is *sparse*: a tool absent from the file uses its shipped
-default (see ``features.is_tool_enabled``). ``doctor --fix`` is the only code
-path that rewrites the file. Non-boolean ``enabled_tools`` entries and genuine
-overrides (boolean value differing from the default) are left untouched.
+Diagnoses (and with ``fix=True`` repairs) three kinds of drift: orphan tool
+keys no longer in ``TOOLS``, entries matching the current shipped default
+(prunable to keep the config sparse), and unknown top-level keys. Absent
+keys use the shipped default (see ``features.is_tool_enabled``); ``doctor``
+is the only code path that rewrites the file.
 """
 
 from __future__ import annotations
@@ -36,8 +27,7 @@ logger = logging.getLogger(__name__)
 # Top-level keys the Config schema accepts. Anything else crashes from_dict.
 _KNOWN_CONFIG_KEYS: frozenset[str] = frozenset(f.name for f in fields(Config))
 
-# A real config is a few KB. Refuse to parse anything wildly larger so a
-# corrupt/adversarial file cannot OOM the process.
+# Configs are a few KB; refuse anything wildly larger to avoid OOM on a corrupt file.
 _MAX_CONFIG_BYTES = 5_000_000
 
 
@@ -53,13 +43,9 @@ def _is_prunable_default(name: str, value: Any) -> bool:
 def run_doctor(storage: Storage | None = None, fix: bool = False) -> dict[str, Any]:
     """Diagnose (and with ``fix=True`` repair) the AQUA config file.
 
-    Returns a report dict with keys: ``config_path``, ``healthy`` (bool),
-    ``fix_applied`` (bool), ``findings`` (list of ``{type, key, detail,
-    action}``) and ``summary``. ``action`` is ``"remove"`` for auto-fixable
-    drift or ``"manual"`` for issues doctor will not touch (corrupt file, etc.).
-    ``healthy`` reflects the state *after* any repair: with ``fix=True`` it is
-    True once every removable finding has been applied (only ``manual`` findings
-    can keep it False); ``findings`` still lists what was repaired.
+    Returns ``{config_path, healthy, fix_applied, findings, summary}``; each
+    finding's ``action`` is "remove" (auto-fixable) or "manual". ``healthy``
+    reflects the state *after* any repair.
     """
     if storage is None:
         storage = Storage()
@@ -86,8 +72,7 @@ def run_doctor(storage: Storage | None = None, fix: bool = False) -> dict[str, A
                 f"config file is implausibly large ({path.stat().st_size} bytes)"
             )
         with open(path) as f:
-            # ValueError covers json.JSONDecodeError; RecursionError covers a
-            # deeply-nested adversarial document.
+            # ValueError covers JSONDecodeError; RecursionError covers deeply-nested input.
             raw = json.load(f)
     except (OSError, ValueError, RecursionError) as exc:
         report["healthy"] = False

--- a/src/aqua/doctor.py
+++ b/src/aqua/doctor.py
@@ -1,8 +1,8 @@
 """Config diagnostics and repair — the `doctor` tool.
 
-Reads ``~/.aqua/config.json`` as raw JSON, never via ``Config.from_dict``
-(which crashes on an unknown top-level key) — this lets doctor repair the
-exact configs that would otherwise break config loading entirely.
+Reads ``~/.aqua/config.json`` as raw JSON, never via ``Config.from_dict`` —
+this lets doctor inspect the file verbatim and repair configs (including
+corrupt ones) that the tolerant load path can only warn about and ignore.
 
 Diagnoses (and with ``fix=True`` repairs) three kinds of drift: orphan tool
 keys no longer in ``TOOLS``, entries matching the current shipped default
@@ -15,17 +15,14 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import fields
+from collections import Counter
 from typing import Any
 
 from .features import SHIPPED_DEFAULTS_ENABLED_TOOLS
-from .storage import Config, Storage
+from .storage import KNOWN_CONFIG_KEYS, Storage
 from .tools import TOOLS
 
 logger = logging.getLogger(__name__)
-
-# Top-level keys the Config schema accepts. Anything else crashes from_dict.
-_KNOWN_CONFIG_KEYS: frozenset[str] = frozenset(f.name for f in fields(Config))
 
 # Configs are a few KB; refuse anything wildly larger to avoid OOM on a corrupt file.
 _MAX_CONFIG_BYTES = 5_000_000
@@ -67,10 +64,9 @@ def run_doctor(storage: Storage | None = None, fix: bool = False) -> dict[str, A
         return report
 
     try:
-        if path.stat().st_size > _MAX_CONFIG_BYTES:
-            raise ValueError(
-                f"config file is implausibly large ({path.stat().st_size} bytes)"
-            )
+        size = path.stat().st_size
+        if size > _MAX_CONFIG_BYTES:
+            raise ValueError(f"config file is implausibly large ({size} bytes)")
         with open(path) as f:
             # ValueError covers JSONDecodeError; RecursionError covers deeply-nested input.
             raw = json.load(f)
@@ -98,24 +94,23 @@ def run_doctor(storage: Storage | None = None, fix: bool = False) -> dict[str, A
         report["summary"] = "Config root is not an object; fix it by hand."
         return report
 
-    # --- Unknown top-level keys (crash Config.from_dict) ---
-    unknown_top = [k for k in raw if k not in _KNOWN_CONFIG_KEYS]
-    for key in unknown_top:
+    # --- Unknown top-level keys (ignored at load; doctor removes them from disk) ---
+    unknown_top = {k for k in raw if k not in KNOWN_CONFIG_KEYS}
+    for key in sorted(unknown_top):
         findings.append({
             "type": "unknown_top_level_key",
             "key": key,
-            "detail": f"Unknown top-level key {key!r} (would crash config loading).",
+            "detail": f"Unknown top-level key {key!r} (ignored at load).",
             "action": "remove",
         })
 
     # --- enabled_tools analysis ---
     enabled = raw.get("enabled_tools")
-    orphans: list[str] = []
-    default_matches: list[str] = []
+    remove_tool_keys: set[str] = set()
     if isinstance(enabled, dict):
         for key, value in enabled.items():
             if key not in TOOLS:
-                orphans.append(key)
+                remove_tool_keys.add(key)
                 findings.append({
                     "type": "orphan_tool",
                     "key": key,
@@ -126,7 +121,7 @@ def run_doctor(storage: Storage | None = None, fix: bool = False) -> dict[str, A
                     "action": "remove",
                 })
             elif _is_prunable_default(key, value):
-                default_matches.append(key)
+                remove_tool_keys.add(key)
                 findings.append({
                     "type": "matches_default",
                     "key": key,
@@ -149,13 +144,13 @@ def run_doctor(storage: Storage | None = None, fix: bool = False) -> dict[str, A
     manual = [f for f in findings if f["action"] == "manual"]
 
     if fix and removable:
-        cleaned: dict[str, Any] = {k: v for k, v in raw.items() if k in _KNOWN_CONFIG_KEYS}
+        # Apply exactly what was diagnosed: the sets built above are the
+        # single source of truth for what gets removed.
+        cleaned: dict[str, Any] = {
+            k: v for k, v in raw.items() if k not in unknown_top
+        }
         if isinstance(enabled, dict):
-            sparse = {
-                k: v
-                for k, v in enabled.items()
-                if k in TOOLS and not _is_prunable_default(k, v)
-            }
+            sparse = {k: v for k, v in enabled.items() if k not in remove_tool_keys}
             if sparse:
                 cleaned["enabled_tools"] = sparse
             else:
@@ -164,10 +159,11 @@ def run_doctor(storage: Storage | None = None, fix: bool = False) -> dict[str, A
         report["fix_applied"] = True
         # Only the (untouched) manual findings can remain after a repair.
         report["healthy"] = not manual
+        counts = Counter(f["type"] for f in removable)
         repaired = (
-            f"Repaired {path}: removed {len(orphans)} orphan tool key(s), "
-            f"pruned {len(default_matches)} default-matching entry(ies), "
-            f"removed {len(unknown_top)} unknown top-level key(s)."
+            f"Repaired {path}: removed {counts['orphan_tool']} orphan tool key(s), "
+            f"pruned {counts['matches_default']} default-matching entry(ies), "
+            f"removed {counts['unknown_top_level_key']} unknown top-level key(s)."
         )
         report["summary"] = (
             f"{repaired} {len(manual)} issue(s) still need manual attention."

--- a/src/aqua/features.py
+++ b/src/aqua/features.py
@@ -152,22 +152,6 @@ def is_tool_enabled(name: str, config: Config) -> bool:
     )
 
 
-def _merge_with_defaults(
-    loaded: dict[str, bool],
-) -> tuple[dict[str, bool], bool]:
-    """Merge shipped defaults into `loaded`, preserving user's overrides.
-
-    Returns `(merged, changed)` — in-memory only, no longer persisted by the caller.
-    """
-    merged = dict(loaded)
-    changed = False
-    for key, default in SHIPPED_DEFAULTS_ENABLED_TOOLS.items():
-        if key not in merged:
-            merged[key] = default
-            changed = True
-    return merged, changed
-
-
 def load_config_with_merge(storage: Storage | None = None) -> Config:
     """Load config and merge shipped defaults IN MEMORY only — never writes to disk.
 
@@ -200,6 +184,5 @@ def load_config_with_merge(storage: Storage | None = None) -> Config:
                 storage.config_path,
             )
 
-    merged, _ = _merge_with_defaults(config.enabled_tools)
-    config.enabled_tools = merged
+    config.enabled_tools = {**SHIPPED_DEFAULTS_ENABLED_TOOLS, **config.enabled_tools}
     return config

--- a/src/aqua/features.py
+++ b/src/aqua/features.py
@@ -157,9 +157,7 @@ def _merge_with_defaults(
 ) -> tuple[dict[str, bool], bool]:
     """Merge shipped defaults into `loaded`, preserving user's overrides.
 
-    Returns `(merged, changed)`. `changed` is True if any default keys were
-    inserted. The merge is in-memory only; `load_config_with_merge` no longer
-    persists it (see that function's docstring).
+    Returns `(merged, changed)` — in-memory only, no longer persisted by the caller.
     """
     merged = dict(loaded)
     changed = False
@@ -171,26 +169,16 @@ def _merge_with_defaults(
 
 
 def load_config_with_merge(storage: Storage | None = None) -> Config:
-    """Load config and merge shipped defaults IN MEMORY. Read-only — never writes.
+    """Load config and merge shipped defaults IN MEMORY only — never writes to disk.
 
-    Startup is non-invasive: the shipped defaults are merged into the returned
-    `Config` so callers see a fully-populated `enabled_tools` for gating, but
-    `config.json` is left untouched on disk. A tool key absent from the file
-    means "use the shipped default" (see `is_tool_enabled`), so new versions can
-    change a default without clobbering the user's explicit choices, and the
-    file is never re-polluted with defaults on every run.
-
-    `doctor` (CLI `aqua doctor --fix`, MCP tool `doctor`) is the only code path
-    that rewrites `config.json`. Unknown keys (typos, removed tools) are warned
-    with a pointer to it — they are no longer silently persisted.
+    An absent tool key means "use the shipped default", so a new version's default
+    change can't clobber a user's choice. `doctor` is the only code path that
+    rewrites `config.json`.
     """
     if storage is None:
         storage = Storage()
 
-    # Startup must never crash on a broken config file — otherwise `aqua doctor`
-    # (the tool that repairs it) could not run either. A corrupt/unreadable file
-    # degrades to in-memory defaults (read-only, so nothing is overwritten) with
-    # a pointer to `doctor`, which reads the raw JSON and reports the problem.
+    # Never crash on a broken config — aqua doctor (which fixes it) must still run.
     try:
         config = storage.load_config()
     except (OSError, ValueError) as exc:  # ValueError ⊇ json.JSONDecodeError
@@ -202,8 +190,7 @@ def load_config_with_merge(storage: Storage | None = None) -> Config:
         )
         config = Config()
 
-    # Warn on unknown keys (typos, removed tools). One line per key, each
-    # pointing at `doctor` so the user can clean them all up at once.
+    # Warn on unknown keys (typos, removed tools); each warning points at doctor.
     for key in config.enabled_tools:
         if key not in TOOLS:
             logger.warning(

--- a/src/aqua/features.py
+++ b/src/aqua/features.py
@@ -127,6 +127,9 @@ CLI_COMMAND_TO_MCP_TOOL: dict[tuple[str, str], str] = {
     # qr group (cli/qr.py)
     ("qr", "decode"): "qr_decode",
 
+    # Top-level diagnostic (cli/doctor.py) — always registered, gated only for MCP.
+    ("", "doctor"): "doctor",
+
     # jan3 group (cli/jan3.py) — JAN3 account login + sessions + Lightning Address
     ("jan3", "login"): "jan3_login",
     ("jan3", "verify"): "jan3_verify",
@@ -169,7 +172,8 @@ def _merge_with_defaults(
     """Merge shipped defaults into `loaded`, preserving user's overrides.
 
     Returns `(merged, changed)`. `changed` is True if any default keys were
-    inserted (so the caller can persist the file).
+    inserted. The merge is in-memory only; `load_config_with_merge` no longer
+    persists it (see that function's docstring).
     """
     merged = dict(loaded)
     changed = False
@@ -181,31 +185,48 @@ def _merge_with_defaults(
 
 
 def load_config_with_merge(storage: Storage | None = None) -> Config:
-    """Load config, merge shipped defaults, warn on unknown keys, persist if changed.
+    """Load config and merge shipped defaults IN MEMORY. Read-only — never writes.
 
-    - On first install (no config file): writes one with shipped defaults.
-    - On upgrade (config exists, lacks `enabled_tools` entries for new tools):
-      adds them and re-saves atomically.
-    - Unknown keys in `enabled_tools` (not in `TOOLS`): warned and otherwise
-      ignored (kept in the saved file so the user can fix the typo).
+    Startup is non-invasive: the shipped defaults are merged into the returned
+    `Config` so callers see a fully-populated `enabled_tools` for gating, but
+    `config.json` is left untouched on disk. A tool key absent from the file
+    means "use the shipped default" (see `is_tool_enabled`), so new versions can
+    change a default without clobbering the user's explicit choices, and the
+    file is never re-polluted with defaults on every run.
+
+    `doctor` (CLI `aqua doctor --fix`, MCP tool `doctor`) is the only code path
+    that rewrites `config.json`. Unknown keys (typos, removed tools) are warned
+    with a pointer to it — they are no longer silently persisted.
     """
     if storage is None:
         storage = Storage()
-    config_existed = storage.config_path.exists()
-    config = storage.load_config()
 
-    # Warn on unknown keys (typos, removed tools).
+    # Startup must never crash on a broken config file — otherwise `aqua doctor`
+    # (the tool that repairs it) could not run either. A corrupt/unreadable file
+    # degrades to in-memory defaults (read-only, so nothing is overwritten) with
+    # a pointer to `doctor`, which reads the raw JSON and reports the problem.
+    try:
+        config = storage.load_config()
+    except (OSError, ValueError) as exc:  # ValueError ⊇ json.JSONDecodeError
+        logger.warning(
+            "Could not read %s (%s). Using defaults for this run; "
+            "run `aqua doctor` to inspect and repair it.",
+            storage.config_path,
+            exc,
+        )
+        config = Config()
+
+    # Warn on unknown keys (typos, removed tools). One line per key, each
+    # pointing at `doctor` so the user can clean them all up at once.
     for key in config.enabled_tools:
         if key not in TOOLS:
             logger.warning(
                 "Unknown tool in enabled_tools: %r (ignored). "
-                "Remove it from %s to silence this warning.",
+                "Run `aqua doctor --fix` to clean it up, or remove it from %s.",
                 key,
                 storage.config_path,
             )
 
-    merged, changed = _merge_with_defaults(config.enabled_tools)
+    merged, _ = _merge_with_defaults(config.enabled_tools)
     config.enabled_tools = merged
-    if changed or not config_existed:
-        storage.save_config(config)
     return config

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1267,6 +1267,31 @@ TOOL_SCHEMAS = {
             "required": ["image_path"],
         },
     },
+    "doctor": {
+        "description": (
+            "Diagnose (and optionally repair) the AQUA config file "
+            "(~/.aqua/config.json): reports orphaned/unknown tool keys (the "
+            "source of the 'Unknown tool in enabled_tools' startup warnings), "
+            "entries that match the shipped default (prunable to keep the config "
+            "sparse), and unknown top-level keys that would break config loading. "
+            "Read-only by default; pass fix=true to apply repairs. Note: the "
+            "running server reads its tool-gating config once at startup, so any "
+            "gating change from a fix takes effect on the next server restart."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "fix": {
+                    "type": "boolean",
+                    "description": (
+                        "If true, apply repairs: remove orphan tool keys, prune "
+                        "entries matching the shipped default, and drop unknown "
+                        "top-level keys. Default false = diagnose only."
+                    ),
+                }
+            },
+        },
+    },
     "jan3_login": {
         "description": (
             "Default JAN3 login (free, email-OTP): the backend emails a 6-digit "

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1273,7 +1273,7 @@ TOOL_SCHEMAS = {
             "(~/.aqua/config.json): reports orphaned/unknown tool keys (the "
             "source of the 'Unknown tool in enabled_tools' startup warnings), "
             "entries that match the shipped default (prunable to keep the config "
-            "sparse), and unknown top-level keys that would break config loading. "
+            "sparse), and unknown top-level keys (ignored at load until removed). "
             "Read-only by default; pass fix=true to apply repairs. Note: the "
             "running server reads its tool-gating config once at startup, so any "
             "gating change from a fix takes effect on the next server restart."

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -126,11 +126,8 @@ class Config:
                     v,
                 )
         data["enabled_tools"] = coerced
-        # Forward/backward compatibility: drop unknown top-level keys instead of
-        # crashing on `cls(**data)` (mirrors WalletData.from_dict). A stray key
-        # — from a newer release, a removed field, or a typo — must not make the
-        # CLI/MCP (including `aqua doctor` itself) unusable. The key is only
-        # dropped in memory here; `aqua doctor --fix` removes it from disk.
+        # Drop unknown top-level keys instead of crashing (mirrors WalletData.from_dict);
+        # `aqua doctor --fix` removes them from disk.
         known = {f.name for f in fields(cls)}
         for key in data:
             if key not in known:
@@ -371,10 +368,8 @@ class Storage:
     def save_raw_config(self, data: dict) -> None:
         """Persist an already-shaped raw config dict atomically (0o600).
 
-        Unlike `save_config`, this does NOT round-trip through `Config`, so the
-        `doctor` tool can rewrite a config file that `Config.from_dict` would
-        reject (e.g. one carrying an unknown top-level key) and can preserve
-        entries verbatim instead of coercing them.
+        Skips the `Config` round-trip so `doctor` can rewrite a file `Config.from_dict`
+        would reject, preserving entries verbatim instead of coercing them.
         """
         self._atomic_write_json(self.config_path, data)
 

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -126,6 +126,20 @@ class Config:
                     v,
                 )
         data["enabled_tools"] = coerced
+        # Forward/backward compatibility: drop unknown top-level keys instead of
+        # crashing on `cls(**data)` (mirrors WalletData.from_dict). A stray key
+        # — from a newer release, a removed field, or a typo — must not make the
+        # CLI/MCP (including `aqua doctor` itself) unusable. The key is only
+        # dropped in memory here; `aqua doctor --fix` removes it from disk.
+        known = {f.name for f in fields(cls)}
+        for key in data:
+            if key not in known:
+                logger.warning(
+                    "Unknown config key %r (ignored). "
+                    "Run `aqua doctor --fix` to clean it up.",
+                    key,
+                )
+        data = {k: v for k, v in data.items() if k in known}
         return cls(**data)
 
 
@@ -353,6 +367,16 @@ class Storage:
 
     def save_config(self, config: Config):
         self._atomic_write_json(self.config_path, config.to_dict())
+
+    def save_raw_config(self, data: dict) -> None:
+        """Persist an already-shaped raw config dict atomically (0o600).
+
+        Unlike `save_config`, this does NOT round-trip through `Config`, so the
+        `doctor` tool can rewrite a config file that `Config.from_dict` would
+        reject (e.g. one carrying an unknown top-level key) and can preserve
+        entries verbatim instead of coercing them.
+        """
+        self._atomic_write_json(self.config_path, data)
 
     # Wallet operations
 

--- a/src/aqua/storage.py
+++ b/src/aqua/storage.py
@@ -128,16 +128,20 @@ class Config:
         data["enabled_tools"] = coerced
         # Drop unknown top-level keys instead of crashing (mirrors WalletData.from_dict);
         # `aqua doctor --fix` removes them from disk.
-        known = {f.name for f in fields(cls)}
         for key in data:
-            if key not in known:
+            if key not in KNOWN_CONFIG_KEYS:
                 logger.warning(
                     "Unknown config key %r (ignored). "
                     "Run `aqua doctor --fix` to clean it up.",
                     key,
                 )
-        data = {k: v for k, v in data.items() if k in known}
+        data = {k: v for k, v in data.items() if k in KNOWN_CONFIG_KEYS}
         return cls(**data)
+
+
+# Single source of truth for the Config schema's top-level keys
+# (shared with `aqua.doctor`, which reads the file as raw JSON).
+KNOWN_CONFIG_KEYS: frozenset[str] = frozenset(f.name for f in fields(Config))
 
 
 def _validate_wallet_name(name: str) -> str:

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -1987,27 +1987,14 @@ def qr_decode(image_path: str) -> dict[str, Any]:
 
 
 def doctor(fix: bool = False) -> dict[str, Any]:
-    """Diagnose (and optionally repair) the AQUA config file (~/.aqua/config.json).
+    """Diagnose (and with fix=True, repair) the AQUA config file (~/.aqua/config.json).
 
-    Reports orphaned/unknown tool keys (the source of the startup 'Unknown tool
-    in enabled_tools' warnings), entries that match the shipped default (prunable
-    to keep the config sparse), and unknown top-level keys that would break config
-    loading. Read-only by default.
-
-    Args:
-        fix: when True, apply the repairs (remove orphan keys, prune
-            default-matching entries, drop unknown top-level keys). Default
-            False = diagnose only.
-
-    Returns:
-        A report dict: config_path, healthy, fix_applied, findings, summary.
+    See `aqua.doctor.run_doctor` for the report shape and repair details.
     """
-    # Imported lazily: `aqua.doctor` imports `features`, which imports this
-    # module — a function-level import keeps that cycle from forming at load.
+    # Lazy import: aqua.doctor imports features, which imports this module (avoids the cycle).
     from .doctor import run_doctor
 
-    # Defensive: a non-compliant MCP client may pass `fix` as a string. Only a
-    # genuine truthy boolean (or "true"/"1"/"yes") should trigger the write.
+    # Defensive: coerce a stringly-typed fix (non-compliant MCP client) to bool.
     if isinstance(fix, str):
         fix = fix.strip().lower() in ("true", "1", "yes")
     return run_doctor(fix=bool(fix))

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -1986,6 +1986,33 @@ def qr_decode(image_path: str) -> dict[str, Any]:
     return {"content": content}
 
 
+def doctor(fix: bool = False) -> dict[str, Any]:
+    """Diagnose (and optionally repair) the AQUA config file (~/.aqua/config.json).
+
+    Reports orphaned/unknown tool keys (the source of the startup 'Unknown tool
+    in enabled_tools' warnings), entries that match the shipped default (prunable
+    to keep the config sparse), and unknown top-level keys that would break config
+    loading. Read-only by default.
+
+    Args:
+        fix: when True, apply the repairs (remove orphan keys, prune
+            default-matching entries, drop unknown top-level keys). Default
+            False = diagnose only.
+
+    Returns:
+        A report dict: config_path, healthy, fix_applied, findings, summary.
+    """
+    # Imported lazily: `aqua.doctor` imports `features`, which imports this
+    # module — a function-level import keeps that cycle from forming at load.
+    from .doctor import run_doctor
+
+    # Defensive: a non-compliant MCP client may pass `fix` as a string. Only a
+    # genuine truthy boolean (or "true"/"1"/"yes") should trigger the write.
+    if isinstance(fix, str):
+        fix = fix.strip().lower() in ("true", "1", "yes")
+    return run_doctor(fix=bool(fix))
+
+
 # ---------------------------------------------------------------------------
 # JAN3 account management (multi-account login + sessions + paid captchaless login)
 # ---------------------------------------------------------------------------
@@ -2302,4 +2329,5 @@ TOOLS = {
     "jan3_ln_check_username": jan3_ln_check_username,
     "jan3_purchase_ln_username": jan3_purchase_ln_username,
     "qr_decode": qr_decode,
+    "doctor": doctor,
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2484,3 +2484,38 @@ class TestWapuPayCli:
         register_commands(cli, Config(enabled_tools=dict(SHIPPED_DEFAULTS_ENABLED_TOOLS)))
         assert "wapupay" in cli.commands
         assert "provision-account" in cli.commands["wapupay"].commands
+
+
+class TestDoctorCommand:
+    """Smoke tests for the top-level `aqua doctor` command."""
+
+    def _isolate(self, monkeypatch, tmp_path):
+        import aqua.storage as storage_mod
+
+        aqua_dir = tmp_path / ".aqua"
+        aqua_dir.mkdir()
+        monkeypatch.setattr(storage_mod, "DEFAULT_DIR", aqua_dir)
+        return aqua_dir / "config.json"
+
+    def test_doctor_diagnose_reports_and_exits_1(self, runner, monkeypatch, tmp_path):
+        cfg = self._isolate(monkeypatch, tmp_path)
+        cfg.write_text(json.dumps({"enabled_tools": {"depix_swap": True}}))
+        result = runner.invoke(cli, ["--format", "json", "doctor"])
+        assert result.exit_code == 1
+        assert "depix_swap" in result.output
+        # Dry-run: file untouched.
+        assert "depix_swap" in cfg.read_text()
+
+    def test_doctor_fix_repairs_and_exits_0(self, runner, monkeypatch, tmp_path):
+        cfg = self._isolate(monkeypatch, tmp_path)
+        cfg.write_text(json.dumps({"version": 9, "enabled_tools": {"depix_swap": True}}))
+        result = runner.invoke(cli, ["--format", "json", "doctor", "--fix"])
+        assert result.exit_code == 0
+        on_disk = json.loads(cfg.read_text())
+        assert "version" not in on_disk
+        assert "depix_swap" not in on_disk.get("enabled_tools", {})
+
+    def test_doctor_healthy_exits_0(self, runner, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)  # no config file → healthy
+        result = runner.invoke(cli, ["--format", "json", "doctor"])
+        assert result.exit_code == 0

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -37,11 +37,14 @@ def _pick_default_true_tool() -> str:
     raise AssertionError("no enabled-by-default tool found")
 
 
-def _pick_default_false_tool() -> str:
-    for name, default in SHIPPED_DEFAULTS_ENABLED_TOOLS.items():
-        if default is False:
-            return name
-    raise AssertionError("no disabled-by-default tool found")
+def _force_default_false(monkeypatch, name: str) -> None:
+    """Force `name`'s shipped default to False for the duration of a test.
+
+    Doesn't assume any tool ships disabled-by-default (currently none do —
+    `_SHIPPED_DISABLED` is empty) — patches the shared dict in place so both
+    `aqua.features` and `aqua.doctor` (which imports the same object) see it.
+    """
+    monkeypatch.setitem(SHIPPED_DEFAULTS_ENABLED_TOOLS, name, False)
 
 
 # --- No config / healthy ---------------------------------------------------
@@ -94,9 +97,10 @@ def test_startup_warning_gone_after_fix(temp_storage, caplog):
 # --- Default-matching pruning ---------------------------------------------
 
 
-def test_default_matching_pruned(temp_storage):
+def test_default_matching_pruned(temp_storage, monkeypatch):
     true_tool = _pick_default_true_tool()
-    false_tool = _pick_default_false_tool()
+    false_tool = next(n for n in SHIPPED_DEFAULTS_ENABLED_TOOLS if n != true_tool)
+    _force_default_false(monkeypatch, false_tool)
     _write_raw(temp_storage, {
         "enabled_tools": {
             true_tool: True,     # equals default → prune

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,295 @@
+"""Tests for the `doctor` config diagnostic/repair tool."""
+
+import json
+import logging
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from aqua.cli.doctor import doctor as doctor_cmd
+from aqua.cli.main import AquaContext
+from aqua.doctor import run_doctor
+from aqua.features import SHIPPED_DEFAULTS_ENABLED_TOOLS, load_config_with_merge
+from aqua.storage import Config, Storage
+from aqua.tools import TOOLS
+
+
+@pytest.fixture
+def temp_storage():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Storage(Path(tmpdir))
+
+
+def _write_raw(storage: Storage, data) -> None:
+    """Write raw JSON to config.json, bypassing Config coercion."""
+    storage.config_path.write_text(json.dumps(data))
+
+
+def _pick_default_true_tool() -> str:
+    for name, default in SHIPPED_DEFAULTS_ENABLED_TOOLS.items():
+        if default is True:
+            return name
+    raise AssertionError("no enabled-by-default tool found")
+
+
+def _pick_default_false_tool() -> str:
+    for name, default in SHIPPED_DEFAULTS_ENABLED_TOOLS.items():
+        if default is False:
+            return name
+    raise AssertionError("no disabled-by-default tool found")
+
+
+# --- No config / healthy ---------------------------------------------------
+
+
+def test_no_config_file_is_healthy(temp_storage):
+    assert not temp_storage.config_path.exists()
+    report = run_doctor(temp_storage, fix=False)
+    assert report["healthy"] is True
+    assert report["findings"] == []
+    assert report["fix_applied"] is False
+
+
+def test_sparse_config_is_healthy(temp_storage):
+    """A config with only genuine overrides has nothing to fix."""
+    tool = _pick_default_true_tool()
+    _write_raw(temp_storage, {"enabled_tools": {tool: False}})  # override (default True)
+    report = run_doctor(temp_storage, fix=False)
+    assert report["healthy"] is True
+
+
+# --- Orphan keys -----------------------------------------------------------
+
+
+def test_orphan_key_reported_and_removed(temp_storage):
+    _write_raw(temp_storage, {"enabled_tools": {"depix_swap": True, "bogus_tool": False}})
+    diag = run_doctor(temp_storage, fix=False)
+    assert diag["healthy"] is False
+    orphans = {f["key"] for f in diag["findings"] if f["type"] == "orphan_tool"}
+    assert orphans == {"depix_swap", "bogus_tool"}
+    # Diagnose is a dry-run: file untouched.
+    assert "depix_swap" in temp_storage.config_path.read_text()
+
+    fix = run_doctor(temp_storage, fix=True)
+    assert fix["fix_applied"] is True
+    on_disk = json.loads(temp_storage.config_path.read_text())
+    assert "depix_swap" not in on_disk.get("enabled_tools", {})
+    assert "bogus_tool" not in on_disk.get("enabled_tools", {})
+
+
+def test_startup_warning_gone_after_fix(temp_storage, caplog):
+    """The whole point: after --fix, no more 'Unknown tool' startup warning."""
+    _write_raw(temp_storage, {"enabled_tools": {"depix_swap": True}})
+    run_doctor(temp_storage, fix=True)
+    with caplog.at_level(logging.WARNING, logger="aqua.features"):
+        load_config_with_merge(temp_storage)
+    assert not any("depix_swap" in rec.message for rec in caplog.records)
+
+
+# --- Default-matching pruning ---------------------------------------------
+
+
+def test_default_matching_pruned(temp_storage):
+    true_tool = _pick_default_true_tool()
+    false_tool = _pick_default_false_tool()
+    _write_raw(temp_storage, {
+        "enabled_tools": {
+            true_tool: True,     # equals default → prune
+            false_tool: False,   # equals default → prune
+        }
+    })
+    diag = run_doctor(temp_storage, fix=False)
+    matches = {f["key"] for f in diag["findings"] if f["type"] == "matches_default"}
+    assert matches == {true_tool, false_tool}
+
+    run_doctor(temp_storage, fix=True)
+    on_disk = json.loads(temp_storage.config_path.read_text())
+    # Both pruned; enabled_tools now empty → omitted entirely (fully sparse).
+    assert "enabled_tools" not in on_disk
+
+
+def test_healthy_true_after_successful_fix(temp_storage):
+    """After --fix removes all removable drift, the report is healthy again."""
+    _write_raw(temp_storage, {"enabled_tools": {"depix_swap": True}})
+    report = run_doctor(temp_storage, fix=True)
+    assert report["fix_applied"] is True
+    assert report["healthy"] is True
+
+
+def test_fix_with_manual_and_removable_stays_unhealthy(temp_storage):
+    """A removable key is fixed, but a coexisting manual issue keeps it unhealthy."""
+    # 'version' is removable; non-dict enabled_tools is a manual finding.
+    _write_raw(temp_storage, {"version": 5, "enabled_tools": "bad"})
+    report = run_doctor(temp_storage, fix=True)
+    assert report["fix_applied"] is True
+    assert report["healthy"] is False  # manual invalid_enabled_tools remains
+    on_disk = json.loads(temp_storage.config_path.read_text())
+    assert "version" not in on_disk  # removable part applied
+    assert "re-run" not in report["summary"].lower()  # no misleading re-run hint
+
+
+def test_genuine_override_preserved(temp_storage):
+    """A value differing from the shipped default is a real choice — keep it."""
+    true_tool = _pick_default_true_tool()
+    _write_raw(temp_storage, {"enabled_tools": {true_tool: False}})  # override
+    report = run_doctor(temp_storage, fix=True)
+    # Nothing to remove → healthy, no write.
+    assert report["healthy"] is True
+    on_disk = json.loads(temp_storage.config_path.read_text())
+    assert on_disk["enabled_tools"][true_tool] is False
+
+
+def test_non_bool_entry_left_untouched(temp_storage):
+    """Per spec: doctor does not normalize non-bool values for known tools."""
+    tool = _pick_default_true_tool()
+    _write_raw(temp_storage, {"enabled_tools": {tool: "yes", "depix_swap": True}})
+    run_doctor(temp_storage, fix=True)
+    on_disk = json.loads(temp_storage.config_path.read_text())
+    # Orphan removed, but the non-bool known-tool entry is preserved verbatim.
+    assert "depix_swap" not in on_disk.get("enabled_tools", {})
+    assert on_disk["enabled_tools"][tool] == "yes"
+
+
+# --- Unknown top-level keys (the crash path) -------------------------------
+
+
+def test_unknown_top_level_key_reported_and_removed(temp_storage):
+    _write_raw(temp_storage, {"version": 5, "network": "mainnet", "enabled_tools": {}})
+    diag = run_doctor(temp_storage, fix=False)
+    assert any(f["type"] == "unknown_top_level_key" and f["key"] == "version"
+               for f in diag["findings"])
+
+    run_doctor(temp_storage, fix=True)
+    on_disk = json.loads(temp_storage.config_path.read_text())
+    assert "version" not in on_disk
+    assert on_disk["network"] == "mainnet"  # known keys preserved
+
+
+def test_unknown_top_level_key_does_not_crash_load(temp_storage, caplog):
+    """A stray top-level key must NOT crash config loading (it is dropped in
+    memory), and doctor --fix removes it from disk."""
+    _write_raw(temp_storage, {"version": 5, "enabled_tools": {"depix_swap": True}})
+    # The load path is now tolerant (it used to raise TypeError on `version`).
+    with caplog.at_level(logging.WARNING, logger="aqua.storage"):
+        config = temp_storage.load_config()
+    assert isinstance(config, Config)
+    assert any("version" in rec.message for rec in caplog.records)
+    # Read-only startup leaves it on disk until doctor cleans it.
+    assert "version" in json.loads(temp_storage.config_path.read_text())
+
+    run_doctor(temp_storage, fix=True)
+    on_disk = json.loads(temp_storage.config_path.read_text())
+    assert "version" not in on_disk
+    assert "depix_swap" not in on_disk.get("enabled_tools", {})
+
+
+# --- Corrupt / invalid configs (manual) ------------------------------------
+
+
+def test_corrupt_json_flagged_manual_not_touched(temp_storage):
+    temp_storage.config_path.write_text("{not valid json")
+    before = temp_storage.config_path.read_text()
+    report = run_doctor(temp_storage, fix=True)
+    assert report["healthy"] is False
+    assert any(f["action"] == "manual" for f in report["findings"])
+    assert report["fix_applied"] is False
+    assert temp_storage.config_path.read_text() == before  # untouched
+
+
+def test_non_object_root_flagged_manual(temp_storage):
+    _write_raw(temp_storage, ["lw_send"])
+    report = run_doctor(temp_storage, fix=True)
+    assert report["healthy"] is False
+    assert any(f["type"] == "invalid_config_root" for f in report["findings"])
+    assert report["fix_applied"] is False
+
+
+# --- Permissions -----------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions only")
+def test_fix_writes_0600(temp_storage):
+    _write_raw(temp_storage, {"enabled_tools": {"depix_swap": True}})
+    run_doctor(temp_storage, fix=True)
+    mode = stat.S_IMODE(os.stat(temp_storage.config_path).st_mode)
+    assert mode == 0o600
+
+
+# --- MCP tool wiring -------------------------------------------------------
+
+
+def test_doctor_is_registered_mcp_tool():
+    assert "doctor" in TOOLS
+
+
+def test_mcp_doctor_tool_diagnose_and_fix(temp_storage, monkeypatch):
+    """The MCP `doctor` tool honors fix=False (default) vs fix=True."""
+    import aqua.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DEFAULT_DIR", temp_storage.base_dir)
+    _write_raw(temp_storage, {"enabled_tools": {"depix_swap": True}})
+
+    diagnose = TOOLS["doctor"]()  # fix defaults to False
+    assert diagnose["fix_applied"] is False
+    assert "depix_swap" in temp_storage.config_path.read_text()
+
+    fixed = TOOLS["doctor"](fix=True)
+    assert fixed["fix_applied"] is True
+    assert "depix_swap" not in json.loads(
+        temp_storage.config_path.read_text()
+    ).get("enabled_tools", {})
+
+
+def test_mcp_doctor_string_fix_false_does_not_write(temp_storage, monkeypatch):
+    """A non-compliant client passing fix as the string 'false' must NOT mutate."""
+    import aqua.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DEFAULT_DIR", temp_storage.base_dir)
+    _write_raw(temp_storage, {"enabled_tools": {"depix_swap": True}})
+
+    report = TOOLS["doctor"](fix="false")
+    assert report["fix_applied"] is False
+    assert "depix_swap" in temp_storage.config_path.read_text()
+
+    # ...but the string 'true' is honored.
+    report_true = TOOLS["doctor"](fix="true")
+    assert report_true["fix_applied"] is True
+
+
+# --- CLI command -----------------------------------------------------------
+
+
+def _invoke_doctor(temp_storage, monkeypatch, args):
+    import aqua.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DEFAULT_DIR", temp_storage.base_dir)
+    runner = CliRunner()
+    return runner.invoke(doctor_cmd, args, obj=AquaContext(fmt="json"))
+
+
+def test_cli_doctor_diagnose_exit_1_when_issues(temp_storage, monkeypatch):
+    _write_raw(temp_storage, {"enabled_tools": {"depix_swap": True}})
+    result = _invoke_doctor(temp_storage, monkeypatch, [])
+    assert result.exit_code == 1
+    assert "depix_swap" in result.output
+    # Dry-run: not fixed.
+    assert "depix_swap" in temp_storage.config_path.read_text()
+
+
+def test_cli_doctor_fix_exit_0(temp_storage, monkeypatch):
+    _write_raw(temp_storage, {"enabled_tools": {"depix_swap": True}})
+    result = _invoke_doctor(temp_storage, monkeypatch, ["--fix"])
+    assert result.exit_code == 0
+    assert "depix_swap" not in json.loads(
+        temp_storage.config_path.read_text()
+    ).get("enabled_tools", {})
+
+
+def test_cli_doctor_healthy_exit_0(temp_storage, monkeypatch):
+    result = _invoke_doctor(temp_storage, monkeypatch, [])
+    assert result.exit_code == 0

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -40,9 +40,7 @@ def _pick_default_true_tool() -> str:
 def _force_default_false(monkeypatch, name: str) -> None:
     """Force `name`'s shipped default to False for the duration of a test.
 
-    Doesn't assume any tool ships disabled-by-default (currently none do —
-    `_SHIPPED_DISABLED` is empty) — patches the shared dict in place so both
-    `aqua.features` and `aqua.doctor` (which imports the same object) see it.
+    Patches the shared dict in place (no tool ships disabled-by-default today).
     """
     monkeypatch.setitem(SHIPPED_DEFAULTS_ENABLED_TOOLS, name, False)
 

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -166,9 +166,8 @@ def test_unknown_enabled_tools_key_warns(temp_storage, caplog):
 def test_fresh_install_does_not_write_config(temp_storage):
     """Startup is read-only: a fresh install must NOT create config.json.
 
-    The shipped defaults are still merged IN MEMORY (so gating sees a fully
-    populated map), but nothing is persisted — an absent key means "use the
-    shipped default". `doctor` is the only path that writes config.json.
+    An absent key means "use the shipped default"; `doctor` is the only path
+    that writes config.json.
     """
     assert not temp_storage.config_path.exists()
     config = load_config_with_merge(temp_storage)

--- a/tests/test_feature_flags.py
+++ b/tests/test_feature_flags.py
@@ -1,6 +1,5 @@
 """Tests for runtime feature-flag gating of MCP tools and CLI commands."""
 
-import json
 import logging
 import tempfile
 from pathlib import Path
@@ -164,18 +163,52 @@ def test_unknown_enabled_tools_key_warns(temp_storage, caplog):
     assert "lw_balance" in config.enabled_tools
 
 
-def test_fresh_install_writes_default_config(temp_storage):
-    """On a brand-new install (no config.json), defaults are persisted on load."""
+def test_fresh_install_does_not_write_config(temp_storage):
+    """Startup is read-only: a fresh install must NOT create config.json.
+
+    The shipped defaults are still merged IN MEMORY (so gating sees a fully
+    populated map), but nothing is persisted — an absent key means "use the
+    shipped default". `doctor` is the only path that writes config.json.
+    """
     assert not temp_storage.config_path.exists()
     config = load_config_with_merge(temp_storage)
-    assert temp_storage.config_path.exists()
-    with open(temp_storage.config_path) as f:
-        data = json.load(f)
-    assert "enabled_tools" in data
-    # Every shipped-default tool key is present.
-    for tool_name in SHIPPED_DEFAULTS_ENABLED_TOOLS:
-        assert tool_name in data["enabled_tools"]
+    # Read-only: no file was created.
+    assert not temp_storage.config_path.exists()
+    # In-memory merge still yields every shipped default for gating.
     assert config.enabled_tools == SHIPPED_DEFAULTS_ENABLED_TOOLS
+
+
+def test_startup_survives_corrupt_config(temp_storage, caplog):
+    """A malformed config.json must not crash startup (so `doctor` can run)."""
+    temp_storage.config_path.write_text("{not valid json")
+    with caplog.at_level(logging.WARNING, logger="aqua.features"):
+        config = load_config_with_merge(temp_storage)
+    # Degrades to in-memory defaults, warns, and points at doctor.
+    assert config.enabled_tools == SHIPPED_DEFAULTS_ENABLED_TOOLS
+    assert any("doctor" in rec.message for rec in caplog.records)
+    # Read-only: the corrupt file is left as-is for doctor to inspect.
+    assert temp_storage.config_path.read_text() == "{not valid json"
+
+
+def test_startup_survives_unknown_top_level_key(temp_storage):
+    """An unknown top-level key must not crash startup (dropped in memory)."""
+    temp_storage.config_path.write_text('{"version": 9, "network": "mainnet"}')
+    config = load_config_with_merge(temp_storage)
+    assert config.network == "mainnet"
+    assert config.enabled_tools == SHIPPED_DEFAULTS_ENABLED_TOOLS
+
+
+def test_startup_does_not_persist_or_repopulate(temp_storage):
+    """Loading a sparse config never rewrites it (no re-pollution with defaults)."""
+    temp_storage.save_config(Config(enabled_tools={"lw_balance": False}))
+    before = temp_storage.config_path.read_text()
+    config = load_config_with_merge(temp_storage)
+    after = temp_storage.config_path.read_text()
+    # Untouched on disk...
+    assert before == after
+    # ...but merged in memory for gating.
+    assert config.enabled_tools["lw_balance"] is False
+    assert config.enabled_tools["btc_balance"] is True
 
 
 def test_cli_only_serve_always_registers(temp_storage):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -74,6 +74,24 @@ def test_get_prompt_unknown_raises(prompt_handler):
         _call(prompt_handler, "nonexistent_prompt", None)
 
 
+def test_tool_schemas_match_tools_registry():
+    """Drift guard: every TOOLS entry has a TOOL_SCHEMAS entry and vice versa.
+
+    A tool in TOOLS without a schema would be silently unavailable over MCP
+    (list_tools iterates TOOL_SCHEMAS); a schema without a TOOLS entry would be
+    listed but uncallable.
+    """
+    from aqua.server import TOOL_SCHEMAS
+    from aqua.tools import TOOLS
+
+    assert set(TOOL_SCHEMAS) == set(TOOLS), (
+        "missing schemas: "
+        + str(set(TOOLS) - set(TOOL_SCHEMAS))
+        + "; schemas without a tool: "
+        + str(set(TOOL_SCHEMAS) - set(TOOLS))
+    )
+
+
 def test_lightning_send_schema_includes_amount_sats():
     """lightning_send tool schema exposes amount_sats and mentions Lightning Address."""
     from aqua.server import TOOL_SCHEMAS

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -77,9 +77,7 @@ def test_get_prompt_unknown_raises(prompt_handler):
 def test_tool_schemas_match_tools_registry():
     """Drift guard: every TOOLS entry has a TOOL_SCHEMAS entry and vice versa.
 
-    A tool in TOOLS without a schema would be silently unavailable over MCP
-    (list_tools iterates TOOL_SCHEMAS); a schema without a TOOLS entry would be
-    listed but uncallable.
+    A gap would mean a tool is silently uncallable or unlisted over MCP.
     """
     from aqua.server import TOOL_SCHEMAS
     from aqua.tools import TOOLS

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1236,6 +1236,7 @@ class TestToolRegistry:
             "jan3_rebind_wallet",
             "jan3_ln_check_username",
             "jan3_purchase_ln_username",
+            "doctor",
         }
         assert set(TOOLS.keys()) == expected
 


### PR DESCRIPTION
### Purpose

Adds an `aqua doctor` (CLI + MCP) command that diagnoses and repairs `~/.aqua/config.json`, so future feature adds/removals stop greeting users with a wall of `WARNING: Unknown tool in enabled_tools: '...'` on every single run.

#### Description

Config drift has been quietly annoying users since we started shipping and retiring tools — every release meant another pile of orphaned keys and a startup log nobody could self-serve fix (short of manually editing JSON). This PR makes the config **sparse**: only genuine user overrides get persisted, everything else just inherits the shipped default. 

#### Main Changes

- ✨ Add `aqua doctor [--fix]` / MCP tool `doctor(fix=false)` — diagnoses by default, repairs with `--fix`/`fix=true`: drops orphaned tool keys (the actual source of the warnings), prunes entries that match the current shipped default, and removes unknown top-level keys.
- 🏗️ Make startup read-only — `load_config_with_merge` merges shipped defaults in memory only and never writes to disk anymore.
- 🐛 Fix two crash paths uncovered while smoke-testing the real CLI: an unknown top-level config key and a corrupt/unreadable config file used to take down the *entire* CLI/MCP server before `doctor` could even run to fix them.
- 📝 Startup warnings now point at `aqua doctor --fix` instead of asking users to hand-edit `config.json`.
- ✅ Add `tests/test_doctor.py` plus CLI/MCP/server coverage, including a `TOOL_SCHEMAS`↔`TOOLS` drift guard.

### Checklist

- [ ] No hardcoded values (they should go in constants.py, .env, or our database)
- [ ] Added/updated tests (if necessary)
- [ ] Added/updated relevant documentation (if necessary)

### Screenshots
<img width="964" height="195" alt="image" src="https://github.com/user-attachments/assets/4435f0f9-b3d9-4011-a2eb-979f17df43c4" />
<img width="577" height="120" alt="image" src="https://github.com/user-attachments/assets/9a9a341b-2202-47da-b090-f149bd288758" />
