### PR TITLE
ci: add Dependabot config (uv + GitHub Actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+version: 2
+updates:
+  # Python deps (uv manages pyproject.toml + uv.lock)
+  - package-ecosystem: "uv"
+    directory: "/"
+    # Follow the develop-first flow; note security updates always target the default branch.
+    target-branch: "develop"
+    schedule:
+      interval: monthly
+      day: monday
+      time: "07:00"
+    open-pull-requests-limit: 15
+    # Wait out just-published releases — supply-chain compromises are usually caught within days.
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"
+    # Majors need a human decision; minors stay in because most deps here are
+    # 0.x (lwk, bdkpython, ...) where the meaningful releases are semver-minor.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    # One grouped PR per run instead of one per dependency — each merge into
+    # develop triggers a beta publish, so ungrouped PRs would spam releases.
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  # GitHub Actions used in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: monthly
+      day: monday
+      time: "07:00"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` with two update streams, both targeting `develop`:

- **`uv`** — Python dependencies via `pyproject.toml` + `uv.lock` (Dependabot supports uv natively; the `pip` ecosystem would not manage our lockfile).
- **`github-actions`** — the actions used in `.github/workflows` (`checkout`, `setup-uv`, `setup-python`).

## Config choices

- **Monthly, grouped updates** — every merge into `develop` triggers a beta publish, so all version bumps arrive as a single grouped PR per run instead of one PR per dependency.
- **7-day cooldown** — for wallet software handling keys (`lwk`, `bdkpython`, `wallycore`, `coincurve`), waiting out just-published releases reduces supply-chain risk; compromised releases are usually caught within days.
- **Majors ignored, minors allowed** — majors need a human decision. Minors are kept (deviating from the reference config this was based on, which was patch-only) because most of our deps are `0.x` where the meaningful releases are semver-minor (e.g. `lwk 0.18 → 0.19`).
- **`target-branch: develop`** — follows the develop-first flow. Note GitHub always sends *security* update PRs to the default branch regardless of this setting.
- Commit prefixes `deps:`/`ci:` with scope, labeled `dependencies` + ecosystem.

CI note: the Tests workflow needs no secrets, so Dependabot PRs get full CI despite the restricted `GITHUB_TOKEN`.