### PR TITLE
Add opt-in Observer Protocol pre-sign policy check (fail-closed) for Liquid sends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ specs/
 .omc/
 .omx/
 .worktrees/
+op-artifacts/

--- a/README.md
+++ b/README.md
@@ -353,10 +353,11 @@ or reject an expired one, so authenticating the delegation itself is a planned f
 
 Every Liquid send routes through the check (L-BTC and other Liquid assets, plus Lightning
 payments funded via Boltz submarine swaps, whose L-BTC lockup is itself a Liquid send).
-Spending-cap enforcement is per-rail and single-currency: the delegation's `per_rail.liquid`
-cap has one currency (L-BTC), so L-BTC sends are cap-enforced, while a non-L-BTC asset send
-(e.g. USDt) is evaluated but not constrained by a matching per-asset cap yet. Native BTC
-on-chain sends are not covered. Per-asset caps and BTC coverage are planned follow-ups.
+Spending caps are **per-asset**, selected by `asset_id`: L-BTC uses the delegation's
+rail-level cap, and a Liquid asset such as **USDt is enforced against its own cap**
+(`per_rail.liquid.per_asset`). A send whose asset has no cap is refused (`no-cap-for-asset`),
+and an asset unknown to the engine is refused (`unknown-asset`) — never measured against the
+wrong cap. Native BTC on-chain sends are not covered (a planned follow-up).
 
 Coverage and verification scope will expand in later changes. See the Observer Protocol
 docs for the delegation format and how to issue one.

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ export OP_DELEGATION_PATH=/path/to/delegation.json   # your signed spending dele
 | `OP_SIDECAR_URL` | `https://api.observerprotocol.org/policy/evaluate` | Policy engine endpoint. |
 | `OP_POLICY_TIMEOUT` | `10` | Request timeout in seconds. |
 | `OP_VERIFY_PEC` | `true` | Verify the returned credential's signature before honoring it. |
