### PR TITLE
🚀 ci: push beta bump via deploy key to bypass develop ruleset

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,12 +16,13 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # push the auto beta bump back to develop
+      contents: read  # push-back uses the deploy key, not GITHUB_TOKEN
     steps:
       - uses: actions/checkout@v4
         with:
-          # Default GITHUB_TOKEN is used for the push-back; fetch-depth 0 so we
-          # can reset to the develop tip before bumping.
+          # Deploy keys bypass develop's required-checks ruleset; GITHUB_TOKEN can't push.
+          ssh-key: ${{ secrets.DEVELOP_DEPLOY_KEY }}
+          # fetch-depth 0 so we can reset to the develop tip before bumping.
           fetch-depth: 0
 
       - name: Install uv
@@ -47,7 +48,7 @@ jobs:
           echo "Bumped beta version to $NEW"
           git add src/aqua/__init__.py
           # [skip ci] stops the bump commit from re-triggering this workflow
-          # (belt-and-suspenders: GITHUB_TOKEN pushes never re-trigger anyway).
+          # (deploy-key pushes DO re-trigger workflows, unlike GITHUB_TOKEN).
           git commit -m "chore: bump beta to $NEW [skip ci]"
           git push origin HEAD:develop
 


### PR DESCRIPTION
### Purpose

Fix the auto beta-bump CI job, which was failing to push its commit back to `develop` because the branch's required-checks ruleset rejects any push whose commit never had a passing "Run tests" run — which the bump commit can never have.

#### Description

`develop`'s branch protection was migrated from a classic rule to a ruleset (`protect-develop`) so that a bypass actor could be configured. `GITHUB_TOKEN` cannot be added as a bypass actor in this org (GitHub Actions app bypass requires an org owner to register the app at the org level, which we don't have). A repo deploy key **can** be added as a bypass actor, so the push-back now authenticates over SSH with a dedicated deploy key instead of `GITHUB_TOKEN`.

#### Main Changes

- 🔒️ Checkout now authenticates with `secrets.DEVELOP_DEPLOY_KEY` (a write-access deploy key registered as a bypass actor on the `develop` ruleset) instead of the default `GITHUB_TOKEN`, so the bump commit push isn't blocked by the required "Run tests" check
- 🔧 Dropped the job's `permissions: contents: write` to `contents: read`, since the token is no longer used for the push
- 📝 Updated inline comments to reflect that deploy-key pushes (unlike `GITHUB_TOKEN` pushes) do re-trigger workflows, so `[skip ci]` is now the only anti-loop guard

#### ⚠️ Breaking Changes

- Requires the `DEVELOP_DEPLOY_KEY` repo secret to exist (already provisioned) and the corresponding deploy key to remain registered with write access on the repo
- `develop` branch protection is now enforced via a repository ruleset (`protect-develop`) instead of classic branch protection; equivalent rules (required "Run tests" check, no force-push, no deletion) with admin + deploy-key bypass

### Checklist

- [x] No hardcoded values (they should go in constants.py, .env, or our database)
- [ ] Added/updated tests (if necessary)
- [ ] Added/updated relevant documentation (if necessary)