### PR TITLE
:eyes::pinching_hand: Doctor tool PR review

### DIFF
--- a/src/aqua/cli/output.py
+++ b/src/aqua/cli/output.py
@@ -65,8 +65,8 @@ def run_tool(ctx, fn):
     """
     try:
         result = fn()
+        click.echo(render(result, ctx.fmt))
+        return result
     except Exception as e:
         click.echo(render_error(type(e).__name__, str(e), ctx.fmt), err=True)
         sys.exit(1)
-    click.echo(render(result, ctx.fmt))
-    return result

--- a/src/aqua/doctor.py
+++ b/src/aqua/doctor.py
@@ -29,11 +29,18 @@ _MAX_CONFIG_BYTES = 5_000_000
 
 
 def _is_prunable_default(name: str, value: Any) -> bool:
-    """True if ``name=value`` is a known tool whose bool value equals its default."""
+    """True if ``name=value`` is a known tool whose bool value equals its default.
+
+    Uses the same default lookup as ``features.is_tool_enabled`` (``.get(name, True)``)
+    so doctor's notion of "matches the default" can never drift from the value the
+    runtime actually applies for an absent key. Pruning is sound only while a shipped
+    default never changes for an *existing* tool: an entry equal to today's default is
+    dropped, so a later default flip would silently change the effective value.
+    """
     return (
         name in TOOLS
         and isinstance(value, bool)
-        and value == SHIPPED_DEFAULTS_ENABLED_TOOLS.get(name)
+        and value == SHIPPED_DEFAULTS_ENABLED_TOOLS.get(name, True)
     )
 
 
@@ -111,13 +118,17 @@ def run_doctor(storage: Storage | None = None, fix: bool = False) -> dict[str, A
         for key, value in enabled.items():
             if key not in TOOLS:
                 remove_tool_keys.add(key)
+                # Show the value so --fix never *silently* drops a deliberate
+                # `False` (a tool from a newer version this binary can't see
+                # yet would fall back to its default once that version knows it).
+                detail = (
+                    f"{key!r}={value!r} is not a known tool (source of the "
+                    "startup 'Unknown tool in enabled_tools' warning)."
+                )
                 findings.append({
                     "type": "orphan_tool",
                     "key": key,
-                    "detail": (
-                        f"{key!r} is not a known tool (source of the startup "
-                        "'Unknown tool in enabled_tools' warning)."
-                    ),
+                    "detail": detail,
                     "action": "remove",
                 })
             elif _is_prunable_default(key, value):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2519,3 +2519,17 @@ class TestDoctorCommand:
         self._isolate(monkeypatch, tmp_path)  # no config file → healthy
         result = runner.invoke(cli, ["--format", "json", "doctor"])
         assert result.exit_code == 0
+
+
+class TestRunTool:
+    """`run_tool` must keep rendering/echo inside its error handler."""
+
+    def test_render_failure_is_formatted_not_uncaught(self):
+        from aqua.cli.main import AquaContext
+        from aqua.cli.output import run_tool
+
+        # A tool result json.dumps can't serialize: render() raises inside run_tool.
+        with pytest.raises(SystemExit) as exc:
+            run_tool(AquaContext(fmt="json"), lambda: {"bad": object()})
+        # Formatted error + exit 1, not a bare traceback escaping run_tool.
+        assert exc.value.code == 1


### PR DESCRIPTION
## PR review fixes for `aqua doctor`

Feel free to edit this PR, no issue is big enough to block the original PR being merged.

Addresses findings from the review of the doctor tool. Two focused commits:

<details>
<summary><code>9509fcb</code> — Fix run_tool: keep output rendering inside the error handler</summary>

Adding a return value moved `click.echo(render(...))` after the try/except, so a failure while rendering or echoing a successful result (e.g. `BrokenPipeError` from `aqua ... | head`, or a `TypeError` from a non-serializable result under `--format json`) escaped as an uncaught traceback with the wrong exit code instead of the formatted `render_error` + exit 1 that every CLI command relied on. Move the echo and return back inside the try and add a regression guard.

</details>

<details>
<summary><code>4cc0926</code> — doctor: surface orphan values and align default lookup with runtime</summary>

Two safety touch-ups from PR review:

- `_is_prunable_default` now uses `.get(name, True)`, matching `features.is_tool_enabled` exactly, so doctor's notion of "matches the default" can't drift from the value the runtime applies for an absent key. Documents that pruning default-matching entries is sound only while an existing tool's shipped default never changes.
- Orphan-tool findings now include the value (`'foo'=False ...`) so `--fix` never *silently* drops a deliberate disable — relevant under version skew, where a tool a newer binary added and the user disabled looks like an orphan to an older binary and would fall back to its default once re-recognized.

</details>
