### PR TITLE
Fix: standardize on expires_at, drop duplicate funding_expires_at in WapuPay orders

### DIFF
--- a/scripts/prompts/prompt_test_wapupay.md
+++ b/scripts/prompts/prompt_test_wapupay.md
@@ -146,7 +146,7 @@ as the refund address. Show me the funding instructions but DO NOT pay yet.
 - Invokes `wapupay_create_order(amount_ars="10000", alias="test.alias.mp", receiver_name="Test Receiver", refund_address="lq1qqw4...k6lng")`
 - Returns `tentative_id`, `status` (`FUNDING_ISSUED`), `address_destination` (Liquid `lq1…/ex1…/VJL…`),
   `asset_id` (USDT on Liquid), `funding_amount_usdt`, `total_amount_usdt`,
-  `total_funding_amount_base_units`, `funding_expires_at`, `pay_instructions`, `qr_code_path`
+  `total_funding_amount_base_units`, `expires_at`, `pay_instructions`, `qr_code_path`
 - ⚠️ The agent shows the funding address/QR **but must NOT call `lw_send_asset`** — keep this dry
 
 ---

--- a/src/aqua/server.py
+++ b/src/aqua/server.py
@@ -1141,7 +1141,7 @@ TOOL_SCHEMAS = {
             "Creates the tentative (freezing the quote) and issues "
             "funding instructions. Returns address_destination (Liquid), asset_id "
             "(USDT), funding_amount_usdt, total_amount_usdt, "
-            "total_funding_amount_base_units, funding_expires_at and a QR. Pay the "
+            "total_funding_amount_base_units, expires_at and a QR. Pay the "
             "TOTAL with lw_send_asset (amount = total_funding_amount_base_units); "
             "WapuPay then makes a P2P payer settle ARS to the bank account. Does NOT broadcast the "
             "payment itself — confirm the quote with the user first via wapupay_quote."

--- a/src/aqua/tools.py
+++ b/src/aqua/tools.py
@@ -1233,7 +1233,7 @@ def wapupay_create_order(
 
     The result includes `address_destination` (a Liquid address), `asset_id`
     (USDT on Liquid), `funding_amount_usdt`, `total_amount_usdt`,
-    `total_funding_amount_base_units`, and `funding_expires_at`. Pay the TOTAL
+    `total_funding_amount_base_units`, and `expires_at`. Pay the TOTAL
     with `lw_send_asset` (amount = `total_funding_amount_base_units`, the exact
     total_amount_usdt in USDT base units; asset_id from the response); WapuPay
     then settles `amount_ars` ARS to the bank account. This tool never
@@ -1258,7 +1258,7 @@ def wapupay_create_order(
     Returns:
         The order record incl. tentative_id, status, address_destination,
         asset_id, funding_amount_usdt, total_amount_usdt,
-        total_funding_amount_base_units, funding_expires_at, funded,
+        total_funding_amount_base_units, expires_at, funded,
         pay_instructions, and qr_code_path (QR of the funding address).
     """
     result = get_wapupay_manager().create_order(

--- a/src/aqua/wapupay.py
+++ b/src/aqua/wapupay.py
@@ -229,7 +229,6 @@ _TENTATIVE_RESP_FIELDS = (
     "address_destination",
     "asset_id",
     "expires_at",
-    "funding_expires_at",
     "refund_address",
     "funding_transaction_id",
     "executed_transaction_id",
@@ -330,7 +329,6 @@ class WapuPayOrder:
     address_destination: Optional[str] = None
     asset_id: Optional[str] = None
     expires_at: Optional[str] = None
-    funding_expires_at: Optional[str] = None
     refund_address: Optional[str] = None
     funding_transaction_id: Optional[str] = None
     executed_transaction_id: Optional[str] = None
@@ -723,7 +721,7 @@ class WapuPayManager:
 
         Returns the order record including ``address_destination`` (Liquid),
         ``asset_id`` (USDT), ``funding_amount_usdt`` / ``total_amount_usdt`` /
-        ``total_funding_amount_base_units`` and ``funding_expires_at``. The
+        ``total_funding_amount_base_units`` and ``expires_at``. The
         caller pays the TOTAL with ``lw_send_asset`` — this method never
         broadcasts.
         """
@@ -892,9 +890,9 @@ class WapuPayManager:
         if order.address_destination and order.total_funding_amount_base_units is not None:
             fee_display = order.fee_amount_usdt if order.fee_amount_usdt is not None else 0
             expires_note = (
-                f" Funding window: expires at {order.funding_expires_at} UTC"
+                f" Funding window: expires at {order.expires_at} UTC"
                 f" (convert to the user's local timezone before displaying)."
-                if order.funding_expires_at
+                if order.expires_at
                 else ""
             )
 

--- a/tests/test_wapupay.py
+++ b/tests/test_wapupay.py
@@ -219,7 +219,7 @@ FUNDING_RESP = {
     "address_destination": "lq1qqfunding0address",
     "asset_id": "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2",
     "funding_amount_usdt": 6.99,
-    "funding_expires_at": "2026-05-24T14:35:00Z",
+    "expires_at": "2026-05-24T14:35:00Z",
 }
 
 


### PR DESCRIPTION
### Purpose

WapuPay's order responses only ever return `expires_at`; the codebase also carried a redundant `funding_expires_at` field that duplicated it. This drops the duplicate and standardizes on `expires_at` end-to-end.

Targets `use-lbtc-on-wapupay` (#122) instead of `develop` so it merges together with the L-BTC funding-rail work, since both touch `WapuPayOrder`/`wapupay.py`.

#### Main Changes

- 🐛 Removed the redundant `funding_expires_at` field from `WapuPayOrder` and `_TENTATIVE_RESP_FIELDS` — `expires_at` is now the single source of truth
- ♻️ `WapuPayManager`'s funding-window display now reads `order.expires_at`
- 📝 Updated docstrings and the MCP tool description (`server.py`, `tools.py`) to reference `expires_at`
- ✅ Updated `tests/test_wapupay.py` and the manual test script (`scripts/prompts/prompt_test_wapupay.md`) to match

#### ⚠️ Breaking Changes

`funding_expires_at` is removed from the `wapupay_create_order` / order-status response shape. Any caller reading that field directly (instead of `expires_at`) needs to switch.

### Checklist

- [ ] No hardcoded values (they should go in constants.py, .env, or our database)
- [x] Added/updated tests (if necessary)
- [ ] Added/updated relevant documentation (if necessary)