-| `OP_POLICY_UNIT` | *(resolved from the delegation)* | Optional unit override. |
+| `OP_POLICY_UNIT` | *(the sent asset's unit)* | Optional override; normally the wallet passes the true unit of the asset being sent. |
 | `OP_DENY_ARTIFACT_DIR` | `./op-artifacts` | Directory where signed denial credentials are saved. |
 
 ### What it guarantees

--- a/README.md
+++ b/README.md
@@ -297,3 +297,66 @@ Built with:
 - [BDK](https://github.com/bitcoindevkit/bdk-python) - Bitcoin Development Kit
 - [MCP](https://modelcontextprotocol.io/) - Model Context Protocol
 - [Boltz](https://boltz.exchange/) - Submarine swaps for Lightning
+
+## Observer Protocol policy checks (optional)
+
+Agentic Aqua can gate Liquid sends behind an [Observer Protocol](https://observerprotocol.org)
+policy engine. When enabled, every Liquid send is evaluated against a signed spending
+delegation *before* the wallet signs. The wallet signs only on a verified `allow`;
+anything else fails closed and the transaction is refused.
+
+This is **off by default** and fully opt-in. With `OP_POLICY_ENABLED` unset, the wallet
+behaves exactly as it does without this feature.
+
+### Enabling
+
+Set at minimum:
+
+```sh
+export OP_POLICY_ENABLED=1
+export OP_DELEGATION_PATH=/path/to/delegation.json   # your signed spending delegation
+```
+
+### Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OP_POLICY_ENABLED` | *(off)* | Master switch (`1`/`true`/`yes`). |
+| `OP_DELEGATION_PATH` | *(required when enabled)* | Path to the delegation credential JSON. |
+| `OP_SIDECAR_URL` | `https://api.observerprotocol.org/policy/evaluate` | Policy engine endpoint. |
+| `OP_POLICY_TIMEOUT` | `10` | Request timeout in seconds. |
+| `OP_VERIFY_PEC` | `true` | Verify the returned credential's signature before honoring it. |
+| `OP_POLICY_UNIT` | *(resolved from the delegation)* | Optional unit override. |
+| `OP_DENY_ARTIFACT_DIR` | `./op-artifacts` | Directory where signed denial credentials are saved. |
+
+### What it guarantees
+
+The wallet signs a Liquid send **only** when the policy engine returns a cryptographically
+signed `allow` that the wallet verifies against Observer Protocol's published DID
+(`did:web:observerprotocol.org#key-3`, `eddsa-jcs-2022`). The wallet trusts a signature it
+checks itself, not the network response.
+
+It fails closed — refusing to sign — if the engine is unreachable, returns a non-2xx
+status, returns a credential whose signature won't verify or has expired, returns a `deny`,
+or returns anything other than `allow`. A same-transaction guard also ensures the wallet
+signs exactly the transaction that was evaluated.
+
+Denials are saved as signed credentials under `OP_DENY_ARTIFACT_DIR` so they can be
+independently audited.
+
+### What it does not (yet) verify
+
+This integration verifies the engine's *response* credential. It does **not** yet verify
+the *delegation credential's* own signature, revocation status, or validity window on the
+wallet side — the engine enforces the delegation's constraints but does not authenticate it
+or reject an expired one, so authenticating the delegation itself is a planned follow-up.
+
+Every Liquid send routes through the check (L-BTC and other Liquid assets, plus Lightning
+payments funded via Boltz submarine swaps, whose L-BTC lockup is itself a Liquid send).
+Spending-cap enforcement is per-rail and single-currency: the delegation's `per_rail.liquid`
+cap has one currency (L-BTC), so L-BTC sends are cap-enforced, while a non-L-BTC asset send
+(e.g. USDt) is evaluated but not constrained by a matching per-asset cap yet. Native BTC
+on-chain sends are not covered. Per-asset caps and BTC coverage are planned follow-ups.
+
+Coverage and verification scope will expand in later changes. See the Observer Protocol
+docs for the delegation format and how to issue one.

--- a/src/aqua/op_policy.py
+++ b/src/aqua/op_policy.py
@@ -130,50 +130,6 @@ def _load_delegation(path: str) -> dict:
         raise PolicyError(f"could not load delegation credential from {path}: {exc} (fail-closed)")
 
 
-def _delegation_cap_unit(delegation: dict, rail: str, asset_id: Optional[str]) -> Optional[str]:
-    """Read the unit of the spending cap for this rail from the delegation.
-
-    NOTE: reconcile this navigation with the authoritative delegation schema (v2.1).
-    The shape below matches the spending-delegation form; if the real credential nests
-    differently, fix it here. We deliberately return None (not a guess) when we can't
-    find it, so the caller fails closed rather than sending a wrong unit — that wrong
-    unit is exactly the spurious unit-mismatch DENY the refinement removed.
-    """
-    try:
-        scope = delegation["credentialSubject"]["delegation"]["scope"]
-        limits = scope["spending_limits"]["per_rail"][rail]
-    except (KeyError, TypeError):
-        return None
-    per_tx = limits.get("per_transaction") if isinstance(limits, dict) else None
-    # Real delegation stores the denomination as `currency`; tolerate `unit` too.
-    if isinstance(per_tx, dict) and (per_tx.get("currency") or per_tx.get("unit")):
-        return per_tx.get("currency") or per_tx.get("unit")
-    if isinstance(limits, dict) and (limits.get("currency") or limits.get("unit")):
-        return limits.get("currency") or limits.get("unit")
-    return None
-
-
-def _resolve_unit(
-    delegation: dict, rail: str, asset_id: Optional[str], override: Optional[str]
-) -> str:
-    """Resolve the unit sent in humanReadable so it matches the delegation cap.
-
-    Sending a unit that disagrees with the cap unit yields a spurious unit-mismatch DENY
-    from the engine — a false negative. So we prefer the cap's own unit; an explicit
-    OP_POLICY_UNIT overrides; if neither is available we fail closed rather than guess.
-    """
-    if override:
-        return override
-    unit = _delegation_cap_unit(delegation, rail, asset_id)
-    if unit:
-        return unit
-    raise PolicyError(
-        "could not resolve the spending-cap unit from the delegation for "
-        f"rail={rail!r} asset_id={asset_id!r}; set OP_POLICY_UNIT or fix the "
-        "delegation (fail-closed)"
-    )
-
-
 def _post(cfg: _Config, body: dict) -> dict:
     data = json.dumps(body).encode("utf-8")
     req = urllib.request.Request(
@@ -257,7 +213,20 @@ def evaluate(
     delegation = delegation if delegation is not None else _load_delegation(cfg.delegation_path)
 
     hr = dict(human_readable)
-    hr["unit"] = _resolve_unit(delegation, rail, hr.get("asset_id"), cfg.unit_override)
+    # Unit is the TRUE unit of the asset being sent (the caller resolves the
+    # ticker from asset_id via the wallet's asset registry). The engine now
+    # SELECTS the cap by asset_id, so we no longer relabel the unit to match the
+    # cap currency — that relabel was exactly what let an uncapped asset ride the
+    # wrong cap. OP_POLICY_UNIT still overrides for local testing. Drop a null
+    # unit so it isn't sent as JSON null.
+    if cfg.unit_override:
+        hr["unit"] = cfg.unit_override
+    if hr.get("unit") is None:
+        hr.pop("unit", None)
+    # L-BTC sends carry no asset_id (native); drop a null so the engine reads it
+    # as absent (== rail-native) rather than a JSON null.
+    if hr.get("asset_id") is None:
+        hr.pop("asset_id", None)
     # The engine reads humanReadable.notional ONLY when it is a JSON number
     # (proposal-hints.ts: `typeof hr.notional === "number" ? ... : undefined`).
     # A string/Decimal is silently dropped -> "no notional hint" -> spurious DENY.

--- a/src/aqua/op_policy.py
+++ b/src/aqua/op_policy.py
@@ -1,0 +1,322 @@
+"""
+op_policy.py — opt-in Observer Protocol pre-sign policy check for Agentic Aqua.
+
+Called from WalletManager.send() immediately before the signer is invoked. When
+enabled (OP_POLICY_ENABLED), it submits the *exact* unsigned transaction to the
+Observer Protocol policy engine and only permits signing on a verified "allow"
+decision. Every other outcome fails closed — the wallet MUST NOT sign:
+
+    engine unreachable            -> PolicyError  (fail closed)
+    non-2xx from engine           -> PolicyError  (fail closed)
+    unverifiable / expired PEC    -> PolicyError  (fail closed)
+    decision == "deny"            -> PolicyDenied (deny artifact persisted, then raised)
+    any non-"allow" decision      -> PolicyError  (fail closed)
+    decision == "allow"           -> returns the verified credential; signing proceeds
+
+When OP_POLICY_ENABLED is unset/false this module is inert: enabled() returns False and
+the wallet behaves exactly as before. This is additive and opt-in.
+
+Config is env-driven (see README). Renamed from op_policy_demo.py; the working-tree
+refinements (stderr logging, unit resolution, deny artifact) are folded in here, plus
+PEC signature verification on the return path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from aqua import op_verify  # vendored; see op_verify.py "READ BEFORE SHIPPING"
+
+_DEFAULT_SIDECAR_URL = "https://api.observerprotocol.org/policy/evaluate"
+_USER_AGENT = "agentic-aqua-op-policy/0.1"
+_DEFAULT_TIMEOUT = 10.0
+_DEFAULT_DENY_DIR = "./op-artifacts"
+_TRUE = {"1", "true", "yes"}
+
+
+class PolicyError(RuntimeError):
+    """Fail-closed condition. The wallet MUST NOT sign."""
+
+
+class PolicyDenied(PolicyError):
+    """Engine returned a signed deny. The wallet MUST NOT sign."""
+
+    def __init__(self, message: str, credential: Optional[dict] = None) -> None:
+        super().__init__(message)
+        self.credential = credential
+
+
+def _emit(msg: str) -> None:
+    """Operator-visible log line on stderr. Kept quiet unless the hook is active."""
+    print(f"[op-policy] {msg}", file=sys.stderr, flush=True)
+
+
+def enabled() -> bool:
+    return os.environ.get("OP_POLICY_ENABLED", "").strip().lower() in _TRUE
+
+
+@dataclass(frozen=True)
+class _Config:
+    sidecar_url: str
+    delegation_path: str
+    timeout: float
+    verify_pec: bool
+    deny_dir: str
+    unit_override: Optional[str]
+
+
+def canonical_bytes(unsigned_pset: Any) -> str:
+    """Hex of the consensus-serialized unsigned tx extracted from THIS exact Pset.
+
+    Ported verbatim from the proven demo extraction. The caller MUST pass the same
+    lwk.Pset instance that will reach signer.sign(); we refuse anything lacking the
+    pre-sign extract_tx()/to_bytes() surface so a wrong type fails loudly rather than
+    silently hashing something else. The engine recomputes proposalHash from these
+    bytes, so we return only the hex.
+    """
+    if not hasattr(unsigned_pset, "extract_tx"):
+        raise PolicyError(
+            "unsigned_pset must be an lwk.Pset (has extract_tx); "
+            f"got {type(unsigned_pset)!r} (fail-closed)"
+        )
+    unsigned_tx = unsigned_pset.extract_tx()
+    # lwk.Transaction.to_bytes() = elements::Transaction::serialize; bytes() is a
+    # deprecated alias; Display is hex of the same consensus bytes.
+    if hasattr(unsigned_tx, "to_bytes"):
+        raw = bytes(unsigned_tx.to_bytes())
+    elif hasattr(unsigned_tx, "bytes"):
+        raw = bytes(unsigned_tx.bytes())
+    else:
+        raw = bytes.fromhex(str(unsigned_tx))
+    return raw.hex()
+
+
+def _load_config() -> _Config:
+    delegation_path = os.environ.get("OP_DELEGATION_PATH", "").strip()
+    if not delegation_path:
+        raise PolicyError(
+            "OP_POLICY_ENABLED is set but OP_DELEGATION_PATH is missing (fail-closed)"
+        )
+    try:
+        timeout = float(os.environ.get("OP_POLICY_TIMEOUT", _DEFAULT_TIMEOUT))
+    except ValueError:
+        raise PolicyError("OP_POLICY_TIMEOUT is not a number (fail-closed)")
+    return _Config(
+        sidecar_url=os.environ.get("OP_SIDECAR_URL", _DEFAULT_SIDECAR_URL).strip(),
+        delegation_path=delegation_path,
+        timeout=timeout,
+        # Verification is on by default. It can be disabled for local testing, but doing
+        # so is loud and drops the wallet's independent-trust guarantee.
+        verify_pec=os.environ.get("OP_VERIFY_PEC", "true").strip().lower() in _TRUE,
+        deny_dir=os.environ.get("OP_DENY_ARTIFACT_DIR", _DEFAULT_DENY_DIR).strip(),
+        unit_override=(os.environ.get("OP_POLICY_UNIT", "").strip() or None),
+    )
+
+
+def _load_delegation(path: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PolicyError(f"could not load delegation credential from {path}: {exc} (fail-closed)")
+
+
+def _delegation_cap_unit(delegation: dict, rail: str, asset_id: Optional[str]) -> Optional[str]:
+    """Read the unit of the spending cap for this rail from the delegation.
+
+    NOTE: reconcile this navigation with the authoritative delegation schema (v2.1).
+    The shape below matches the spending-delegation form; if the real credential nests
+    differently, fix it here. We deliberately return None (not a guess) when we can't
+    find it, so the caller fails closed rather than sending a wrong unit — that wrong
+    unit is exactly the spurious unit-mismatch DENY the refinement removed.
+    """
+    try:
+        scope = delegation["credentialSubject"]["delegation"]["scope"]
+        limits = scope["spending_limits"]["per_rail"][rail]
+    except (KeyError, TypeError):
+        return None
+    per_tx = limits.get("per_transaction") if isinstance(limits, dict) else None
+    # Real delegation stores the denomination as `currency`; tolerate `unit` too.
+    if isinstance(per_tx, dict) and (per_tx.get("currency") or per_tx.get("unit")):
+        return per_tx.get("currency") or per_tx.get("unit")
+    if isinstance(limits, dict) and (limits.get("currency") or limits.get("unit")):
+        return limits.get("currency") or limits.get("unit")
+    return None
+
+
+def _resolve_unit(
+    delegation: dict, rail: str, asset_id: Optional[str], override: Optional[str]
+) -> str:
+    """Resolve the unit sent in humanReadable so it matches the delegation cap.
+
+    Sending a unit that disagrees with the cap unit yields a spurious unit-mismatch DENY
+    from the engine — a false negative. So we prefer the cap's own unit; an explicit
+    OP_POLICY_UNIT overrides; if neither is available we fail closed rather than guess.
+    """
+    if override:
+        return override
+    unit = _delegation_cap_unit(delegation, rail, asset_id)
+    if unit:
+        return unit
+    raise PolicyError(
+        "could not resolve the spending-cap unit from the delegation for "
+        f"rail={rail!r} asset_id={asset_id!r}; set OP_POLICY_UNIT or fix the "
+        "delegation (fail-closed)"
+    )
+
+
+def _post(cfg: _Config, body: dict) -> dict:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        cfg.sidecar_url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            # Cloudflare fronts api.observerprotocol.org and 403s the default
+            # "Python-urllib/*" UA (browser_signature_banned). Send an explicit UA
+            # or every real request fails closed on a 403.
+            "User-Agent": _USER_AGENT,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=cfg.timeout) as resp:
+            status = getattr(resp, "status", resp.getcode())
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raise PolicyError(
+            f"policy engine returned HTTP {exc.code}. FAIL-CLOSED. The wallet MUST NOT sign."
+        )
+    except urllib.error.URLError as exc:
+        raise PolicyError(
+            f"policy engine unreachable ({exc.reason}). FAIL-CLOSED. The wallet MUST NOT sign."
+        )
+
+    # Belt-and-suspenders: some stacks don't raise on all non-2xx.
+    if status != 200:
+        raise PolicyError(
+            f"policy engine returned HTTP {status}. FAIL-CLOSED. The wallet MUST NOT sign."
+        )
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        raise PolicyError("policy engine returned a non-JSON body. FAIL-CLOSED.")
+
+
+def _pec_not_expired(pec: dict) -> None:
+    """If the credential carries validUntil, honor it. Absence is tolerated (forward-compat)."""
+    valid_until = pec.get("validUntil")
+    if not valid_until:
+        return
+    try:
+        exp = datetime.fromisoformat(valid_until.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        raise PolicyError(f"credential validUntil is unparseable ({valid_until!r}). FAIL-CLOSED.")
+    if datetime.now(timezone.utc) >= exp:
+        raise PolicyError(f"credential expired at {valid_until}. FAIL-CLOSED.")
+
+
+def _persist_deny_artifact(cfg: _Config, pec: dict) -> Optional[str]:
+    try:
+        Path(cfg.deny_dir).mkdir(parents=True, exist_ok=True)
+        fname = f"deny-{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}.json"
+        fpath = Path(cfg.deny_dir) / fname
+        with open(fpath, "w", encoding="utf-8") as fh:
+            json.dump(pec, fh, indent=2)
+        return str(fpath)
+    except OSError as exc:
+        # Failing to persist the artifact must not turn a deny into an allow.
+        _emit(f"warning: could not persist deny artifact: {exc}")
+        return None
+
+
+def evaluate(
+    *,
+    rail: str,
+    canonical_bytes_hex: str,
+    human_readable: dict,
+    delegation: Optional[dict] = None,
+) -> dict:
+    """Evaluate the exact unsigned transaction. Returns the verified allow credential,
+    or raises (PolicyDenied / PolicyError). Never returns on anything but a clean allow.
+
+    The caller (wallet.py) is responsible for the same-PSET identity guard: it must sign
+    exactly the transaction whose canonical bytes were passed here.
+    """
+    cfg = _load_config()
+    delegation = delegation if delegation is not None else _load_delegation(cfg.delegation_path)
+
+    hr = dict(human_readable)
+    hr["unit"] = _resolve_unit(delegation, rail, hr.get("asset_id"), cfg.unit_override)
+    # The engine reads humanReadable.notional ONLY when it is a JSON number
+    # (proposal-hints.ts: `typeof hr.notional === "number" ? ... : undefined`).
+    # A string/Decimal is silently dropped -> "no notional hint" -> spurious DENY.
+    # Coerce here so a well-formed send is actually evaluated against the cap.
+    if hr.get("notional") is not None and not isinstance(hr["notional"], bool):
+        try:
+            n = float(hr["notional"])
+            hr["notional"] = int(n) if n.is_integer() else n
+        except (TypeError, ValueError):
+            raise PolicyError(
+                f"notional {hr.get('notional')!r} is not numeric; the engine cannot "
+                f"evaluate the spending cap (fail-closed)"
+            )
+
+    body = {
+        "proposal": {
+            "rail": rail,
+            "canonicalBytes": canonical_bytes_hex,
+            "humanReadable": hr,
+        },
+        "delegationCredential": delegation,
+        # Liquid attestation graph is not seeded; credentials carry
+        # evaluatedWithAttestations=false by design.
+        "attestations": [],
+    }
+
+    pec = _post(cfg, body)
+
+    # PEC-out verification: trust a signed decision, not the transport. Absence of a
+    # proof is a hard fail. Unknown *extra* fields (validUntil, proof.@context, and
+    # future additive fields such as a Crossrail budget) are tolerated by design.
+    if cfg.verify_pec:
+        try:
+            op_verify.verify_pec(pec, timeout=cfg.timeout)
+        except op_verify.VerificationError as exc:
+            raise PolicyError(f"could not verify policy credential signature: {exc}. FAIL-CLOSED.")
+        _pec_not_expired(pec)
+    else:
+        _emit(
+            "WARNING: OP_VERIFY_PEC is off — honoring the decision "
+            "WITHOUT verifying its signature."
+        )
+
+    decision = pec.get("decision") or (pec.get("credentialSubject") or {}).get("decision")
+
+    if decision == "allow":
+        _emit(f"allow: rail={rail} notional={hr.get('notional')} {hr.get('unit')}")
+        return pec
+
+    if decision == "deny":
+        artifact = _persist_deny_artifact(cfg, pec)
+        reason = (
+            pec.get("denyReason")
+            or (pec.get("credentialSubject") or {}).get("denyReason")
+            or {}
+        )
+        _emit(f"deny: {reason} artifact={artifact}")
+        raise PolicyDenied(f"policy denied the transaction: {reason}", credential=pec)
+
+    # Unknown / missing decision -> fail closed. (The wallet path speaks allow/deny;
+    # permit/pending_approval belong to the OP-internal /op-evaluate route, not this one.)
+    raise PolicyError(f"unexpected policy decision {decision!r}. FAIL-CLOSED.")

--- a/src/aqua/op_verify.py
+++ b/src/aqua/op_verify.py
@@ -1,0 +1,197 @@
+"""
+op_verify.py — self-contained verifier for Observer Protocol PolicyEvaluationCredentials.
+
+The point of shipping this INSIDE the wallet is independence: the wallet does not trust
+the transport, it trusts a signature it checks itself against the published DID.
+
+Suite: eddsa-jcs-2022 (W3C Data Integrity), verification method
+did:web:observerprotocol.org#key-3.
+
+============================ READ BEFORE SHIPPING ============================
+This is a REFERENCE implementation. Two things MUST be reconciled before this
+goes into the PR:
+
+  1. Prefer vendoring the proven ~200-LOC June verifier over this file. That verifier
+     already verifies real PECs correctly; this reference exists so op_policy.py has a
+     working import today, not to replace a proven artifact with an unproven one.
+
+  2. If you do keep this file, VALIDATE IT AGAINST A LIVE PEC first. Two known traps:
+       - JCS: the canonicalization here uses json.dumps(sort_keys, compact) as an
+         approximation of RFC 8785. That is correct for string/object-only documents
+         but NOT for arbitrary numbers. If a signed PEC field is numeric, use a real
+         RFC 8785 JCS implementation (or the June verifier).
+       - proof.@context drift: CC reported the live sidecar emits a proof.@context block
+         that is absent from the checked-in policy-core source. The proof-config
+         canonicalization MUST match exactly what the sidecar signed. Verify against a
+         freshly fetched live PEC and adjust _proof_config() if the server's proof shape
+         differs from what this file assumes.
+=============================================================================
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import urllib.request
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+# did:web:observerprotocol.org -> https://observerprotocol.org/.well-known/did.json
+DID_WEB = "did:web:observerprotocol.org"
+EXPECTED_VM = f"{DID_WEB}#key-3"
+_DID_DOC_URL = "https://observerprotocol.org/.well-known/did.json"
+
+_B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+_B58_INDEX = {c: i for i, c in enumerate(_B58)}
+
+
+class VerificationError(Exception):
+    """Raised when a PEC signature cannot be verified. Callers MUST fail closed."""
+
+
+def _b58decode(s: str) -> bytes:
+    n = 0
+    for ch in s:
+        if ch not in _B58_INDEX:
+            raise VerificationError(f"invalid base58 char: {ch!r}")
+        n = n * 58 + _B58_INDEX[ch]
+    full = n.to_bytes((n.bit_length() + 7) // 8, "big") if n else b""
+    pad = len(s) - len(s.lstrip("1"))
+    return b"\x00" * pad + full
+
+
+def _multibase_decode(mb: str) -> bytes:
+    # We only handle the 'z' (base58btc) multibase prefix, which is what OP emits.
+    if not mb or mb[0] != "z":
+        raise VerificationError(f"unsupported multibase prefix in {mb[:1]!r}")
+    return _b58decode(mb[1:])
+
+
+def _jcs(obj: Any) -> bytes:
+    # Approximate JCS. See "READ BEFORE SHIPPING" — validate against a live PEC.
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def _reject_float_leaves(obj: Any, path: str = "$") -> None:
+    """Fail closed if any leaf is a non-integer JSON number (a float).
+
+    json.dumps and RFC 8785 agree on integers (shortest decimal), so integer leaves
+    are safe — and real deny PECs legitimately carry integer bounds
+    (denyReason.currentValue / proposedValue), which must stay verifiable. They
+    diverge on FLOATS: RFC 8785 mandates ES6 %.17g canonicalization, which json.dumps
+    does not reproduce, so a float leaf could let a mis-canonicalized signature verify.
+    Every PEC signed today is integer/string-only, so this never fires — but if OP ever
+    signs a fractional field, we turn that silent risk into a loud VerificationError
+    (caller then fails closed) rather than trusting the approximation outside its range.
+    Swap in a real RFC 8785 JCS implementation before signing fractional PEC fields.
+    """
+    if isinstance(obj, bool):
+        return
+    if isinstance(obj, float):
+        raise VerificationError(
+            f"float leaf at {path} in signed content; the JCS approximation does not "
+            f"cover RFC 8785 float canonicalization — refusing to verify (fail-closed)."
+        )
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            _reject_float_leaves(v, f"{path}.{k}")
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            _reject_float_leaves(v, f"{path}[{i}]")
+
+
+def _fetch_public_key(vm_id: str, *, timeout: float) -> bytes:
+    # observerprotocol.org is Cloudflare-fronted and 403s the default "Python-urllib/*"
+    # UA, so an unadorned urlopen here fails closed on every verification. Send a UA.
+    _req = urllib.request.Request(
+        _DID_DOC_URL, headers={"User-Agent": "agentic-aqua-op-policy/0.1"}
+    )
+    with urllib.request.urlopen(_req, timeout=timeout) as resp:
+        if resp.status != 200:
+            raise VerificationError(f"DID doc fetch returned HTTP {resp.status}")
+        did_doc = json.loads(resp.read().decode("utf-8"))
+
+    methods = did_doc.get("verificationMethod", []) or []
+    _frag = vm_id.split("#")[-1]
+    vm = next(
+        (m for m in methods if m.get("id") in (vm_id, _frag, "#" + _frag)), None
+    )
+    if vm is None:
+        raise VerificationError(f"verification method {vm_id} not found in DID document")
+
+    mb = vm.get("publicKeyMultibase")
+    if not mb:
+        # publicKeyJwk is the other legal shape; reconcile if OP switches to it.
+        raise VerificationError(
+            "verification method has no publicKeyMultibase (JWK not handled here)"
+        )
+
+    raw = _multibase_decode(mb)
+    # multicodec ed25519-pub prefix is 0xed 0x01
+    if raw[:2] == b"\xed\x01":
+        raw = raw[2:]
+    if len(raw) != 32:
+        raise VerificationError(f"expected 32-byte ed25519 key, got {len(raw)}")
+    return raw
+
+
+def _proof_config(proof: dict, doc_context: Any) -> dict:
+    cfg = {k: v for k, v in proof.items() if k != "proofValue"}
+    # Data Integrity: proof config is canonicalized with the document's @context if the
+    # proof does not carry its own. If the live proof DOES carry @context, keep it as-is.
+    if "@context" not in cfg and doc_context is not None:
+        cfg["@context"] = doc_context
+    return cfg
+
+
+def verify_pec(pec: dict, *, expected_vm: str = EXPECTED_VM, timeout: float = 10.0) -> None:
+    """Verify a PolicyEvaluationCredential in place. Returns None on success, raises on failure.
+
+    Verifies: (a) the proof's verificationMethod is the one we expect, and (b) the
+    eddsa-jcs-2022 signature is valid against the key published in the OP DID document.
+    Does NOT judge the decision field — that's op_policy's job.
+    """
+    proof = pec.get("proof")
+    if not isinstance(proof, dict):
+        raise VerificationError("credential has no proof")
+
+    if proof.get("type") not in ("DataIntegrityProof",):
+        raise VerificationError(f"unexpected proof.type: {proof.get('type')!r}")
+    if proof.get("cryptosuite") not in ("eddsa-jcs-2022",):
+        raise VerificationError(f"unexpected cryptosuite: {proof.get('cryptosuite')!r}")
+
+    vm = proof.get("verificationMethod")
+    if vm != expected_vm:
+        raise VerificationError(f"unexpected verificationMethod {vm!r}, expected {expected_vm!r}")
+
+    proof_value = proof.get("proofValue")
+    if not proof_value:
+        raise VerificationError("proof has no proofValue")
+    signature = _multibase_decode(proof_value)
+    if len(signature) != 64:
+        raise VerificationError(f"expected 64-byte signature, got {len(signature)}")
+
+    document = {k: v for k, v in pec.items() if k != "proof"}
+    doc_context = pec.get("@context")
+    proof_config = _proof_config(proof, doc_context)
+
+    # Guard: the JCS approximation matches RFC 8785 for integers/strings but not
+    # floats. Fail closed on float leaves rather than trust it outside that range.
+    _reject_float_leaves(document, "$")
+    _reject_float_leaves(proof_config, "$.proof")
+
+    pc_hash = hashlib.sha256(_jcs(proof_config)).digest()
+    doc_hash = hashlib.sha256(_jcs(document)).digest()
+    signing_input = pc_hash + doc_hash  # proofConfig hash || document hash
+
+    public_key = _fetch_public_key(expected_vm, timeout=timeout)
+    try:
+        Ed25519PublicKey.from_public_bytes(public_key).verify(signature, signing_input)
+    except InvalidSignature as exc:
+        raise VerificationError(
+            "PEC signature did not verify against did:web:observerprotocol.org#key-3"
+        ) from exc

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -495,8 +495,17 @@ class WalletManager:
         if op_policy.enabled():
             _pset_before = id(unsigned_pset)
             # amount is integer satoshis (codebase invariant); the engine reads
-            # humanReadable.notional only when numeric. Unit is resolved from the
-            # delegation cap inside op_policy.evaluate(), never passed from here.
+            # humanReadable.notional only when numeric.
+            #
+            # Pass the TRUE unit of the asset being sent (its ticker), resolved
+            # from asset_id via Aqua's own registry — NOT relabelled to match the
+            # cap. The engine selects the cap by asset_id and enforces per-asset,
+            # so a send whose asset has no cap is refused, not measured against
+            # the wrong one. L-BTC has no asset_id (native) → ticker "L-BTC". An
+            # asset unknown to the wallet registry → unit None; the engine then
+            # denies unknown-asset from the asset_id alone.
+            _op_asset = lookup_asset(asset_id, wallet.network) if asset_id else None
+            _op_unit = _op_asset.ticker if _op_asset else ("L-BTC" if asset_id is None else None)
             op_policy.evaluate(
                 rail="liquid",
                 canonical_bytes_hex=op_policy.canonical_bytes(unsigned_pset),
@@ -504,6 +513,7 @@ class WalletManager:
                     "notional": amount,
                     "counterparty": address,
                     "asset_id": asset_id,
+                    "unit": _op_unit,
                 },
             )  # returns the verified allow credential; raises on anything else
             # Same-PSET identity guard: sign exactly what was evaluated.

--- a/src/aqua/wallet.py
+++ b/src/aqua/wallet.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import lwk
 
+from . import op_policy
 from .assets import lookup_asset, resolve_asset_name
 from .storage import Storage, WalletData
 
@@ -484,6 +485,35 @@ class WalletManager:
             builder.add_lbtc_recipient(lwk_address, amount)
 
         unsigned_pset = builder.finish(wollet)
+
+        # --- Observer Protocol pre-sign policy check (opt-in, fail-closed) -----
+        # Evaluate the EXACT unsigned transaction. On a verified "allow" we fall
+        # through to signing; deny / non-2xx / unreachable / unverifiable all raise,
+        # so the signer is never reached. Do NOT rebuild or round-trip the PSET in
+        # between: the blinding factors bound at builder.finish() tie the canonical
+        # bytes to this Pset instance. See src/aqua/op_policy.py.
+        if op_policy.enabled():
+            _pset_before = id(unsigned_pset)
+            # amount is integer satoshis (codebase invariant); the engine reads
+            # humanReadable.notional only when numeric. Unit is resolved from the
+            # delegation cap inside op_policy.evaluate(), never passed from here.
+            op_policy.evaluate(
+                rail="liquid",
+                canonical_bytes_hex=op_policy.canonical_bytes(unsigned_pset),
+                human_readable={
+                    "notional": amount,
+                    "counterparty": address,
+                    "asset_id": asset_id,
+                },
+            )  # returns the verified allow credential; raises on anything else
+            # Same-PSET identity guard: sign exactly what was evaluated.
+            if id(unsigned_pset) != _pset_before:
+                raise ValueError(
+                    "OP policy: PSET identity changed between evaluation and "
+                    "signing; refusing to sign"
+                )
+        # --- end Observer Protocol block --------------------------------------
+
         signed_pset = signer.sign(unsigned_pset)
         tx = signed_pset.finalize()
 


### PR DESCRIPTION
# Add opt-in Observer Protocol pre-sign policy check (fail-closed) for Liquid sends

## What this does

Adds an **opt-in, fail-closed** policy check to the Liquid send path. When enabled via a
single env var (`OP_POLICY_ENABLED`), the wallet submits the *exact unsigned transaction*
to the Observer Protocol policy engine and only signs on a **verified `allow`** decision.
Deny, non-2xx, an unreachable engine, or a credential whose signature won't verify all
fail closed — the wallet does not sign.

When the flag is off, this code is inert and `send()` behaves exactly as it does today.
It's additive, env-gated, and adds no wallet dependencies beyond the one noted below.

## The path

```
WalletManager.send()
  └─ extract canonical bytes from the exact unsigned PSET
     └─ POST EvaluationInput → https://api.observerprotocol.org/policy/evaluate
        └─ receive signed PolicyEvaluationCredential (PEC)
           └─ verify PEC signature (eddsa-jcs-2022, did:web:observerprotocol.org#key-3)
              └─ decision == "allow"?  ── no → raise (fail closed), never sign
                 └─ yes → same-PSET identity guard → signer.sign()
```

The thing that is genuinely real here — and can't be faked — is that a real send is gated
by a real signed credential from the real engine, and the wallet verifies that signature
itself before trusting the decision.

## Rail coverage

- **Per-asset spending caps, enforced at the signer boundary — including USDt.** Caps are
  selected by `asset_id` (the cryptographic ground truth of what's moving), not a currency
  label. Validated **live against production** with the returned credential's signature
  verified: L-BTC within cap → `allow`, over → `deny`; **USDt within its own cap → `allow`,
  over → `deny`**; a USDt send with **no** USDt cap → `deny` (`no-cap-for-asset`, not waved
  through the L-BTC cap); an asset unknown to the engine registry → `deny`
  (`unknown-asset`). The delegation carries an optional `per_rail.liquid.per_asset` map
  (context v2); native L-BTC keeps the rail-level cap, so every already-issued delegation
  is unchanged.
- **Lightning funded via Boltz — covered *transitively*.** Confirmed in current code
  (`lightning.py`): the submarine-swap lockup is an L-BTC `wallet_manager.send()` routed
  through this same path, so it's evaluated as a Liquid send (counterparty = Boltz swap
  address).
- **Native BTC on-chain — not covered (named gap).** `bitcoin.py` builds a BDK PSBT and
  signs directly, bypassing this hook. Extending the same pre-sign pattern to that path is
  a clean follow-up, called out here rather than left silent.

## Verification scope — what the wallet checks, and what it doesn't yet

This is the honest core of the PR, stated plainly:

- **Verified now (this PR):** the returned credential's **signature and validity window**.
  The wallet resolves `did:web:observerprotocol.org#key-3` from the published DID document
  and verifies the `eddsa-jcs-2022` proof itself. It trusts a signed decision, not the
  transport. If the signature doesn't verify, it fails closed.
- **Not verified yet (named follow-up):** the **delegation credential's own signature,
  revocation status, and validity window**. The hosted `/policy/evaluate` enforces the
  mandate's *constraints* against the delegation as-provided, but it does not authenticate
  the delegation and does not reject an expired one (confirmed live: an out-of-window
  delegation still evaluates to `allow`), and this PR doesn't check those either. Full
  caller-side delegation verification (signature + revocation + `validFrom`/`validUntil`)
  is the explicit next step. We'd rather name this than ship it silently unhandled under a
  "verify everything" banner.

Fail-closed still holds unconditionally for engine reachability, HTTP status, decision
value, and PEC-signature validity.

## Configuration (env-driven)

| Variable | Default | Purpose |
|---|---|---|
| `OP_POLICY_ENABLED` | *(off)* | Master switch. `1`/`true`/`yes` to enable. |
| `OP_DELEGATION_PATH` | *(required when enabled)* | Path to the delegation credential JSON. |
| `OP_SIDECAR_URL` | `https://api.observerprotocol.org/policy/evaluate` | Policy engine endpoint. |
| `OP_POLICY_TIMEOUT` | `10` | Request timeout (seconds). |
| `OP_VERIFY_PEC` | `true` | Verify the returned credential's signature. Off is loud and drops the independence guarantee. |
| `OP_POLICY_UNIT` | *(the sent asset's unit)* | Optional override. Normally the wallet passes the true unit of the asset being sent (its ticker, from `lookup_asset(asset_id)`); set this only to force a unit for testing. |
| `OP_DENY_ARTIFACT_DIR` | `./op-artifacts` | Where signed deny credentials are persisted. |

## Fail-closed contract

The wallet signs **only** on a verified `allow`. Every one of these refuses to sign:

- engine unreachable → refuse
- non-2xx from engine → refuse
- PEC signature won't verify → refuse
- PEC expired (`validUntil` in the past) → refuse
- decision `deny` → persist the signed deny artifact, then refuse
- any other/missing decision → refuse

Plus a same-PSET identity guard: the transaction handed to the signer must be the exact
one that was evaluated.

## Dependency note

**Zero new dependencies.** PEC signature verification needs Ed25519 verify; the vendored
verifier (`src/aqua/op_verify.py`, self-contained) uses `cryptography`, which is already a
direct dependency of Aqua (`pyproject.toml`: `cryptography>=42.0.0`, used for mnemonic
encryption). Nothing is added to the dependency set.

## Explicitly out of scope (deferred)

Native BTC/BDK path; a pluggable `pre_sign_hook` registry; surfacing config through
`config.json` (the env gate keeps it honestly "opt-in demo→beta"); delegation transport
polish; seeding the Liquid attestation graph; full caller-side delegation
signature/revocation verification (named above); OP Crossrail (adapters,
`crossRailBudget`, the cross-rail ledger — orthogonal to this hosted-endpoint path and not
wired into it); the not-yet-enforced advisory rule families; install ergonomics.

Forward-compat: the hook tolerates unknown extra credential fields, so future additive
fields (e.g. a Crossrail budget) won't break this integration.

## Files

- `src/aqua/op_policy.py` — evaluate-or-raise module (replaces the demo
  `op_policy_demo.py`, which is removed). Submits the send with the caller-supplied true
  asset unit (no cap-currency relabel — the engine selects the cap by `asset_id`), verifies
  the returned PEC's signature, persists deny artifacts, logs to stderr, and carries the
  `canonical_bytes()` PSET-extraction helper.
- `src/aqua/op_verify.py` — vendored, self-contained PEC verifier (eddsa-jcs-2022 /
  `#key-3`), with a float-leaf guard that fail-closes rather than trust the JCS
  approximation outside its proven integer/string range.
- `src/aqua/wallet.py` — the pre-sign block in `WalletManager.send()` plus the import.
- `README` — the Observer Protocol section (enable/disable, env vars, fail-closed contract,
  verification scope, rail coverage).

## Base

Built as a single additive feature on top of current `develop` (== `main` at the time of
writing), targeting `develop` per the repo's PR convention.
